### PR TITLE
[ISSUE-87] Make builtin tool mounts optional and scope per-agent tool lists

### DIFF
--- a/cmd/agbox/agent_session.go
+++ b/cmd/agbox/agent_session.go
@@ -32,14 +32,22 @@ const (
 	sigtermGracePeriod = 10 * time.Second
 )
 
-// defaultBuiltinTools lists the tool names projected into every agent session sandbox.
-// This list is intentionally fixed; new tools are not added automatically.
-var defaultBuiltinTools = []string{"claude", "codex", "git", "uv", "npm", "apt"}
+// agentToolDef defines the container-internal command and the builtin tools for an agent.
+type agentToolDef struct {
+	command      []string
+	builtinTools []string
+}
 
-// agentToolCommand maps the top-level command name to the container-internal command and args.
-var agentToolCommand = map[string][]string{
-	"claude": {"claude", "--dangerously-skip-permissions"},
-	"codex":  {"codex", "--dangerously-bypass-approvals-and-sandbox"},
+// agentToolDefs maps the top-level command name to its full definition.
+var agentToolDefs = map[string]agentToolDef{
+	"claude": {
+		command:      []string{"claude", "--dangerously-skip-permissions"},
+		builtinTools: []string{"claude", "git", "uv", "npm", "apt"},
+	},
+	"codex": {
+		command:      []string{"codex", "--dangerously-bypass-approvals-and-sandbox"},
+		builtinTools: []string{"codex", "git", "uv", "npm", "apt"},
+	},
 }
 
 // sanitizeContainerName replicates the daemon's sanitizeRuntimeName rule so that
@@ -76,18 +84,18 @@ func runAgentSession(
 		return runtimeErrorf("resolve working directory: %v", err)
 	}
 
-	parsed, err := parseAgentSessionArgs(args, cwd, defaultBuiltinTools)
+	toolDef, ok := agentToolDefs[toolName]
+	if !ok {
+		return runtimeErrorf("unknown agent tool %q", toolName)
+	}
+
+	parsed, err := parseAgentSessionArgs(args, cwd, toolDef.builtinTools)
 	if err != nil {
 		return err
 	}
 
 	if _, err := os.Stat(parsed.mount); err != nil {
 		return usageErrorf("--mount path %q: %v", parsed.mount, err)
-	}
-
-	containerCmd := agentToolCommand[toolName]
-	if containerCmd == nil {
-		return runtimeErrorf("unknown agent tool %q", toolName)
 	}
 
 	socketPath, err := platform.SocketPath(lookupEnv)
@@ -158,7 +166,7 @@ func runAgentSession(
 	if err := waitForSandboxReady(ctx, client, sandboxID, lastEventSeq, sigintCh, sigtermCh); err != nil {
 		return err
 	}
-	dockerArgs := append([]string{"exec", "-it", "--user", "agbox", containerName}, containerCmd...)
+	dockerArgs := append([]string{"exec", "-it", "--user", "agbox", containerName}, toolDef.command...)
 	cmd := exec.Command("docker", dockerArgs...) //nolint:gosec
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/control/docker_runtime_materialize.go
+++ b/internal/control/docker_runtime_materialize.go
@@ -3,6 +3,7 @@ package control
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,9 +106,14 @@ func (backend *dockerRuntimeBackend) materializeBuiltinTools(
 	if len(resources) == 0 {
 		return nil, nil
 	}
-	// Collect unique mount IDs across all requested tools, preserving first-seen order.
+
+	// Resolve each tool into its mount IDs, tracking which mounts belong to optional tools.
+	type mountEntry struct {
+		mountID  profile.MountID
+		optional bool
+	}
 	seen := make(map[profile.MountID]struct{})
-	var mountIDs []profile.MountID
+	var entries []mountEntry
 	for _, resource := range resources {
 		capability, ok := profile.CapabilityByID(resource)
 		if !ok {
@@ -116,24 +122,41 @@ func (backend *dockerRuntimeBackend) materializeBuiltinTools(
 		for _, mountID := range capability.MountIDs {
 			if _, exists := seen[mountID]; !exists {
 				seen[mountID] = struct{}{}
-				mountIDs = append(mountIDs, mountID)
+				entries = append(entries, mountEntry{mountID: mountID, optional: capability.Optional})
 			}
 		}
 	}
 
-	mounts := make([]dockerMount, 0, len(mountIDs))
-	for _, mountID := range mountIDs {
-		mount, ok := profile.MountByID(mountID)
+	logger := backend.config.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	mounts := make([]dockerMount, 0, len(entries))
+	for _, entry := range entries {
+		mount, ok := profile.MountByID(entry.mountID)
 		if !ok {
-			return nil, fmt.Errorf("unknown capability mount %q", mountID)
+			return nil, fmt.Errorf("unknown capability mount %q", entry.mountID)
 		}
 		sourcePath, err := resolveCapabilityMountSource(mount)
 		if err != nil {
+			if entry.optional {
+				logger.Info("skipping optional builtin mount: host path not available",
+					slog.String("mount", string(entry.mountID)),
+					slog.String("error", err.Error()))
+				continue
+			}
 			return nil, err
 		}
 		switch mount.Mode {
 		case profile.CapabilityModeSocket:
 			if err := requireSocketPath(sourcePath); err != nil {
+				if entry.optional {
+					logger.Info("skipping optional builtin mount: socket not available",
+						slog.String("mount", string(entry.mountID)),
+						slog.String("error", err.Error()))
+					continue
+				}
 				return nil, err
 			}
 			mounts = append(mounts, dockerMount{
@@ -145,6 +168,12 @@ func (backend *dockerRuntimeBackend) materializeBuiltinTools(
 			writable := mount.Mode == profile.CapabilityModeReadWrite
 			actualSource, readOnly, err := backend.materializeBuiltinToolPath(sourcePath, writable, state)
 			if err != nil {
+				if entry.optional {
+					logger.Info("skipping optional builtin mount: host path not available",
+						slog.String("mount", string(entry.mountID)),
+						slog.String("error", err.Error()))
+					continue
+				}
 				return nil, err
 			}
 			mounts = append(mounts, dockerMount{

--- a/internal/control/service_stage2_runtime_contracts_test.go
+++ b/internal/control/service_stage2_runtime_contracts_test.go
@@ -660,6 +660,31 @@ func TestStateRootOnlyServesCopiesAndBuiltinShadowCopy(t *testing.T) {
 	}
 }
 
+func TestMaterializeBuiltinToolsSkipsOptionalWhenHostPathMissing(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	backendWithoutState := &dockerRuntimeBackend{
+		config: ServiceConfig{},
+	}
+
+	// Request an optional tool (uv) whose host paths do not exist.
+	// materializeBuiltinTools should skip them silently instead of failing.
+	mounts, err := backendWithoutState.materializeBuiltinTools("sandbox-optional-skip", []string{"uv"}, &sandboxRuntimeState{})
+	if err != nil {
+		t.Fatalf("expected optional tool mounts to be skipped, got error: %v", err)
+	}
+	if len(mounts) != 0 {
+		t.Fatalf("expected zero mounts when optional host paths are missing, got %d", len(mounts))
+	}
+
+	// When mixing required and optional tools, the required tool must still fail
+	// if its path is missing.
+	if _, err := backendWithoutState.materializeBuiltinTools("sandbox-mixed", []string{"uv", "claude"}, &sandboxRuntimeState{}); err == nil {
+		t.Fatal("expected error for required tool (claude) with missing host path, got nil")
+	}
+}
+
 func TestProtoEventTypesForServices(t *testing.T) {
 	values := agboxv1.EventType(0).Descriptor().Values()
 	sandboxReady := values.ByName("SANDBOX_READY")

--- a/internal/profile/capabilities.go
+++ b/internal/profile/capabilities.go
@@ -49,8 +49,10 @@ type CapabilityMount struct {
 
 // ToolingCapability is a user-facing tool name that maps to one or more mount IDs.
 // Users request tools by name; the daemon resolves and deduplicates the underlying mounts.
+// Optional tools are silently skipped when their host paths do not exist.
 type ToolingCapability struct {
 	MountIDs []MountID
+	Optional bool
 }
 
 var capabilityMounts = buildMountIndex([]CapabilityMount{
@@ -130,12 +132,13 @@ var builtInToolingCapabilities = map[ToolID]ToolingCapability{
 	ToolIDClaude: {MountIDs: []MountID{MountIDClaude, MountIDClaudeJSON}},
 	// codex requires its own config dir and the shared agents state directory.
 	ToolIDCodex: {MountIDs: []MountID{MountIDCodex, MountIDAgents}},
-	// git requires SSH key forwarding and GitHub CLI auth.
-	ToolIDGit: {MountIDs: []MountID{MountIDSSHAgent, MountIDGHAuth}},
-	// uv requires both the package cache and the data directory (Python interpreters + global tools).
-	ToolIDUV:  {MountIDs: []MountID{MountIDUVCache, MountIDUVData}},
-	ToolIDNPM: {MountIDs: []MountID{MountIDNPM}},
-	ToolIDApt: {MountIDs: []MountID{MountIDApt}},
+	// git mounts are optional: SSH agent may not be running and gh CLI may not be configured.
+	// Each mount is independently skipped if its host path is unavailable.
+	ToolIDGit: {MountIDs: []MountID{MountIDSSHAgent, MountIDGHAuth}, Optional: true},
+	// uv, npm, apt are cache/acceleration mounts; the host may not have them installed.
+	ToolIDUV:  {MountIDs: []MountID{MountIDUVCache, MountIDUVData}, Optional: true},
+	ToolIDNPM: {MountIDs: []MountID{MountIDNPM}, Optional: true},
+	ToolIDApt: {MountIDs: []MountID{MountIDApt}, Optional: true},
 }
 
 func BuiltInToolingCapabilities() []ToolingCapability {


### PR DESCRIPTION
## Summary

- Add `Optional` field to `ToolingCapability` — tools marked optional (`uv`, `npm`, `apt`) are silently skipped with a log message when their host paths don't exist, instead of failing sandbox creation
- Merge `agentToolCommand` and `defaultBuiltinTools` into per-agent `agentToolDefs` — `agbox claude` no longer requests `codex` mounts and vice versa
- Add test coverage for optional tool skip behavior (both pure-optional and mixed required+optional cases)

## Test plan

- [x] Existing `TestMaterializeBuiltinTools*` tests pass (required tool still fails on missing path)
- [x] New `TestMaterializeBuiltinToolsSkipsOptionalWhenHostPathMissing` validates skip behavior
- [x] All pre-commit hooks and full test suite pass

Close #87
