### PR TITLE
[ISSUE-99] Strip debug symbols to reduce binary size by ~30%

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
           VERSION: ${{ needs.resolve-version.outputs.go_version }}
         run: |
           set -e
-          ldflags="-X github.com/1996fanrui/agents-sandbox/internal/version.Version=${VERSION}"
+          ldflags="-s -w -X github.com/1996fanrui/agents-sandbox/internal/version.Version=${VERSION}"
           suffix="${GOOS}_${GOARCH}"
 
           go build -ldflags "${ldflags}" -o "agboxd_${suffix}" ./cmd/agboxd

--- a/scripts/install_local.sh
+++ b/scripts/install_local.sh
@@ -47,10 +47,10 @@ echo "Building agboxd and agbox from source..."
 cd "${PROJECT_ROOT}"
 mkdir -p "${INSTALL_DIR}"
 
-"${GO_BIN}" build -o "${INSTALL_DIR}/agboxd" ./cmd/agboxd
+"${GO_BIN}" build -ldflags="-s -w" -o "${INSTALL_DIR}/agboxd" ./cmd/agboxd
 echo "Installed: ${INSTALL_DIR}/agboxd"
 
-"${GO_BIN}" build -o "${INSTALL_DIR}/agbox" ./cmd/agbox
+"${GO_BIN}" build -ldflags="-s -w" -o "${INSTALL_DIR}/agbox" ./cmd/agbox
 echo "Installed: ${INSTALL_DIR}/agbox"
 
 # Sync stale copies in ~/bin/ if they exist and we installed elsewhere.


### PR DESCRIPTION
## Summary
- Add `-s -w` ldflags to strip DWARF debug info and symbol table from release and local builds
- Reduces binary size by ~30%: agboxd 22→15 MB, agbox 18→13 MB

## Test plan
- [x] Local build verified: `go build -ldflags="-s -w"` produces correct smaller binaries
- [x] All Go and Python tests pass

Close #99
