### PR TITLE
[ISSUE-80] Mount ~/.claude.json into sandbox container for interactive mode

### DIFF
--- a/docs/container_dependency_strategy.md
+++ b/docs/container_dependency_strategy.md
@@ -28,7 +28,7 @@ Tools are the user-facing names passed in `builtin_tools`. Each tool resolves to
 
 | Tool | Resolved Mounts (Host Source → Container Target, Mode) |
 |------|--------------------------------------------------------|
-| `claude` | `~/.claude` → `/home/agbox/.claude` (read-write) |
+| `claude` | `~/.claude` → `/home/agbox/.claude` (rw), `~/.claude.json` → `/home/agbox/.claude.json` (rw) |
 | `codex` | `~/.codex` → `/home/agbox/.codex` (rw), `~/.agents` → `/home/agbox/.agents` (rw) |
 | `git` | `SSH_AUTH_SOCK` → `/ssh-agent` (socket forwarding), `~/.config/gh` → `/home/agbox/.config/gh` (read-only) |
 | `uv` | `~/.cache/uv` → `/home/agbox/.cache/uv` (rw), `~/.local/share/uv` → `/home/agbox/.local/share/uv` (rw) |

--- a/internal/control/service_stage2_runtime_contracts_test.go
+++ b/internal/control/service_stage2_runtime_contracts_test.go
@@ -612,6 +612,10 @@ func TestStateRootOnlyServesCopiesAndBuiltinShadowCopy(t *testing.T) {
 	if err := os.MkdirAll(builtinSource, 0o755); err != nil {
 		t.Fatalf("MkdirAll builtin source failed: %v", err)
 	}
+	claudeJSONSource := filepath.Join(homeDir, ".claude.json")
+	if err := os.WriteFile(claudeJSONSource, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("WriteFile .claude.json failed: %v", err)
+	}
 	externalRoot := t.TempDir()
 	externalFile := filepath.Join(externalRoot, "secret.txt")
 	if err := os.WriteFile(externalFile, []byte("secret"), 0o644); err != nil {
@@ -628,14 +632,29 @@ func TestStateRootOnlyServesCopiesAndBuiltinShadowCopy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("materializeBuiltinTools failed: %v", err)
 	}
-	if len(mounts) != 1 {
-		t.Fatalf("expected one builtin mount, got %d", len(mounts))
+	if len(mounts) != 2 {
+		t.Fatalf("expected two builtin mounts, got %d", len(mounts))
 	}
 	if mounts[0].Source != builtinSource {
 		t.Fatalf("expected builtin source to be %q, got %q", builtinSource, mounts[0].Source)
 	}
 	if mounts[0].ReadOnly {
 		t.Fatal("expected writable builtin mount to preserve capability mode")
+	}
+	if mounts[1].Source != claudeJSONSource {
+		t.Fatalf("expected .claude.json source to be %q, got %q", claudeJSONSource, mounts[1].Source)
+	}
+	if mounts[1].ReadOnly {
+		t.Fatal("expected writable .claude.json mount to preserve capability mode")
+	}
+
+	// Negative case: when ~/.claude.json does not exist on host, materializeBuiltinTools
+	// must fail because os.Stat will return an error for the missing file.
+	if err := os.Remove(claudeJSONSource); err != nil {
+		t.Fatalf("Remove .claude.json failed: %v", err)
+	}
+	if _, err := backendWithoutState.materializeBuiltinTools("sandbox-builtin-missing", []string{"claude"}, &sandboxRuntimeState{}); err == nil {
+		t.Fatal("expected error when ~/.claude.json does not exist, got nil")
 	}
 }
 

--- a/internal/profile/capabilities.go
+++ b/internal/profile/capabilities.go
@@ -14,15 +14,16 @@ const (
 type MountID string
 
 const (
-	MountIDClaude   MountID = ".claude"
-	MountIDCodex    MountID = ".codex"
-	MountIDAgents   MountID = ".agents"
-	MountIDGHAuth   MountID = "gh-auth"
-	MountIDSSHAgent MountID = "ssh-agent"
-	MountIDUVCache  MountID = "uv-cache"
-	MountIDUVData   MountID = "uv-data"
-	MountIDNPM      MountID = "npm"
-	MountIDApt      MountID = "apt"
+	MountIDClaude     MountID = ".claude"
+	MountIDClaudeJSON MountID = ".claude.json"
+	MountIDCodex      MountID = ".codex"
+	MountIDAgents     MountID = ".agents"
+	MountIDGHAuth     MountID = "gh-auth"
+	MountIDSSHAgent   MountID = "ssh-agent"
+	MountIDUVCache    MountID = "uv-cache"
+	MountIDUVData     MountID = "uv-data"
+	MountIDNPM        MountID = "npm"
+	MountIDApt        MountID = "apt"
 )
 
 // ToolID is the canonical identifier for a tooling capability.
@@ -57,6 +58,12 @@ var capabilityMounts = buildMountIndex([]CapabilityMount{
 		ID:              MountIDClaude,
 		DefaultHostPath: "~/.claude",
 		ContainerTarget: "/home/agbox/.claude",
+		Mode:            CapabilityModeReadWrite,
+	},
+	{
+		ID:              MountIDClaudeJSON,
+		DefaultHostPath: "~/.claude.json",
+		ContainerTarget: "/home/agbox/.claude.json",
 		Mode:            CapabilityModeReadWrite,
 	},
 	{
@@ -120,7 +127,7 @@ func buildMountIndex(mounts []CapabilityMount) map[MountID]CapabilityMount {
 }
 
 var builtInToolingCapabilities = map[ToolID]ToolingCapability{
-	ToolIDClaude: {MountIDs: []MountID{MountIDClaude}},
+	ToolIDClaude: {MountIDs: []MountID{MountIDClaude, MountIDClaudeJSON}},
 	// codex requires its own config dir and the shared agents state directory.
 	ToolIDCodex: {MountIDs: []MountID{MountIDCodex, MountIDAgents}},
 	// git requires SSH key forwarding and GitHub CLI auth.

--- a/internal/profile/capabilities_test.go
+++ b/internal/profile/capabilities_test.go
@@ -54,6 +54,19 @@ func TestUVMountsBothDirs(t *testing.T) {
 	}
 }
 
+func TestClaudeMountsBothEntries(t *testing.T) {
+	capability, ok := CapabilityByID(string(ToolIDClaude))
+	if !ok {
+		t.Fatal("missing tool capability claude")
+	}
+	if len(capability.MountIDs) != 2 {
+		t.Fatalf("expected claude to have 2 mount IDs, got %d", len(capability.MountIDs))
+	}
+	if capability.MountIDs[0] != MountIDClaude || capability.MountIDs[1] != MountIDClaudeJSON {
+		t.Fatalf("unexpected claude mount IDs: %v", capability.MountIDs)
+	}
+}
+
 func TestGitMountsBothAuthResources(t *testing.T) {
 	capability, ok := CapabilityByID(string(ToolIDGit))
 	if !ok {

--- a/sdk/python/tests/test_real_runtime.py
+++ b/sdk/python/tests/test_real_runtime.py
@@ -93,6 +93,7 @@ def test_sdk_can_project_claude_directory_with_symlink(tmp_path: Path) -> None:
     claude_root.mkdir(parents=True)
     (claude_root / "settings.json").write_text('{"theme":"dark"}', encoding="utf-8")
     (claude_root / "settings-link.json").symlink_to("settings.json")
+    (fake_home / ".claude.json").write_text("{}", encoding="utf-8")
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()


### PR DESCRIPTION
## Summary

- Add `~/.claude.json` to the capability mounts so Claude Code interactive mode inside the container can read the onboarding state (`hasCompletedOnboarding`) and skip the welcome screen
- Update `docs/container_dependency_strategy.md` to reflect the new mount
- Add `TestClaudeMountsBothEntries` unit test following the existing pattern for codex/uv/git tools

## Test Plan

- [x] `go test ./internal/...` passes
- [x] `TestClaudeMountsBothEntries` verifies claude tool resolves both mount IDs
- [x] `TestStateRootOnlyServesCopiesAndBuiltinShadowCopy` verifies `materializeBuiltinTools` produces 2 mounts for claude
- [ ] Manual: run Claude Code interactive mode inside a sandbox container and verify no onboarding prompt

Close #80
