### PR TITLE
[ISSUE-61] Change SDK config APIs to accept config_yaml content

### DIFF
--- a/docs/declarative_yaml_config.md
+++ b/docs/declarative_yaml_config.md
@@ -1,6 +1,6 @@
 # Declarative YAML Configuration
 
-AgentsSandbox supports declarative YAML configuration files for sandbox creation. Instead of assembling all parameters in code, define the sandbox environment in an `agents-sandbox.yaml` file.
+AgentsSandbox supports declarative YAML configuration for sandbox creation. Instead of assembling all parameters in code, define the sandbox environment as YAML content and send it through the SDK.
 
 ## YAML Schema
 
@@ -10,7 +10,7 @@ The YAML schema is a 1:1 mapping of the proto `CreateSpec` message. Every field 
 image: coding-runtime:latest
 
 copies:
-  - source: .
+  - source: /absolute/path/to/project
     target: /workspace
     exclude_patterns: [".venv", "__pycache__", "node_modules"]
 
@@ -110,12 +110,18 @@ Services use a map format where the YAML key becomes `ServiceSpec.name`:
 ### Python SDK
 
 ```python
+yaml_config = """
+image: ghcr.io/agents-sandbox/coding-runtime:latest
+builtin_resources:
+  - .claude
+"""
+
 # YAML only
-sandbox = await client.create_sandbox(config="agents-sandbox.yaml")
+sandbox = await client.create_sandbox(config_yaml=yaml_config)
 
 # YAML with parameter overrides
 sandbox = await client.create_sandbox(
-    config="agents-sandbox.yaml",
+    config_yaml=yaml_config,
     image="custom:latest",
     labels={"team": "my-team"},
     envs={"APP_ENV": "staging"},
@@ -128,12 +134,18 @@ sandbox = await client.create_sandbox(image="python:3.12")
 ### Go SDK
 
 ```go
+configYAML := []byte(`
+image: ghcr.io/agents-sandbox/coding-runtime:latest
+builtin_resources:
+  - .claude
+`)
+
 // YAML only
-sandbox, err := client.CreateSandbox(ctx, sdkclient.WithConfig("agents-sandbox.yaml"))
+sandbox, err := client.CreateSandbox(ctx, sdkclient.WithConfigYAML(configYAML))
 
 // YAML with parameter overrides
 sandbox, err := client.CreateSandbox(ctx,
-    sdkclient.WithConfig("agents-sandbox.yaml"),
+    sdkclient.WithConfigYAML(configYAML),
     sdkclient.WithImage("custom:latest"),
     sdkclient.WithLabels(map[string]string{"team": "my-team"}),
     sdkclient.WithEnvs(map[string]string{"APP_ENV": "staging"}),
@@ -163,7 +175,7 @@ Sandbox-level `envs` are applied to the primary container at creation time and a
 
 ## Architecture
 
-YAML parsing is implemented in the daemon, not in SDKs. SDKs read the YAML file as raw bytes and send them to the daemon via the `config_yaml` field in `CreateSandboxRequest`. This avoids duplicating parsing logic across Python, Go, and future SDKs.
+YAML parsing is implemented in the daemon, not in SDKs. SDKs send raw YAML bytes to the daemon via the `config_yaml` field in `CreateSandboxRequest`. Callers may load YAML from a file, template it in memory, or generate it dynamically before the SDK call. This avoids duplicating parsing logic across Python, Go, and future SDKs.
 
 The daemon uses strict YAML parsing that rejects unknown fields, ensuring the YAML schema stays aligned with the proto `CreateSpec` definition.
 

--- a/docs/sdk_async_usage.md
+++ b/docs/sdk_async_usage.md
@@ -142,15 +142,17 @@ Important rules:
 - normal lifecycle flow: use `wait=True` or call `run(...)` when you want a completed exec result
 - advanced orchestration: use `wait=False` and call `subscribe_sandbox_events` directly
 - example/demo flow: pass the runtime image explicitly on every `create_sandbox(...)` call
-- declarative config: use `config="agents-sandbox.yaml"` to load sandbox configuration from a YAML file (see `docs/declarative_yaml_config.md`)
+- declarative config: pass `config_yaml=...` with YAML content generated in memory or loaded by your application (see `docs/declarative_yaml_config.md`)
 
 ```python
-# Create from YAML config file
-sandbox = await client.create_sandbox(config="agents-sandbox.yaml")
+# Create from YAML content
+sandbox = await client.create_sandbox(
+    config_yaml="image: ghcr.io/agents-sandbox/coding-runtime:latest\n"
+)
 
 # YAML config with parameter overrides
 sandbox = await client.create_sandbox(
-    config="agents-sandbox.yaml",
+    config_yaml="builtin_resources:\n  - .claude\n",
     image="custom:latest",
     labels={"team": "my-team"},
 )

--- a/sdk/go/client/client.go
+++ b/sdk/go/client/client.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"sync"
 	"time"
 
@@ -113,7 +112,7 @@ func (c *Client) Ping(ctx context.Context) (PingInfo, error) {
 }
 
 // CreateSandbox creates a sandbox and optionally waits until it becomes ready.
-// At least one of WithImage or WithConfig must be provided.
+// At least one of WithImage or WithConfigYAML must be provided.
 func (c *Client) CreateSandbox(ctx context.Context, opts ...CreateSandboxOption) (SandboxHandle, error) {
 	options := defaultCreateSandboxOptions()
 	for _, opt := range opts {
@@ -122,17 +121,8 @@ func (c *Client) CreateSandbox(ctx context.Context, opts ...CreateSandboxOption)
 		}
 	}
 
-	if options.image == nil && options.configPath == nil {
-		return SandboxHandle{}, fmt.Errorf("at least one of WithImage or WithConfig must be provided")
-	}
-
-	var configYaml []byte
-	if options.configPath != nil {
-		data, err := os.ReadFile(*options.configPath)
-		if err != nil {
-			return SandboxHandle{}, fmt.Errorf("read config file: %w", err)
-		}
-		configYaml = data
+	if options.image == nil && len(options.configYAML) == 0 {
+		return SandboxHandle{}, fmt.Errorf("at least one of WithImage or WithConfigYAML must be provided")
 	}
 
 	image := ""
@@ -142,7 +132,7 @@ func (c *Client) CreateSandbox(ctx context.Context, opts ...CreateSandboxOption)
 
 	request := &agboxv1.CreateSandboxRequest{
 		SandboxId:  valueOrEmpty(options.sandboxID),
-		ConfigYaml: configYaml,
+		ConfigYaml: append([]byte(nil), options.configYAML...),
 		CreateSpec: &agboxv1.CreateSpec{
 			Image:            image,
 			Mounts:           toProtoMounts(options.mounts),

--- a/sdk/go/client/client_config_test.go
+++ b/sdk/go/client/client_config_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 
@@ -14,10 +13,7 @@ func TestCreateSandboxWithConfig(t *testing.T) {
 
 	t.Run("config_only", func(t *testing.T) {
 		t.Parallel()
-		tmpFile := t.TempDir() + "/test.yaml"
-		if err := os.WriteFile(tmpFile, []byte("image: test:latest\n"), 0644); err != nil {
-			t.Fatalf("write temp file: %v", err)
-		}
+		configYAML := []byte("image: test:latest\n")
 
 		base := &fakeRPCClient{}
 		base.createSandboxFn = func(_ context.Context, req *agboxv1.CreateSandboxRequest) (*agboxv1.CreateSandboxResponse, error) {
@@ -40,7 +36,7 @@ func TestCreateSandboxWithConfig(t *testing.T) {
 		}
 
 		client := newTestClient(base, nil)
-		_, err := client.CreateSandbox(context.Background(), WithConfig(tmpFile), WithWait(false))
+		_, err := client.CreateSandbox(context.Background(), WithConfigYAML(configYAML), WithWait(false))
 		if err != nil {
 			t.Fatalf("CreateSandbox failed: %v", err)
 		}
@@ -48,10 +44,7 @@ func TestCreateSandboxWithConfig(t *testing.T) {
 
 	t.Run("config_and_image", func(t *testing.T) {
 		t.Parallel()
-		tmpFile := t.TempDir() + "/test.yaml"
-		if err := os.WriteFile(tmpFile, []byte("builtin_resources:\n  - .claude\n"), 0644); err != nil {
-			t.Fatalf("write temp file: %v", err)
-		}
+		configYAML := []byte("builtin_resources:\n  - .claude\n")
 
 		base := &fakeRPCClient{}
 		base.createSandboxFn = func(_ context.Context, req *agboxv1.CreateSandboxRequest) (*agboxv1.CreateSandboxResponse, error) {
@@ -74,7 +67,7 @@ func TestCreateSandboxWithConfig(t *testing.T) {
 		}
 
 		client := newTestClient(base, nil)
-		_, err := client.CreateSandbox(context.Background(), WithConfig(tmpFile), WithImage("override:latest"), WithWait(false))
+		_, err := client.CreateSandbox(context.Background(), WithConfigYAML(configYAML), WithImage("override:latest"), WithWait(false))
 		if err != nil {
 			t.Fatalf("CreateSandbox failed: %v", err)
 		}
@@ -92,12 +85,12 @@ func TestCreateSandboxWithConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("config_file_not_found", func(t *testing.T) {
+	t.Run("empty_config_yaml", func(t *testing.T) {
 		t.Parallel()
 		client := newTestClient(&fakeRPCClient{}, nil)
-		_, err := client.CreateSandbox(context.Background(), WithConfig("/nonexistent/path.yaml"))
+		_, err := client.CreateSandbox(context.Background(), WithConfigYAML(nil))
 		if err == nil {
-			t.Fatal("expected error for nonexistent config file")
+			t.Fatal("expected error for empty config_yaml")
 		}
 	})
 }

--- a/sdk/go/client/options.go
+++ b/sdk/go/client/options.go
@@ -64,7 +64,7 @@ type CreateSandboxOption interface {
 
 type createSandboxOptions struct {
 	image            *string
-	configPath       *string
+	configYAML       []byte
 	sandboxID        *string
 	mounts           []MountSpec
 	copies           []CopySpec
@@ -80,7 +80,7 @@ func defaultCreateSandboxOptions() createSandboxOptions {
 	return createSandboxOptions{
 		labels: map[string]string{},
 		envs:   map[string]string{},
-		wait:        true,
+		wait:   true,
 	}
 }
 
@@ -176,19 +176,18 @@ func (o imageOption) applyCreateSandbox(opts *createSandboxOptions) error {
 	return nil
 }
 
-type configOption string
+type configYAMLOption []byte
 
-// WithConfig sets the path to a YAML config file for sandbox creation.
-func WithConfig(path string) configOption {
-	return configOption(path)
+// WithConfigYAML sets raw YAML content for sandbox creation.
+func WithConfigYAML(configYAML []byte) configYAMLOption {
+	return configYAMLOption(append([]byte(nil), configYAML...))
 }
 
-func (o configOption) applyCreateSandbox(opts *createSandboxOptions) error {
-	value := string(o)
-	if value == "" {
-		return fmt.Errorf("config path must not be empty")
+func (o configYAMLOption) applyCreateSandbox(opts *createSandboxOptions) error {
+	if len(o) == 0 {
+		return fmt.Errorf("config_yaml must not be empty")
 	}
-	opts.configPath = &value
+	opts.configYAML = append([]byte(nil), o...)
 	return nil
 }
 

--- a/sdk/python/src/agents_sandbox/client.py
+++ b/sdk/python/src/agents_sandbox/client.py
@@ -7,7 +7,6 @@ import dataclasses
 import os
 import platform
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
-from pathlib import Path
 from threading import Event as ThreadEvent
 from threading import Thread
 from typing import cast
@@ -77,6 +76,16 @@ def _validate_optional_id(field_name: str, value: str | None) -> str | None:
     return value
 
 
+def _normalize_config_yaml(config_yaml: str | bytes | None) -> bytes:
+    if config_yaml is None:
+        return b""
+    if isinstance(config_yaml, bytes):
+        return config_yaml
+    if isinstance(config_yaml, str):
+        return config_yaml.encode("utf-8")
+    raise TypeError("config_yaml must be str, bytes, or None")
+
+
 class AgentsSandboxClient:
     """Async high-level client that exposes the northbound SDK surface."""
 
@@ -110,7 +119,7 @@ class AgentsSandboxClient:
     async def create_sandbox(
         self,
         *,
-        config: str | Path | None = None,
+        config_yaml: str | bytes | None = None,
         image: str | None = None,
         sandbox_id: str | None = None,
         mounts: tuple[MountSpec, ...] = (),
@@ -122,12 +131,9 @@ class AgentsSandboxClient:
         envs: Mapping[str, str] | None = None,
         wait: bool = True,
     ) -> SandboxHandle:
-        if config is None and image is None:
-            raise ValueError("at least one of 'config' or 'image' must be provided")
-
-        config_yaml = b""
-        if config is not None:
-            config_yaml = Path(config).read_bytes()
+        resolved_config_yaml = _normalize_config_yaml(config_yaml)
+        if not resolved_config_yaml and image is None:
+            raise ValueError("at least one of 'config_yaml' or 'image' must be provided")
 
         request = CreateSandboxRequest(
             sandbox_id=_validate_optional_id("sandbox_id", sandbox_id),
@@ -141,7 +147,7 @@ class AgentsSandboxClient:
                 labels={} if labels is None else dict(labels),
                 envs={} if envs is None else dict(envs),
             ),
-            config_yaml=config_yaml,
+            config_yaml=resolved_config_yaml,
         )
         try:
             response = await asyncio.to_thread(

--- a/sdk/python/tests/test_create_sandbox_config.py
+++ b/sdk/python/tests/test_create_sandbox_config.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import tempfile
-from pathlib import Path
 
 import pytest
 from agents_sandbox._request_types import CreateSandboxRequest, CreateSandboxSpec
@@ -41,17 +39,12 @@ def test_create_sandbox_request_with_image_and_config() -> None:
     assert proto.create_spec.image == "override:latest"
 
 
-def test_create_sandbox_config_reads_file(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Client reads config file and sends bytes."""
+def test_create_sandbox_accepts_config_yaml_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Client encodes config_yaml strings and sends bytes."""
     from agents_sandbox._generated import service_pb2
     from agents_sandbox.client import AgentsSandboxClient
 
-    yaml_content = b"image: test:latest\nbuiltin_resources:\n  - .claude\n"
-    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
-        f.write(yaml_content)
-        f.flush()
-        config_path = f.name
-
+    yaml_content = "image: test:latest\nbuiltin_resources:\n  - .claude\n"
     captured_requests: list[service_pb2.CreateSandboxRequest] = []
 
     class _FakeRawSandboxClient:
@@ -83,17 +76,61 @@ def test_create_sandbox_config_reads_file(monkeypatch: pytest.MonkeyPatch) -> No
         lambda **_kwargs: "/tmp/agents-sandbox.sock",
     )
 
-    try:
-        async def run_test() -> None:
-            client = AgentsSandboxClient()
-            await client.create_sandbox(config=config_path, wait=False)
+    async def run_test() -> None:
+        client = AgentsSandboxClient()
+        await client.create_sandbox(config_yaml=yaml_content, wait=False)
 
-        asyncio.run(run_test())
-        assert len(captured_requests) == 1
-        assert captured_requests[0].config_yaml == yaml_content
-        assert captured_requests[0].create_spec.image == ""
-    finally:
-        Path(config_path).unlink()
+    asyncio.run(run_test())
+    assert len(captured_requests) == 1
+    assert captured_requests[0].config_yaml == yaml_content.encode("utf-8")
+    assert captured_requests[0].create_spec.image == ""
+
+
+def test_create_sandbox_accepts_config_yaml_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Client forwards config_yaml bytes without modification."""
+    from agents_sandbox._generated import service_pb2
+    from agents_sandbox.client import AgentsSandboxClient
+
+    yaml_content = b"image: test:latest\nbuiltin_resources:\n  - .claude\n"
+    captured_requests: list[service_pb2.CreateSandboxRequest] = []
+
+    class _FakeRawSandboxClient:
+        def __init__(self, socket_path: str, *, timeout_seconds: float) -> None:
+            pass
+
+        def close(self) -> None:
+            return None
+
+        def create_sandbox(self, request: service_pb2.CreateSandboxRequest) -> service_pb2.CreateSandboxResponse:
+            captured_requests.append(request)
+            return service_pb2.CreateSandboxResponse(
+                sandbox_id="sandbox-1",
+                initial_state=service_pb2.SANDBOX_STATE_PENDING,
+            )
+
+        def get_sandbox(self, sandbox_id: str) -> service_pb2.GetSandboxResponse:
+            return service_pb2.GetSandboxResponse(
+                sandbox=service_pb2.SandboxHandle(
+                    sandbox_id=sandbox_id,
+                    state=service_pb2.SANDBOX_STATE_READY,
+                    last_event_sequence=1,
+                )
+            )
+
+    monkeypatch.setattr("agents_sandbox.client.SandboxGrpcClient", _FakeRawSandboxClient)
+    monkeypatch.setattr(
+        "agents_sandbox.client._resolve_default_socket_path",
+        lambda **_kwargs: "/tmp/agents-sandbox.sock",
+    )
+
+    async def run_test() -> None:
+        client = AgentsSandboxClient()
+        await client.create_sandbox(config_yaml=yaml_content, wait=False)
+
+    asyncio.run(run_test())
+    assert len(captured_requests) == 1
+    assert captured_requests[0].config_yaml == yaml_content
+    assert captured_requests[0].create_spec.image == ""
 
 
 def test_create_sandbox_request_with_envs() -> None:
@@ -109,8 +146,8 @@ def test_create_sandbox_request_with_envs() -> None:
     assert env_map == {"APP_ENV": "prod", "DB_HOST": "localhost"}
 
 
-def test_create_sandbox_neither_config_nor_image_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    """ValueError when neither config nor image is provided."""
+def test_create_sandbox_neither_config_yaml_nor_image_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ValueError when neither config_yaml nor image is provided."""
     monkeypatch.setattr(
         "agents_sandbox.client._resolve_default_socket_path",
         lambda **_kwargs: "/tmp/agents-sandbox.sock",

--- a/sdk/python/tests/test_smoke_public_api.py
+++ b/sdk/python/tests/test_smoke_public_api.py
@@ -276,7 +276,7 @@ def test_agents_sandbox_client_signatures_match_public_contract() -> None:
     create_signature = inspect.signature(AgentsSandboxClient.create_sandbox)
     assert list(create_signature.parameters) == [
         "self",
-        "config",
+        "config_yaml",
         "image",
         "sandbox_id",
         "mounts",


### PR DESCRIPTION
## Summary
- change the Python SDK `create_sandbox` API to accept `config_yaml` content instead of a config file path
- replace Go `WithConfig(path)` with `WithConfigYAML([]byte)` and remove SDK-side file reads
- update public docs and examples to show in-memory YAML usage and absolute host copy paths

## Testing
- `uv run --project sdk/python pytest sdk/python/tests/test_create_sandbox_config.py sdk/python/tests/test_smoke_public_api.py`
- `go test ./sdk/go/client`

Close #61
