### PR TITLE
[ISSUE-46] Move internal request types and conversions out of public API surface

### DIFF
--- a/sdk/python/src/agents_sandbox/_conversions.py
+++ b/sdk/python/src/agents_sandbox/_conversions.py
@@ -6,10 +6,9 @@ from datetime import UTC
 
 from ._generated import service_pb2
 from .models import ExecState, SandboxEventType, SandboxState
+from ._request_types import CreateExecRequest, CreateSandboxRequest
 from .types import (
     CopySpec,
-    CreateExecRequest,
-    CreateSandboxRequest,
     ExecHandle,
     HealthcheckConfig,
     MountSpec,

--- a/sdk/python/src/agents_sandbox/_request_types.py
+++ b/sdk/python/src/agents_sandbox/_request_types.py
@@ -1,0 +1,37 @@
+"""Internal request types used by the SDK client to build protobuf messages."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from .types import CopySpec, MountSpec, ServiceSpec
+
+
+@dataclass(frozen=True, slots=True)
+class CreateSandboxSpec:
+    image: str
+    mounts: tuple[MountSpec, ...] = ()
+    copies: tuple[CopySpec, ...] = ()
+    builtin_resources: tuple[str, ...] = ()
+    required_services: tuple[ServiceSpec, ...] = ()
+    optional_services: tuple[ServiceSpec, ...] = ()
+    labels: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "labels", dict(self.labels))
+
+
+@dataclass(frozen=True, slots=True)
+class CreateSandboxRequest:
+    create_spec: CreateSandboxSpec
+    sandbox_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CreateExecRequest:
+    sandbox_id: str
+    command: tuple[str, ...]
+    exec_id: str | None = None
+    cwd: str | None = None
+    env_overrides: Mapping[str, str] = field(default_factory=dict)

--- a/sdk/python/src/agents_sandbox/client.py
+++ b/sdk/python/src/agents_sandbox/client.py
@@ -13,7 +13,7 @@ from typing import cast
 
 from ._generated import service_pb2
 from ._grpc_client import SandboxGrpcClient
-from .conversions import (
+from ._conversions import (
     normalize_from_sequence,
     parse_event_sequence,
     to_exec_handle,
@@ -31,11 +31,9 @@ from .errors import (
     SandboxInvalidStateError,
 )
 from .models import SandboxState
+from ._request_types import CreateExecRequest, CreateSandboxRequest, CreateSandboxSpec
 from .types import (
     CopySpec,
-    CreateExecRequest,
-    CreateSandboxRequest,
-    CreateSandboxSpec,
     DeleteSandboxesResult,
     ExecHandle,
     MountSpec,

--- a/sdk/python/src/agents_sandbox/types.py
+++ b/sdk/python/src/agents_sandbox/types.py
@@ -49,35 +49,6 @@ class CopySpec:
 
 
 @dataclass(frozen=True, slots=True)
-class CreateSandboxSpec:
-    image: str
-    mounts: tuple[MountSpec, ...] = ()
-    copies: tuple[CopySpec, ...] = ()
-    builtin_resources: tuple[str, ...] = ()
-    required_services: tuple[ServiceSpec, ...] = ()
-    optional_services: tuple[ServiceSpec, ...] = ()
-    labels: Mapping[str, str] = field(default_factory=dict)
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "labels", dict(self.labels))
-
-
-@dataclass(frozen=True, slots=True)
-class CreateSandboxRequest:
-    create_spec: CreateSandboxSpec
-    sandbox_id: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class CreateExecRequest:
-    sandbox_id: str
-    command: tuple[str, ...]
-    exec_id: str | None = None
-    cwd: str | None = None
-    env_overrides: Mapping[str, str] = field(default_factory=dict)
-
-
-@dataclass(frozen=True, slots=True)
 class SandboxEvent:
     event_id: str
     sequence: int
@@ -133,9 +104,6 @@ class ExecHandle:
 
 __all__ = [
     "CopySpec",
-    "CreateExecRequest",
-    "CreateSandboxRequest",
-    "CreateSandboxSpec",
     "DeleteSandboxesResult",
     "ExecHandle",
     "HealthcheckConfig",

--- a/sdk/python/tests/test_smoke_public_api.py
+++ b/sdk/python/tests/test_smoke_public_api.py
@@ -24,7 +24,7 @@ from agents_sandbox import (
 )
 from agents_sandbox._generated import service_pb2
 from agents_sandbox.client import _resolve_default_socket_path
-from agents_sandbox.conversions import to_exec_handle, to_exec_snapshot, to_sandbox_handle
+from agents_sandbox._conversions import to_exec_handle, to_exec_snapshot, to_sandbox_handle
 from agents_sandbox.types import CallerMetadata
 
 from tests.smoke_support import (


### PR DESCRIPTION
## Summary

- Rename `conversions.py` to `_conversions.py` to align with `_` prefix convention for internal modules
- Move `CreateSandboxRequest`, `CreateSandboxSpec`, `CreateExecRequest` from `types.py` to new `_request_types.py`
- Update imports in `client.py`, `_conversions.py`, and tests

## Test plan

- [x] All passing tests remain green (18 passed, 1 skipped)
- [x] Pre-existing test failures unrelated to this change confirmed

Close #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)
