### PR TITLE
[ISSUE-93] Replace shadow-copy bind mounts with CopyToContainer

### DIFF
--- a/cmd/agboxd/config.go
+++ b/cmd/agboxd/config.go
@@ -22,7 +22,6 @@ type daemonFileConfig struct {
 	Runtime struct {
 		IdleTTL           string `toml:"idle_ttl"`
 		CleanupTTL string `toml:"cleanup_ttl"`
-		StateRoot         string `toml:"state_root"`
 		LogLevel          string `toml:"log_level"`
 	} `toml:"runtime"`
 	Artifacts struct {
@@ -105,9 +104,6 @@ func applyFileConfig(
 			return control.ServiceConfig{}, fmt.Errorf("parse runtime.cleanup_ttl from %s: %w", configPath, err)
 		}
 		serviceConfig.CleanupTTL = cleanupTTL
-	}
-	if fileConfig.Runtime.StateRoot != "" {
-		serviceConfig.StateRoot = fileConfig.Runtime.StateRoot
 	}
 	if fileConfig.Runtime.LogLevel != "" {
 		serviceConfig.LogLevel = fileConfig.Runtime.LogLevel

--- a/cmd/agboxd/main.go
+++ b/cmd/agboxd/main.go
@@ -58,7 +58,6 @@ func runWithDeps(
 	logger.Info("starting",
 		slog.String("socket_path", startup.socketPath),
 		slog.String("id_store_path", startup.idStorePath),
-		slog.String("state_root", startup.serviceConfig.StateRoot),
 		slog.String("idle_ttl", startup.serviceConfig.IdleTTL.String()),
 		slog.String("cleanup_ttl", startup.serviceConfig.CleanupTTL.String()),
 		slog.String("log_level", startup.serviceConfig.LogLevel),

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -80,7 +80,7 @@ The repository exposes three integration styles: a raw transport Go client, a hi
 
 - Unsafe or invalid create inputs are rejected at the RPC boundary instead of accepted and failing later in the background.
 - `mounts` and `copies` require absolute container targets and real host sources.
-- `copies` and builtin-tool shadow copies require a configured state root because the daemon materializes content into daemon-owned filesystem state.
+- `copies` are injected into the container via `CopyToContainer` (tar stream) between create and start, eliminating host-side shadow state.
 - Runtime exec assumes a non-root sandbox user model.
 - Built-in resources are daemon-defined; callers cannot replace them with arbitrary host paths.
 

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -34,7 +34,6 @@ The host lock always lives next to the socket so the lock protects the exact run
 | `runtime.idle_ttl` | duration string | `"10m"` | Daemon config only | Global idle stop threshold based on `last_terminal_run_finished_at`. Set to `"0"` to disable idle detection globally. |
 | `runtime.cleanup_ttl` | duration string | `"360h"` | Daemon config only | Time after which STOPPED sandboxes have their Docker resources cleaned up and DB records deleted, and DELETED sandbox event history is purged |
 | `runtime.log_level` | string | `"info"` | Daemon config only | Log verbosity: `debug`, `info`, `warn`, `error` |
-| `runtime.state_root` | string | unset | Daemon config only | Root for generic copy inputs and builtin-tool shadow-copy state |
 | `artifacts.exec_output_root` | string | Platform default: Linux: `$XDG_DATA_HOME/agents-sandbox/exec-logs`; macOS: `~/Library/Application Support/agents-sandbox/exec-logs` | Daemon config only | Root directory for exec log files; bind-mounted into the primary container at `/var/log/agents-sandbox/` so exec output is written directly to the host |
 | `artifacts.exec_output_template` | string | `"{sandbox_id}/{exec_id}"` | Daemon config only | Relative path prefix expanded against `artifacts.exec_output_root`; supported fields are `sandbox_id` and `exec_id`; daemon appends `.stdout.log` and `.stderr.log` suffixes |
 

--- a/docs/container_dependency_strategy.md
+++ b/docs/container_dependency_strategy.md
@@ -55,14 +55,15 @@ When an imported runtime image needs host-backed authentication material, `HOST_
 ### Generic copies
 
 - The copy source must be a real file or directory, not a symlink.
-- `exclude_patterns` are applied while populating the copied tree (see [Declarative YAML Config](declarative_yaml_config.md) for the YAML field reference).
-- Project-internal symlinks are preserved as symlinks; absolute host paths are rewritten to relative targets when needed.
+- Copies are injected into the container via Docker's `CopyToContainer` API (tar stream) between container create and start — no host-side shadow directories are needed.
+- `exclude_patterns` are applied while building the tar stream (see [Declarative YAML Config](declarative_yaml_config.md) for the YAML field reference).
+- Project-internal symlinks are preserved as symlinks in the tar archive.
 - Project-external or unreadable symlink targets are rejected instead of being auto-imported.
 
 ### Built-in resources
 
 - Regular directories use bind mounts when safe.
-- Directory trees with escaping symlinks fall back to daemon-owned shadow copies.
+- Directory trees with escaping symlinks are bind-mounted directly from the host path.
 - Socket resources such as `ssh-agent` are forwarded only when the host path is a real Unix socket.
 
 ## Service Model
@@ -106,7 +107,7 @@ The runtime must execute under a non-root user inside the sandbox. Bind-mounted 
 
 ## Cleanup and Ownership
 
-`agents-sandbox` owns cleanup for resources carrying the `io.github.1996fanrui.agents-sandbox.*` label namespace: primary containers, service containers, dedicated networks, shadow-copy trees, and event/artifact files.
+`agents-sandbox` owns cleanup for resources carrying the `io.github.1996fanrui.agents-sandbox.*` label namespace: primary containers, service containers, dedicated networks, and event/artifact files.
 
 Docker objects without these labels are never inspected, stopped, or removed by the daemon. Ownership must be derivable from runtime state plus namespaced labels without requiring an external product database snapshot. Cleanup continues on daemon-owned contexts rather than request-scoped cancellation.
 

--- a/internal/control/docker_runtime.go
+++ b/internal/control/docker_runtime.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -85,7 +84,6 @@ type sandboxRuntimeState struct {
 	NetworkName           string
 	PrimaryContainerName  string
 	ServiceContainers     []runtimeServiceContainer
-	ShadowRoot            string
 	OptionalServiceStarts optionalServiceStarts
 }
 
@@ -213,11 +211,10 @@ func (backend *dockerRuntimeBackend) CreateSandbox(ctx context.Context, record *
 		return runtimeCreateResult{}, err
 	}
 	mounts = append(mounts, genericMounts...)
-	copyMounts, err := backend.materializeGenericCopies(record.handle.GetSandboxId(), record.createSpec.GetCopies(), state)
+	deferredCopies, err := validateGenericCopies(record.createSpec.GetCopies())
 	if err != nil {
 		return runtimeCreateResult{}, err
 	}
-	mounts = append(mounts, copyMounts...)
 	// Bind-mount exec log directory into the primary container so exec output is written directly to the host.
 	// The directory is pre-created by the service layer before calling this function.
 	if backend.config.ArtifactOutputRoot != "" {
@@ -312,6 +309,11 @@ func (backend *dockerRuntimeBackend) CreateSandbox(ctx context.Context, record *
 		},
 	}); err != nil {
 		return runtimeCreateResult{}, err
+	}
+	for _, copy := range deferredCopies {
+		if err := backend.dockerCopyToContainer(ctx, state.PrimaryContainerName, copy); err != nil {
+			return runtimeCreateResult{}, err
+		}
 	}
 	if err := backend.dockerContainerStart(ctx, state.PrimaryContainerName); err != nil {
 		return runtimeCreateResult{}, err
@@ -505,9 +507,6 @@ func (backend *dockerRuntimeBackend) deleteRuntimeArtifacts(ctx context.Context,
 	}
 	if state.NetworkName != "" {
 		joined = append(joined, backend.dockerNetworkRemove(ctx, state.NetworkName))
-	}
-	if state.ShadowRoot != "" {
-		joined = append(joined, os.RemoveAll(state.ShadowRoot))
 	}
 	return errors.Join(joined...)
 }

--- a/internal/control/docker_runtime_copy.go
+++ b/internal/control/docker_runtime_copy.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"archive/tar"
 	"fmt"
 	"io"
 	"io/fs"
@@ -9,111 +10,6 @@ import (
 
 	runtimedocker "github.com/1996fanrui/agents-sandbox/internal/runtime/docker"
 )
-
-func copyTree(sourceRoot string, targetRoot string) error {
-	return copyTreeWithOptions(sourceRoot, targetRoot, nil, false)
-}
-
-func copyTreeAllowExternalSymlinks(sourceRoot string, targetRoot string) error {
-	return copyTreeWithOptions(sourceRoot, targetRoot, nil, true)
-}
-
-func copyTreeWithPatterns(sourceRoot string, targetRoot string, excludePatterns []string) error {
-	return copyTreeWithOptions(sourceRoot, targetRoot, excludePatterns, false)
-}
-
-func copyTreeWithOptions(sourceRoot string, targetRoot string, excludePatterns []string, allowExternalSymlinks bool) error {
-	sourceInfo, err := os.Stat(sourceRoot)
-	if err != nil {
-		return err
-	}
-	if !sourceInfo.IsDir() {
-		return copyFile(sourceRoot, targetRoot, sourceInfo.Mode())
-	}
-	rootAbs, err := filepath.Abs(sourceRoot)
-	if err != nil {
-		return err
-	}
-	return filepath.WalkDir(sourceRoot, func(currentSource string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		relativePath, err := filepath.Rel(sourceRoot, currentSource)
-		if err != nil {
-			return err
-		}
-		currentTarget := targetRoot
-		if relativePath != "." {
-			currentTarget = filepath.Join(targetRoot, relativePath)
-		}
-		info, err := entry.Info()
-		if err != nil {
-			return err
-		}
-		if relativePath != "." && matchesExcludePattern(relativePath, excludePatterns) {
-			if entry.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if entry.IsDir() {
-			return os.MkdirAll(currentTarget, info.Mode())
-		}
-		if entry.Type()&os.ModeSymlink != 0 {
-			target, copyResolved, resolvedTarget, err := rewriteCopiedSymlink(rootAbs, targetRoot, currentSource, currentTarget, allowExternalSymlinks)
-			if err != nil {
-				return err
-			}
-			if copyResolved {
-				resolvedInfo, err := os.Stat(resolvedTarget)
-				if err != nil {
-					return err
-				}
-				if resolvedInfo.IsDir() {
-					return copyTreeWithOptions(resolvedTarget, currentTarget, nil, allowExternalSymlinks)
-				}
-				return copyFile(resolvedTarget, currentTarget, resolvedInfo.Mode())
-			}
-			if err := os.MkdirAll(filepath.Dir(currentTarget), 0o755); err != nil {
-				return err
-			}
-			return os.Symlink(target, currentTarget)
-		}
-		return copyFile(currentSource, currentTarget, info.Mode())
-	})
-}
-
-func rewriteCopiedSymlink(
-	sourceRoot string,
-	targetRoot string,
-	currentSource string,
-	currentTarget string,
-	allowExternalSymlinks bool,
-) (string, bool, string, error) {
-	target, err := os.Readlink(currentSource)
-	if err != nil {
-		return "", false, "", err
-	}
-	resolvedTarget, err := runtimedocker.ResolveLinkTarget(currentSource)
-	if err != nil {
-		return "", false, "", err
-	}
-	if !pathWithinRoot(sourceRoot, resolvedTarget) {
-		if !allowExternalSymlinks {
-			return "", false, "", fmt.Errorf("copy source contains external symlink: %s", currentSource)
-		}
-		return "", true, resolvedTarget, nil
-	}
-	if filepath.IsAbs(target) {
-		relativeTarget, err := filepath.Rel(sourceRoot, resolvedTarget)
-		if err != nil {
-			return "", false, "", err
-		}
-		rewrittenTarget, err := filepath.Rel(filepath.Dir(currentTarget), filepath.Join(targetRoot, relativeTarget))
-		return rewrittenTarget, false, "", err
-	}
-	return target, false, "", nil
-}
 
 func matchesExcludePattern(relativePath string, patterns []string) bool {
 	base := filepath.Base(relativePath)
@@ -131,22 +27,115 @@ func matchesExcludePattern(relativePath string, patterns []string) bool {
 	return false
 }
 
-func copyFile(sourcePath string, targetPath string, mode fs.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
-		return err
+// buildCopyTar writes a tar archive of sourceRoot to w, applying exclude patterns
+// and preserving symlinks. The archive paths are relative so that CopyToContainer
+// extracts them under the target directory. The writer is always closed.
+func buildCopyTar(w io.WriteCloser, sourceRoot string, excludePatterns []string) error {
+	tw := tar.NewWriter(w)
+	closeAll := func(tarErr error) error {
+		twErr := tw.Close()
+		wErr := w.Close()
+		if tarErr != nil {
+			return tarErr
+		}
+		if twErr != nil {
+			return twErr
+		}
+		return wErr
 	}
-	sourceFile, err := os.Open(sourcePath)
+
+	rootAbs, err := filepath.Abs(sourceRoot)
+	if err != nil {
+		return closeAll(err)
+	}
+
+	sourceInfo, err := os.Lstat(sourceRoot)
+	if err != nil {
+		return closeAll(err)
+	}
+	if !sourceInfo.IsDir() {
+		// Single file: write it as the base name.
+		err := writeTarFile(tw, sourceRoot, sourceInfo.Name(), sourceInfo)
+		return closeAll(err)
+	}
+
+	err = filepath.WalkDir(sourceRoot, func(currentPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relPath, err := filepath.Rel(sourceRoot, currentPath)
+		if err != nil {
+			return err
+		}
+		if relPath == "." {
+			return nil
+		}
+		if matchesExcludePattern(relPath, excludePatterns) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return writeTarSymlink(tw, currentPath, relPath, rootAbs)
+		}
+		if entry.IsDir() {
+			header, headerErr := tar.FileInfoHeader(info, "")
+			if headerErr != nil {
+				return headerErr
+			}
+			header.Name = relPath + "/"
+			return tw.WriteHeader(header)
+		}
+		return writeTarFile(tw, currentPath, relPath, info)
+	})
+	return closeAll(err)
+}
+
+func writeTarFile(tw *tar.Writer, sourcePath string, archiveName string, info fs.FileInfo) error {
+	header, err := tar.FileInfoHeader(info, "")
 	if err != nil {
 		return err
 	}
-	defer sourceFile.Close()
-	targetFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode.Perm())
+	header.Name = archiveName
+	if err := tw.WriteHeader(header); err != nil {
+		return err
+	}
+	f, err := os.Open(sourcePath)
 	if err != nil {
 		return err
 	}
-	defer targetFile.Close()
-	if _, err := io.Copy(targetFile, sourceFile); err != nil {
+	defer f.Close()
+	_, err = io.Copy(tw, f)
+	return err
+}
+
+func writeTarSymlink(tw *tar.Writer, sourcePath string, archiveName string, sourceRootAbs string) error {
+	linkTarget, err := os.Readlink(sourcePath)
+	if err != nil {
 		return err
 	}
-	return nil
+	// Reject external symlinks (those resolving outside the source tree).
+	resolvedTarget, err := runtimedocker.ResolveLinkTarget(sourcePath)
+	if err != nil {
+		return err
+	}
+	if !pathWithinRoot(sourceRootAbs, resolvedTarget) {
+		return fmt.Errorf("copy source contains external symlink: %s", sourcePath)
+	}
+	info, err := os.Lstat(sourcePath)
+	if err != nil {
+		return err
+	}
+	header, err := tar.FileInfoHeader(info, linkTarget)
+	if err != nil {
+		return err
+	}
+	header.Name = archiveName
+	header.Linkname = linkTarget
+	return tw.WriteHeader(header)
 }

--- a/internal/control/docker_runtime_dockerapi.go
+++ b/internal/control/docker_runtime_dockerapi.go
@@ -391,6 +391,31 @@ func envMapToSlice(environment map[string]string) []string {
 	return values
 }
 
+// dockerCopyToContainer copies the source tree into the container at the given target path,
+// applying exclude patterns. The container must be created but may or may not be started.
+// Symlinks within the source tree are preserved in the tar stream.
+func (backend *dockerRuntimeBackend) dockerCopyToContainer(ctx context.Context, containerName string, copy deferredCopy) error {
+	if backend == nil || backend.dockerClient == nil {
+		return errors.New("docker client is not initialized")
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- buildCopyTar(pipeWriter, copy.SourcePath, copy.ExcludePatterns)
+	}()
+
+	err := backend.dockerClient.CopyToContainer(ctx, containerName, copy.ContainerTarget, pipeReader, container.CopyToContainerOptions{})
+	tarErr := <-errCh
+	if err != nil {
+		return fmt.Errorf("copy to container %s at %s: %w", containerName, copy.ContainerTarget, err)
+	}
+	if tarErr != nil {
+		return fmt.Errorf("build tar for %s: %w", copy.SourcePath, tarErr)
+	}
+	return nil
+}
+
 func ptrTo[T any](value T) *T {
 	return &value
 }

--- a/internal/control/docker_runtime_materialize.go
+++ b/internal/control/docker_runtime_materialize.go
@@ -46,22 +46,20 @@ func (backend *dockerRuntimeBackend) materializeGenericMounts(
 	return mounts, nil
 }
 
-func (backend *dockerRuntimeBackend) materializeGenericCopies(
-	sandboxID string,
-	requests []*agboxv1.CopySpec,
-	state *sandboxRuntimeState,
-) ([]dockerMount, error) {
+// deferredCopy represents a validated copy request that will be applied via
+// CopyToContainer after the container is created but before it is started.
+type deferredCopy struct {
+	SourcePath      string
+	ContainerTarget string
+	ExcludePatterns []string
+}
+
+func validateGenericCopies(requests []*agboxv1.CopySpec) ([]deferredCopy, error) {
 	if len(requests) == 0 {
 		return nil, nil
 	}
-	if backend.config.StateRoot == "" {
-		return nil, errors.New("runtime.state_root is required for generic copy inputs")
-	}
-	if state.ShadowRoot == "" {
-		state.ShadowRoot = filepath.Join(backend.config.StateRoot, "sandboxes", sandboxID, "shadow")
-	}
-	mounts := make([]dockerMount, 0, len(requests))
-	for index, request := range requests {
+	copies := make([]deferredCopy, 0, len(requests))
+	for _, request := range requests {
 		if request.GetSource() == "" {
 			return nil, errors.New("copy source is required")
 		}
@@ -82,20 +80,13 @@ func (backend *dockerRuntimeBackend) materializeGenericCopies(
 		if !sourceInfo.Mode().IsRegular() && !sourceInfo.IsDir() {
 			return nil, fmt.Errorf("copy source must be a file or directory: %s", sourcePath)
 		}
-		copyRoot := filepath.Join(state.ShadowRoot, "copies", fmt.Sprintf("%02d-%s", index, sanitizeRuntimeName(request.GetTarget())))
-		if err := os.RemoveAll(copyRoot); err != nil {
-			return nil, err
-		}
-		if err := copyTreeWithPatterns(sourcePath, copyRoot, request.GetExcludePatterns()); err != nil {
-			return nil, err
-		}
-		mounts = append(mounts, dockerMount{
-			Source:   copyRoot,
-			Target:   request.GetTarget(),
-			ReadOnly: false,
+		copies = append(copies, deferredCopy{
+			SourcePath:      sourcePath,
+			ContainerTarget: request.GetTarget(),
+			ExcludePatterns: request.GetExcludePatterns(),
 		})
 	}
-	return mounts, nil
+	return copies, nil
 }
 
 func (backend *dockerRuntimeBackend) materializeBuiltinTools(
@@ -192,7 +183,7 @@ func (backend *dockerRuntimeBackend) materializeBuiltinToolPath(
 	state *sandboxRuntimeState,
 ) (string, bool, error) {
 	// Builtin tools are always bind-mounted as-is, including any symlinks.
-	// Shadow-copy logic is intentionally skipped: these are trusted host directories
+	// Builtin tools are always bind-mounted as-is, including any symlinks. These are trusted host directories
 	// (tool configs, caches) that may contain symlinks to arbitrary host paths,
 	// and the container is expected to see them exactly as they appear on the host.
 	if _, err := os.Stat(sourcePath); err != nil {

--- a/internal/control/service.go
+++ b/internal/control/service.go
@@ -27,7 +27,6 @@ type ServiceConfig struct {
 	IdleTTL                time.Duration
 	CleanupTTL             time.Duration
 	CleanupInterval        time.Duration
-	StateRoot              string
 	ArtifactOutputRoot     string
 	ArtifactOutputTemplate string
 	Version                string

--- a/internal/control/service_runtime_test.go
+++ b/internal/control/service_runtime_test.go
@@ -1,7 +1,9 @@
 package control
 
 import (
+	"archive/tar"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,7 +49,7 @@ func TestExecStatusCarriesExitCode(t *testing.T) {
 	}
 }
 
-func TestMaterializeGenericCopiesRejectsExternalSymlink(t *testing.T) {
+func TestBuildCopyTarRejectsExternalSymlink(t *testing.T) {
 	sourceRoot := t.TempDir()
 	externalRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(externalRoot, "secret.txt"), []byte("secret"), 0o644); err != nil {
@@ -57,17 +59,15 @@ func TestMaterializeGenericCopiesRejectsExternalSymlink(t *testing.T) {
 		t.Fatalf("Symlink failed: %v", err)
 	}
 
-	backend := &dockerRuntimeBackend{config: ServiceConfig{StateRoot: t.TempDir()}}
-	state := &sandboxRuntimeState{}
-	_, err := backend.materializeGenericCopies("sandbox-1", []*agboxv1.CopySpec{
-		{Source: sourceRoot, Target: "/workspace/project"},
-	}, state)
+	pr, pw := io.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, pr) }()
+	err := buildCopyTar(pw, sourceRoot, nil)
 	if err == nil || !strings.Contains(err.Error(), "external symlink") {
 		t.Fatalf("expected external symlink failure, got %v", err)
 	}
 }
 
-func TestMaterializeGenericCopiesAppliesExcludePatterns(t *testing.T) {
+func TestBuildCopyTarAppliesExcludePatterns(t *testing.T) {
 	sourceRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(sourceRoot, "keep.txt"), []byte("keep"), 0o644); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
@@ -76,22 +76,59 @@ func TestMaterializeGenericCopiesAppliesExcludePatterns(t *testing.T) {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
-	backend := &dockerRuntimeBackend{config: ServiceConfig{StateRoot: t.TempDir()}}
-	state := &sandboxRuntimeState{}
-	mounts, err := backend.materializeGenericCopies("sandbox-1", []*agboxv1.CopySpec{
-		{Source: sourceRoot, Target: "/workspace/project", ExcludePatterns: []string{".git"}},
-	}, state)
-	if err != nil {
-		t.Fatalf("materializeGenericCopies failed: %v", err)
+	pr, pw := io.Pipe()
+	go func() {
+		_ = buildCopyTar(pw, sourceRoot, []string{".git"})
+	}()
+	tr := tar.NewReader(pr)
+	names := make(map[string]bool)
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			break
+		}
+		names[header.Name] = true
 	}
-	if len(mounts) != 1 {
-		t.Fatalf("expected one mount, got %d", len(mounts))
+	if !names["keep.txt"] {
+		t.Fatal("expected keep.txt in tar archive")
 	}
-	if _, err := os.Stat(filepath.Join(mounts[0].Source, "keep.txt")); err != nil {
-		t.Fatalf("expected keep.txt to be copied: %v", err)
+	if names[".git"] {
+		t.Fatal("expected .git to be excluded from tar archive")
 	}
-	if _, err := os.Stat(filepath.Join(mounts[0].Source, ".git")); !os.IsNotExist(err) {
-		t.Fatalf("expected excluded file to be absent, got %v", err)
+}
+
+func TestBuildCopyTarPreservesSymlinks(t *testing.T) {
+	sourceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceRoot, "real.txt"), []byte("content"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	if err := os.Symlink("real.txt", filepath.Join(sourceRoot, "link.txt")); err != nil {
+		t.Fatalf("Symlink failed: %v", err)
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		_ = buildCopyTar(pw, sourceRoot, nil)
+	}()
+	tr := tar.NewReader(pr)
+	var found bool
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			break
+		}
+		if header.Name == "link.txt" {
+			found = true
+			if header.Typeflag != tar.TypeSymlink {
+				t.Fatalf("expected symlink type, got %d", header.Typeflag)
+			}
+			if header.Linkname != "real.txt" {
+				t.Fatalf("expected linkname real.txt, got %s", header.Linkname)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected link.txt in tar archive")
 	}
 }
 

--- a/internal/control/service_stage2_runtime_contracts_test.go
+++ b/internal/control/service_stage2_runtime_contracts_test.go
@@ -594,20 +594,7 @@ func TestProtoMessageFieldContracts(t *testing.T) {
 	}
 }
 
-func TestStateRootOnlyServesCopiesAndBuiltinShadowCopy(t *testing.T) {
-	sourceRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(sourceRoot, "keep.txt"), []byte("keep"), 0o644); err != nil {
-		t.Fatalf("WriteFile failed: %v", err)
-	}
-	backendWithoutState := &dockerRuntimeBackend{config: ServiceConfig{}}
-	if _, err := backendWithoutState.materializeGenericCopies(
-		"sandbox-copy",
-		[]*agboxv1.CopySpec{{Source: sourceRoot, Target: "/workspace/project"}},
-		&sandboxRuntimeState{},
-	); err == nil || !strings.Contains(err.Error(), "runtime.state_root is required for generic copy inputs") {
-		t.Fatalf("expected generic copy state_root error, got %v", err)
-	}
-
+func TestBuiltinToolMountsPreserveSymlinks(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	builtinSource := filepath.Join(homeDir, ".claude")
@@ -627,9 +614,9 @@ func TestStateRootOnlyServesCopiesAndBuiltinShadowCopy(t *testing.T) {
 		t.Fatalf("Symlink failed: %v", err)
 	}
 
-	// Builtin resources are mounted directly from the host path without shadow
-	// copies; StateRoot is not required and symlinks are preserved as-is.
+	// Builtin resources are mounted directly from the host path; symlinks are preserved as-is.
 	runtimeState := &sandboxRuntimeState{}
+	backendWithoutState := &dockerRuntimeBackend{config: ServiceConfig{}}
 	mounts, err := backendWithoutState.materializeBuiltinTools("sandbox-builtin", []string{"claude"}, runtimeState)
 	if err != nil {
 		t.Fatalf("materializeBuiltinTools failed: %v", err)

--- a/internal/runtime/docker/projections.go
+++ b/internal/runtime/docker/projections.go
@@ -9,18 +9,6 @@ import (
 
 var ErrProjectionTargetUnreadable = errors.New("projection target is unreadable")
 
-type ProjectionMode string
-
-const (
-	ProjectionModeBind       ProjectionMode = "bind"
-	ProjectionModeShadowCopy ProjectionMode = "shadow_copy"
-)
-
-type ProjectionResolution struct {
-	Mode      ProjectionMode
-	WriteBack bool
-}
-
 func ValidateWorkspaceTree(projectRoot string) error {
 	rootAbs, err := filepath.Abs(projectRoot)
 	if err != nil {
@@ -48,52 +36,6 @@ func ValidateWorkspaceTree(projectRoot string) error {
 	})
 }
 
-func ResolveProjectionMode(projectionRoot string, declaredRoots []string, writable bool) (ProjectionResolution, error) {
-	rootAbs, err := filepath.Abs(projectionRoot)
-	if err != nil {
-		return ProjectionResolution{}, err
-	}
-	allowedRoots := make([]string, 0, len(declaredRoots))
-	for _, declaredRoot := range declaredRoots {
-		absoluteRoot, err := filepath.Abs(declaredRoot)
-		if err != nil {
-			return ProjectionResolution{}, err
-		}
-		allowedRoots = append(allowedRoots, absoluteRoot)
-	}
-	resolution := ProjectionResolution{
-		Mode:      ProjectionModeBind,
-		WriteBack: writable,
-	}
-	err = filepath.WalkDir(rootAbs, func(path string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.Type()&os.ModeSymlink == 0 {
-			return nil
-		}
-		targetPath, err := ResolveLinkTarget(path)
-		if err != nil {
-			return err
-		}
-		if _, err := os.Stat(targetPath); err != nil {
-			// Unresolvable symlink (broken target or permission denied): skip for
-			// projection mode decision. The symlink passes through as-is in a bind
-			// mount (stale cache entries, cross-environment paths, root-owned paths).
-			return nil
-		}
-		if !withinAnyRoot(targetPath, allowedRoots) {
-			resolution.Mode = ProjectionModeShadowCopy
-			resolution.WriteBack = false
-		}
-		return nil
-	})
-	if err != nil {
-		return ProjectionResolution{}, err
-	}
-	return resolution, nil
-}
-
 func ResolveLinkTarget(path string) (string, error) {
 	target, err := os.Readlink(path)
 	if err != nil {
@@ -103,13 +45,4 @@ func ResolveLinkTarget(path string) (string, error) {
 		return filepath.Abs(target)
 	}
 	return filepath.Abs(filepath.Join(filepath.Dir(path), target))
-}
-
-func withinAnyRoot(candidate string, allowedRoots []string) bool {
-	for _, allowedRoot := range allowedRoots {
-		if pathWithinRoot(allowedRoot, candidate) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/runtime/docker/projections_test.go
+++ b/internal/runtime/docker/projections_test.go
@@ -41,37 +41,3 @@ func TestValidateWorkspaceTreeRejectsSymlinksEscapingWorkspaceRoot(t *testing.T)
 		t.Fatalf("expected ErrArtifactPathEscapesRoot, got %v", err)
 	}
 }
-
-func TestResolveProjectionModeFallsBackToShadowCopyForEscapingSymlink(t *testing.T) {
-	projectionRoot := t.TempDir()
-	insideRoot := filepath.Join(projectionRoot, "inside")
-	outsideRoot := t.TempDir()
-	insideTarget := filepath.Join(insideRoot, "kept.txt")
-	outsideTarget := filepath.Join(outsideRoot, "secret.txt")
-	if err := os.MkdirAll(insideRoot, 0o755); err != nil {
-		t.Fatalf("MkdirAll failed: %v", err)
-	}
-	if err := os.WriteFile(insideTarget, []byte("inside"), 0o644); err != nil {
-		t.Fatalf("WriteFile failed: %v", err)
-	}
-	if err := os.WriteFile(outsideTarget, []byte("outside"), 0o644); err != nil {
-		t.Fatalf("WriteFile failed: %v", err)
-	}
-	if err := os.Symlink(filepath.Join("inside", "kept.txt"), filepath.Join(projectionRoot, "inside-link")); err != nil {
-		t.Fatalf("Symlink failed: %v", err)
-	}
-	if err := os.Symlink(outsideTarget, filepath.Join(projectionRoot, "outside-link")); err != nil {
-		t.Fatalf("Symlink failed: %v", err)
-	}
-
-	resolution, err := ResolveProjectionMode(projectionRoot, []string{projectionRoot}, true)
-	if err != nil {
-		t.Fatalf("ResolveProjectionMode failed: %v", err)
-	}
-	if resolution.Mode != ProjectionModeShadowCopy {
-		t.Fatalf("unexpected projection mode: got %s want %s", resolution.Mode, ProjectionModeShadowCopy)
-	}
-	if resolution.WriteBack {
-		t.Fatalf("shadow copy projection must disable write-back")
-	}
-}

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -37,14 +37,7 @@ DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/agents-sandbox"
 RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/agbox"
 
 rm -f "$DATA_DIR/ids.db"
-# state/ may contain root-owned files from container shadow copies
-if [ -d "$DATA_DIR/state" ]; then
-    sudo rm -rf "$DATA_DIR/state"
-fi
 rm -rf "$RUNTIME_DIR"
-# Recreate runtime directory with correct ownership so agboxd can start cleanly.
-# Without this, systemd auto-restart may race and the directory could end up
-# root-owned if sudo was used earlier in this script.
 mkdir -p "$RUNTIME_DIR"
 
 echo ""


### PR DESCRIPTION
## Summary

- Replace host-side shadow-copy + bind-mount mechanism for `CopySpec` inputs with Docker's `CopyToContainer` API (tar stream injected between container create and start)
- Remove `runtime.state_root` config key, `ShadowRoot` runtime state field, and all host-side shadow directory management
- Remove `sudo` requirement from `cleanup.sh` (no more root-owned files on host)
- Remove dead code: `ResolveProjectionMode`, `ProjectionModeShadowCopy`, filesystem copy functions (`copyTree*`, `copyFile`, `rewriteCopiedSymlink`)

## Test plan

- [x] All existing Go tests pass
- [x] All existing Python SDK tests pass
- [x] New unit tests for tar building: exclude patterns, symlink preservation, external symlink rejection
- [x] Pre-commit hooks pass (lint, proto generation, etc.)
- [ ] Manual E2E: create sandbox with `CopySpec`, verify files appear in container

Close #93
