### PR TITLE
[ISSUE-49] Add PyPI publish workflow for Python SDK

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,33 @@
+name: Publish Python SDK
+
+on:
+  push:
+    tags:
+      - "sdk-python-v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build SDK
+        working-directory: sdk/python
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdk/python/dist/


### PR DESCRIPTION
## Summary

- Add `publish-sdk.yml` workflow that publishes `agents-sandbox-sdk` to PyPI via Trusted Publisher (OIDC) on `sdk-python-v*` tag push
- Uses `pypi` GitHub environment for deployment isolation

## Publish flow

```bash
# bump version in sdk/python/pyproject.toml, then:
git tag sdk-python-v0.1.0
git push origin sdk-python-v0.1.0
```

## Test plan

- [ ] Merge PR, tag `sdk-python-v0.1.0`, verify workflow runs and package appears on PyPI

Close #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)
