### PR TITLE
[ISSUE-44] Runtime hardening: optional service hooks, builtin mount simplification, exec user, and uv-python capability

### DIFF
--- a/internal/control/docker_runtime.go
+++ b/internal/control/docker_runtime.go
@@ -238,7 +238,7 @@ func (backend *dockerRuntimeBackend) CreateSandbox(ctx context.Context, record *
 		statuses = append(statuses, runtimeServiceStatus{Name: service.GetName(), Required: true, Ready: true})
 	}
 
-	optionalStarts = startOptionalServicesAsync(ctx, record.handle.GetSandboxId(), state.NetworkName, record.optionalServices, userLabels, func(ctx context.Context, spec dockerContainerSpec) error {
+	optionalStarts = startOptionalServicesAsync(ctx, record.handle.GetSandboxId(), state.NetworkName, state.PrimaryContainerName, record.optionalServices, userLabels, backend, func(ctx context.Context, spec dockerContainerSpec) error {
 		return backend.dockerContainerCreate(ctx, spec)
 	}, func(ctx context.Context, name string) error {
 		return backend.dockerContainerStart(ctx, name)
@@ -278,6 +278,7 @@ func (backend *dockerRuntimeBackend) CreateSandbox(ctx context.Context, record *
 			if _, err := backend.dockerExec(ctx, dockerExecSpec{
 				ContainerName: state.PrimaryContainerName,
 				Command:       []string{"sh", "-lc", hook},
+				Environment:   keyValuesToMap(service.GetEnvironment()),
 			}); err != nil {
 				return runtimeCreateResult{}, err
 			}
@@ -343,8 +344,10 @@ func startOptionalServicesAsync(
 	ctx context.Context,
 	sandboxID string,
 	networkName string,
+	primaryContainerName string,
 	services []*agboxv1.ServiceSpec,
 	userLabels map[string]string,
+	backend *dockerRuntimeBackend,
 	createContainer func(context.Context, dockerContainerSpec) error,
 	startContainer func(context.Context, string) error,
 ) optionalServiceStarts {
@@ -375,8 +378,28 @@ func startOptionalServicesAsync(
 			if err := startContainer(optionalCtx, containerName); err != nil {
 				status.Ready = false
 				status.Message = err.Error()
+				results <- status
+				return
 			}
 			results <- status
+			// Run post_start_on_primary hooks after healthcheck passes in a separate
+			// goroutine so sandbox ready is not delayed by optional service setup.
+			if len(service.GetPostStartOnPrimary()) > 0 && service.GetHealthcheck() != nil {
+				go func(svc *agboxv1.ServiceSpec, ctrName string) {
+					if err := backend.dockerWaitRequiredServiceHealthy(optionalCtx, ctrName, svc.GetHealthcheck()); err != nil {
+						return
+					}
+					for _, hook := range svc.GetPostStartOnPrimary() {
+						if _, err := backend.dockerExec(optionalCtx, dockerExecSpec{
+							ContainerName: primaryContainerName,
+							Command:       []string{"sh", "-lc", hook},
+							Environment:   keyValuesToMap(svc.GetEnvironment()),
+						}); err != nil {
+							return
+						}
+					}
+				}(service, containerName)
+			}
 		}(service, containerName)
 	}
 	go func() {
@@ -462,6 +485,7 @@ func (backend *dockerRuntimeBackend) RunExec(ctx context.Context, record *sandbo
 		Command:       execRecord.GetCommand(),
 		Workdir:       execRecord.GetCwd(),
 		Environment:   keyValuesToMap(execRecord.GetEnvOverrides()),
+		User:          "agbox",
 		LogDir:        logDir,
 		ExecID:        execRecord.GetExecId(),
 	})

--- a/internal/control/docker_runtime_dockerapi.go
+++ b/internal/control/docker_runtime_dockerapi.go
@@ -47,6 +47,7 @@ type dockerExecSpec struct {
 	Command       []string
 	Workdir       string
 	Environment   map[string]string
+	User          string // Override exec user; empty = container default
 	LogDir        string // Container-side log directory; non-empty enables output redirection
 	ExecID        string // Used to construct log file names when LogDir is set
 }
@@ -317,6 +318,7 @@ func (backend *dockerRuntimeBackend) dockerExec(ctx context.Context, spec docker
 		Tty:          false,
 		Env:          envMapToSlice(spec.Environment),
 		WorkingDir:   spec.Workdir,
+		User:         spec.User,
 		Cmd:          cmd,
 	})
 	if err != nil {

--- a/internal/control/docker_runtime_materialize.go
+++ b/internal/control/docker_runtime_materialize.go
@@ -9,7 +9,6 @@ import (
 
 	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
 	"github.com/1996fanrui/agents-sandbox/internal/profile"
-	runtimedocker "github.com/1996fanrui/agents-sandbox/internal/runtime/docker"
 )
 
 func (backend *dockerRuntimeBackend) materializeGenericMounts(
@@ -155,34 +154,14 @@ func (backend *dockerRuntimeBackend) materializeBuiltinResourcePath(
 	writable bool,
 	state *sandboxRuntimeState,
 ) (string, bool, error) {
-	info, err := os.Stat(sourcePath)
-	if err != nil {
+	// Builtin resources are always bind-mounted as-is, including any symlinks.
+	// Shadow-copy logic is intentionally skipped: these are trusted host directories
+	// (tool configs, caches) that may contain symlinks to arbitrary host paths,
+	// and the container is expected to see them exactly as they appear on the host.
+	if _, err := os.Stat(sourcePath); err != nil {
 		return "", false, err
 	}
-	actualSource := sourcePath
-	readOnly := !writable
-	if info.IsDir() {
-		resolution, err := runtimedocker.ResolveProjectionMode(sourcePath, []string{sourcePath}, writable)
-		if err != nil {
-			return "", false, err
-		}
-		if resolution.Mode == runtimedocker.ProjectionModeShadowCopy {
-			if backend.config.StateRoot == "" {
-				return "", false, errors.New("runtime.state_root is required for builtin resource shadow copies")
-			}
-			if state.ShadowRoot == "" {
-				state.ShadowRoot = filepath.Join(backend.config.StateRoot, "sandboxes", sandboxID, "shadow")
-			}
-			actualSource = filepath.Join(state.ShadowRoot, "builtin", sanitizeRuntimeName(capability.ID))
-			if err := os.RemoveAll(actualSource); err != nil {
-				return "", false, err
-			}
-			if err := copyTreeAllowExternalSymlinks(sourcePath, actualSource); err != nil {
-				return "", false, err
-			}
-		}
-	}
-	return actualSource, readOnly, nil
+	return sourcePath, !writable, nil
 }
 
 func resolveCapabilitySource(capability profile.ToolingCapability) (string, error) {

--- a/internal/control/service_validation.go
+++ b/internal/control/service_validation.go
@@ -87,8 +87,8 @@ func validateServiceSpecs(items []*agboxv1.ServiceSpec, required bool, seen map[
 		if required && service.GetHealthcheck() == nil {
 			return fmt.Errorf("required service %q must define healthcheck", service.GetName())
 		}
-		if !required && len(service.GetPostStartOnPrimary()) > 0 {
-			return fmt.Errorf("optional service %q must not define post_start_on_primary", service.GetName())
+		if !required && len(service.GetPostStartOnPrimary()) > 0 && service.GetHealthcheck() == nil {
+			return fmt.Errorf("optional service %q with post_start_on_primary must define healthcheck", service.GetName())
 		}
 		if err := validateHealthcheck(service.GetName(), service.GetHealthcheck(), required); err != nil {
 			return err

--- a/internal/profile/capabilities.go
+++ b/internal/profile/capabilities.go
@@ -54,6 +54,12 @@ var builtInToolingCapabilities = map[string]ToolingCapability{
 		ContainerTarget: "/home/agbox/.cache/uv",
 		Mode:            CapabilityModeReadWrite,
 	},
+	"uv-python": {
+		ID:              "uv-python",
+		DefaultHostPath: "~/.local/share/uv",
+		ContainerTarget: "/home/agbox/.local/share/uv",
+		Mode:            CapabilityModeReadWrite,
+	},
 	"npm": {
 		ID:              "npm",
 		DefaultHostPath: "~/.npm",

--- a/internal/runtime/docker/projections.go
+++ b/internal/runtime/docker/projections.go
@@ -77,10 +77,10 @@ func ResolveProjectionMode(projectionRoot string, declaredRoots []string, writab
 			return err
 		}
 		if _, err := os.Stat(targetPath); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return ErrProjectionTargetUnreadable
-			}
-			return err
+			// Unresolvable symlink (broken target or permission denied): skip for
+			// projection mode decision. The symlink passes through as-is in a bind
+			// mount (stale cache entries, cross-environment paths, root-owned paths).
+			return nil
 		}
 		if !withinAnyRoot(targetPath, allowedRoots) {
 			resolution.Mode = ProjectionModeShadowCopy

--- a/sdk/python/src/agents_sandbox/_grpc_client.py
+++ b/sdk/python/src/agents_sandbox/_grpc_client.py
@@ -27,7 +27,7 @@ _REASON_TO_ERROR = dict(
 class SandboxGrpcClient:
     """Thin synchronous wrapper around the generated gRPC stub."""
 
-    def __init__(self, socket_path: str, *, timeout_seconds: float = 5.0) -> None:
+    def __init__(self, socket_path: str, *, timeout_seconds: float | None = 5.0) -> None:
         self._timeout_seconds = timeout_seconds
         self._channel = grpc.insecure_channel(f"unix://{socket_path}")
         self._stub = service_pb2_grpc.SandboxServiceStub(self._channel)


### PR DESCRIPTION
## Summary

- Allow optional services to define `post_start_on_primary` hooks (must pair with healthcheck); hooks run in a background goroutine after healthcheck passes, without blocking sandbox ready
- Inject service `Environment` into `post_start_on_primary` hook execution for both required and optional services
- Simplify builtin resource mounting: remove shadow-copy logic, bind-mount trusted host directories as-is (preserving symlinks)
- Tolerate broken/unresolvable symlinks in `ResolveProjectionMode` instead of returning an error
- Explicitly set exec user to `agbox` in `RunExec`
- Add `uv-python` builtin capability (`~/.local/share/uv` → `/home/agbox/.local/share/uv`)
- Allow `timeout_seconds=None` in Python SDK `SandboxGrpcClient`

## Test plan

- [ ] Create a sandbox with an optional service that has both `healthcheck` and `post_start_on_primary` — verify hook runs after healthcheck passes
- [ ] Create a sandbox with a required service that has `post_start_on_primary` using service env vars — verify env vars are available in hook
- [ ] Mount a builtin resource directory containing broken symlinks — verify sandbox creation succeeds
- [ ] Run exec and verify it executes as `agbox` user (`whoami`)
- [ ] Verify `uv-python` capability mounts `~/.local/share/uv` correctly
- [ ] Python SDK: pass `timeout_seconds=None` and verify no timeout on long exec

Close #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)
