### PR TITLE
[ISSUE-34] Relax caller-provided ID validation and update README messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Unleash the full power of your AI agents.
 - **Unrestricted execution** — Agents install anything, run anything, break anything. Your host stays untouched.
 - **No more babysitting** — Zero permission prompts, zero manual approvals. Agents run autonomously and deliver results directly.
 - **Secure by default** — Every sandbox is fully isolated. No host network. No host filesystem. No exceptions.
+- **Host credentials, zero setup** — Sandboxes inherit host authentication (SSH agent, GitHub CLI, etc.) out of the box. Claude Code and Codex work immediately — powered by your flat-rate CLI subscriptions, not per-token API billing.
 - **Local-first, cloud-optional** — Zero latency, zero cost, and your data never leaves your machine.
 
 ## Why agents-sandbox?
@@ -50,7 +51,7 @@ A remote VPS gives you isolation too — but with tradeoffs. agents-sandbox runs
 | | Local Sandbox | Remote VPS |
 |---|---|---|
 | **Latency** | Near-zero | 10–100ms+ per command round-trip |
-| **Cost** | Free — you own the hardware | Pay per hour/VM/GB |
+| **Cost** | Free — you own the hardware. Agents use flat-rate CLI subscriptions (Claude Code, Codex), not per-token API billing | Pay per hour/VM/GB, plus API metering for every token |
 | **Data privacy** | Code and credentials never leave your machine | Source code and API keys travel to a third party |
 | **Startup** | Seconds | 30s–minutes for VM provisioning |
 | **Local resources** | Direct access to files, GPU via controlled mounts | Must sync files up/down |

--- a/internal/control/service.go
+++ b/internal/control/service.go
@@ -89,7 +89,7 @@ type eventMutation struct {
 	execState    agboxv1.ExecState
 }
 
-var callerProvidedIDPattern = regexp.MustCompile(`^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`)
+var callerProvidedIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{2,198}[a-zA-Z0-9]$`)
 
 func NewService(config ServiceConfig) (*Service, io.Closer, error) {
 	defaults := DefaultServiceConfig()
@@ -578,7 +578,9 @@ func validateCallerProvidedID(fieldName string, id string) error {
 		return status.Errorf(codes.InvalidArgument, "%s must be at least 4 characters", fieldName)
 	}
 	if !callerProvidedIDPattern.MatchString(id) {
-		return status.Errorf(codes.InvalidArgument, "%s must match %s", fieldName, callerProvidedIDPattern.String())
+		return status.Errorf(codes.InvalidArgument,
+			"%s must be 4-200 characters, start and end with a letter or digit, and contain only letters, digits, hyphens, or underscores",
+			fieldName)
 	}
 	return nil
 }

--- a/internal/control/service_lifecycle_ids_test.go
+++ b/internal/control/service_lifecycle_ids_test.go
@@ -250,14 +250,15 @@ func TestCallerProvidedSandboxID(t *testing.T) {
 func TestCallerProvidedSandboxIDValidation(t *testing.T) {
 	client := newBufconnClient(t, ServiceConfig{})
 	invalidIDs := []string{
-		"MyBox",
-		"my_box",
-		"-mybox",
-		"mybox-",
-		"ab",
-		"a234567890123456789012345678901234567890123456789012345678901234",
-		"my/box",
-		"my.box",
+		"-mybox",   // must start with letter or digit
+		"_mybox",   // must start with letter or digit
+		"mybox-",   // must end with letter or digit
+		"mybox_",   // must end with letter or digit
+		"ab",       // too short (< 4 characters)
+		"a" + strings.Repeat("x", 200) + "z", // too long (> 200)
+		"my/box",   // slashes not allowed
+		"my.box",   // dots not allowed
+		"my box",   // spaces not allowed
 	}
 	for _, sandboxID := range invalidIDs {
 		t.Run(sandboxID, func(t *testing.T) {
@@ -267,6 +268,28 @@ func TestCallerProvidedSandboxIDValidation(t *testing.T) {
 			})
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("expected invalid argument, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCallerProvidedSandboxIDAcceptsFlexibleFormats(t *testing.T) {
+	client := newBufconnClient(t, ServiceConfig{})
+	validIDs := []string{
+		"MyBox-1",                                     // mixed case
+		"my_box_1",                                    // underscores
+		"36d4492a-f142-4d30-afbe-7954cf698d73",        // UUID
+		"Session_With-Mixed_Chars-123",                // mixed separators
+		"ALLCAPS",                                     // all uppercase
+	}
+	for _, sandboxID := range validIDs {
+		t.Run(sandboxID, func(t *testing.T) {
+			_, err := client.CreateSandbox(context.Background(), &agboxv1.CreateSandboxRequest{
+				SandboxId:  sandboxID,
+				CreateSpec: createSpecWithImage("ghcr.io/agents-sandbox/coding-runtime:test"),
+			})
+			if err != nil {
+				t.Fatalf("expected valid sandbox_id %q, got error: %v", sandboxID, err)
 			}
 		})
 	}
@@ -358,7 +381,7 @@ func TestExecIDValidationDuplicateAndUUIDFallback(t *testing.T) {
 	}
 	waitForSandboxState(t, client, createResp.GetSandboxId(), agboxv1.SandboxState_SANDBOX_STATE_READY)
 
-	for _, execID := range []string{"MyExec", "my_exec", "-myexec", "ab"} {
+	for _, execID := range []string{"-myexec", "ab", "exec/"} {
 		t.Run("invalid-"+execID, func(t *testing.T) {
 			_, err := client.CreateExec(context.Background(), &agboxv1.CreateExecRequest{
 				SandboxId: createResp.GetSandboxId(),


### PR DESCRIPTION
## Summary

- Relax caller-provided ID validation: allow uppercase, underscores, and up to 200 characters (was lowercase-only, max ~63)
- UUIDs and mixed-case identifiers (e.g. `MyBox-1`, `36d4492a-f142-4d30-afbe-7954cf698d73`) are now valid sandbox/exec IDs
- Improve validation error message to human-readable description instead of raw regex
- README: add "Host credentials, zero setup" feature bullet; update cost table to mention flat-rate CLI subscription model

## Test plan

- [ ] Existing negative cases still rejected: IDs starting/ending with `-` or `_`, IDs with `/` `.` spaces, IDs < 4 chars, IDs > 200 chars
- [ ] New positive cases accepted: UUID format, mixed case, underscores, uppercase-only
- [ ] `TestCallerProvidedSandboxIDValidation` and `TestCallerProvidedSandboxIDAcceptsFlexibleFormats` pass
- [ ] `TestExecIDValidationDuplicateAndUUIDFallback` passes with updated invalid exec ID list

close #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
