### PR TITLE
[ISSUE-103] Fix install path: use ~/.local/bin and auto-add to PATH

### DIFF
--- a/scripts/install_local.sh
+++ b/scripts/install_local.sh
@@ -19,26 +19,9 @@ if ! command -v "${GO_BIN}" >/dev/null 2>&1; then
 fi
 
 # ---------------------------------------------------------------------------
-# Detect best install directory already in PATH.
-# Priority: ~/.local/bin (if in PATH) > ~/bin (if in PATH)
-#           > /usr/local/bin (if writable) > ~/.local/bin (fallback)
+# Install directory: ~/.local/bin (XDG standard, same convention as uv, pipx, etc.)
 # ---------------------------------------------------------------------------
-_in_path() {
-  case ":${PATH}:" in
-    *":$1:"*) return 0 ;;
-    *)        return 1 ;;
-  esac
-}
-
-if _in_path "${HOME}/.local/bin"; then
-  INSTALL_DIR="${HOME}/.local/bin"
-elif _in_path "${HOME}/bin"; then
-  INSTALL_DIR="${HOME}/bin"
-elif [[ -d "/usr/local/bin" && -w "/usr/local/bin" ]]; then
-  INSTALL_DIR="/usr/local/bin"
-else
-  INSTALL_DIR="${HOME}/.local/bin"
-fi
+INSTALL_DIR="${HOME}/.local/bin"
 
 # ---------------------------------------------------------------------------
 # Build both binaries
@@ -53,34 +36,44 @@ echo "Installed: ${INSTALL_DIR}/agboxd"
 "${GO_BIN}" build -ldflags="-s -w" -o "${INSTALL_DIR}/agbox" ./cmd/agbox
 echo "Installed: ${INSTALL_DIR}/agbox"
 
-# Sync stale copies in ~/bin/ if they exist and we installed elsewhere.
-if [[ "${INSTALL_DIR}" != "${HOME}/bin" && -d "${HOME}/bin" ]]; then
-  for bin in agboxd agbox; do
-    if [[ -f "${HOME}/bin/${bin}" ]]; then
-      cp "${INSTALL_DIR}/${bin}" "${HOME}/bin/${bin}"
-      chmod 755 "${HOME}/bin/${bin}"
-      echo "Updated  : ${HOME}/bin/${bin}"
-    fi
-  done
-fi
+# ---------------------------------------------------------------------------
+# Ensure install directory is in PATH.
+# Auto-adds to shell profile unless AGBOX_NO_MODIFY_PATH=1.
+# ---------------------------------------------------------------------------
+_ensure_path() {
+  case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) return ;;
+  esac
 
-# ---------------------------------------------------------------------------
-# Warn if install directory is not in PATH
-# ---------------------------------------------------------------------------
-case ":${PATH}:" in
-  *":${INSTALL_DIR}:"*) ;;
-  *)
-    echo ""
-    echo "WARNING: ${INSTALL_DIR} is not in your PATH."
-    echo "  Add it by running:"
-    SHELL_NAME=$(basename "${SHELL:-/bin/bash}")
-    case "${SHELL_NAME}" in
-      zsh)  echo "    echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.zshrc && source ~/.zshrc" ;;
-      fish) echo "    fish_add_path ${INSTALL_DIR}" ;;
-      *)    echo "    echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.bashrc && source ~/.bashrc" ;;
-    esac
-    ;;
-esac
+  local path_line="export PATH=\"${INSTALL_DIR}:\$PATH\""
+  local shell_name
+  shell_name=$(basename "${SHELL:-/bin/bash}")
+
+  local profile=""
+  case "${shell_name}" in
+    zsh)  profile="${HOME}/.zshrc" ;;
+    bash)
+      if [[ "$(uname -s)" == "Darwin" ]]; then
+        profile="${HOME}/.bash_profile"
+      else
+        profile="${HOME}/.bashrc"
+      fi
+      ;;
+    *)    profile="${HOME}/.profile" ;;
+  esac
+
+  if [[ -n "${profile}" ]]; then
+    if ! grep -qF "${INSTALL_DIR}" "${profile}" 2>/dev/null; then
+      echo "" >> "${profile}"
+      echo "# Added by agents-sandbox installer" >> "${profile}"
+      echo "${path_line}" >> "${profile}"
+      echo "Added ${INSTALL_DIR} to PATH in ${profile}"
+    fi
+    export PATH="${INSTALL_DIR}:${PATH}"
+  fi
+}
+
+_ensure_path
 
 # ---------------------------------------------------------------------------
 # Set up and restart the agboxd service

--- a/website/install.sh
+++ b/website/install.sh
@@ -17,7 +17,7 @@
 # What this script does:
 #   1. Checks that Docker is installed and the daemon is running.
 #   2. Downloads agboxd and agbox binaries for your OS/arch from GitHub Releases.
-#   3. Installs binaries to the best available directory already in PATH.
+#   3. Installs binaries to ~/.local/bin.
 #   4. Linux : creates/updates ~/.config/systemd/user/agboxd.service and restarts it.
 #   5. macOS : creates/updates ~/Library/LaunchAgents/io.github.agents-sandbox.agboxd.plist
 #              and restarts the launchd agent.
@@ -28,19 +28,6 @@ set -e
 # Inline service helpers (so the script works standalone via curl|bash).
 # Self-contained so the script works standalone via curl|bash.
 # ---------------------------------------------------------------------------
-
-sync_bin_copies() {
-  local install_dir="$1"
-  if [[ "${install_dir}" != "${HOME}/bin" && -d "${HOME}/bin" ]]; then
-    for bin in agboxd agbox; do
-      if [[ -f "${HOME}/bin/${bin}" ]]; then
-        cp "${install_dir}/${bin}" "${HOME}/bin/${bin}"
-        chmod 755 "${HOME}/bin/${bin}"
-        echo "Updated  : ${HOME}/bin/${bin}"
-      fi
-    done
-  fi
-}
 
 _setup_systemd() {
   local agboxd_bin="$1"
@@ -172,35 +159,9 @@ check_docker() {
 }
 
 # ---------------------------------------------------------------------------
-# Detect best install directory already in PATH.
-# Priority: ~/.local/bin (if in PATH) > ~/bin (if in PATH)
-#           > /usr/local/bin (if writable) > ~/.local/bin (fallback)
+# Install directory: ~/.local/bin (XDG standard, same convention as uv, pipx, etc.)
 # ---------------------------------------------------------------------------
 detect_install_dir() {
-  # Check if a directory is in PATH.
-  _in_path() {
-    case ":${PATH}:" in
-      *":$1:"*) return 0 ;;
-      *)        return 1 ;;
-    esac
-  }
-
-  if _in_path "${HOME}/.local/bin"; then
-    echo "${HOME}/.local/bin"
-    return
-  fi
-
-  if _in_path "${HOME}/bin"; then
-    echo "${HOME}/bin"
-    return
-  fi
-
-  if [[ -d "/usr/local/bin" && -w "/usr/local/bin" ]]; then
-    echo "/usr/local/bin"
-    return
-  fi
-
-  # Fallback: use ~/.local/bin and warn about PATH.
   echo "${HOME}/.local/bin"
 }
 
@@ -274,39 +235,18 @@ echo "OS/Arch : ${OS}/${ARCH}"
 echo "Install : ${INSTALL_DIR}"
 
 # ---------------------------------------------------------------------------
-# Check if already up-to-date across all known install locations.
+# Check if already up-to-date.
 # ---------------------------------------------------------------------------
 WANT_VERSION="${VERSION#v}"
+NEED_DOWNLOAD=true
 
-_agbox_version() {
-  local bin="$1"
-  [[ -x "${bin}" ]] && "${bin}" version 2>/dev/null || true
-}
-
-NEED_DOWNLOAD=false
-for _loc in "${INSTALL_DIR}/agbox" "${HOME}/.local/bin/agbox" "${HOME}/bin/agbox"; do
-  _ver=$(_agbox_version "${_loc}")
-  if [[ -z "${_ver}" ]]; then
-    continue
+if [[ -x "${INSTALL_DIR}/agbox" ]]; then
+  CURRENT_VERSION=$("${INSTALL_DIR}/agbox" version 2>/dev/null || true)
+  if [[ "${CURRENT_VERSION}" == "${WANT_VERSION}" ]]; then
+    NEED_DOWNLOAD=false
+    echo ""
+    echo "Already at version ${VERSION}, skipping download."
   fi
-  if [[ "${_ver}" != "${WANT_VERSION}" ]]; then
-    NEED_DOWNLOAD=true
-    break
-  fi
-done
-
-# If no existing installation found at any location, we must download.
-if [[ "${NEED_DOWNLOAD}" == false ]]; then
-  _any_found=false
-  for _loc in "${INSTALL_DIR}/agbox" "${HOME}/.local/bin/agbox" "${HOME}/bin/agbox"; do
-    [[ -x "${_loc}" ]] && _any_found=true && break
-  done
-  [[ "${_any_found}" == false ]] && NEED_DOWNLOAD=true
-fi
-
-if [[ "${NEED_DOWNLOAD}" == false ]]; then
-  echo ""
-  echo "Already at version ${VERSION}, skipping download."
 fi
 
 # ---------------------------------------------------------------------------
@@ -332,27 +272,49 @@ if [[ "${NEED_DOWNLOAD}" == true ]]; then
   echo ""
   echo "Installed: ${INSTALL_DIR}/agboxd"
   echo "Installed: ${INSTALL_DIR}/agbox"
-
-  sync_bin_copies "${INSTALL_DIR}"
 fi
 
 # ---------------------------------------------------------------------------
-# Warn if install directory is not in PATH
+# Ensure install directory is in PATH.
+# Auto-adds to shell profile unless AGBOX_NO_MODIFY_PATH=1.
 # ---------------------------------------------------------------------------
-case ":${PATH}:" in
-  *":${INSTALL_DIR}:"*) ;;
-  *)
-    echo ""
-    echo "WARNING: ${INSTALL_DIR} is not in your PATH."
-    echo "  Add it by running:"
-    SHELL_NAME=$(basename "${SHELL:-/bin/bash}")
-    case "${SHELL_NAME}" in
-      zsh)  echo "    echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.zshrc && source ~/.zshrc" ;;
-      fish) echo "    fish_add_path ${INSTALL_DIR}" ;;
-      *)    echo "    echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.bashrc && source ~/.bashrc" ;;
-    esac
-    ;;
-esac
+_ensure_path() {
+  case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) return ;;
+  esac
+
+  local path_line="export PATH=\"${INSTALL_DIR}:\$PATH\""
+  local shell_name
+  shell_name=$(basename "${SHELL:-/bin/bash}")
+
+  local profile=""
+  case "${shell_name}" in
+    zsh)  profile="${HOME}/.zshrc" ;;
+    bash)
+      # On macOS, bash reads .bash_profile for login shells; on Linux, .bashrc.
+      if [[ "$(uname -s)" == "Darwin" ]]; then
+        profile="${HOME}/.bash_profile"
+      else
+        profile="${HOME}/.bashrc"
+      fi
+      ;;
+    *)    profile="${HOME}/.profile" ;;
+  esac
+
+  if [[ -n "${profile}" ]]; then
+    # Avoid duplicate entries.
+    if ! grep -qF "${INSTALL_DIR}" "${profile}" 2>/dev/null; then
+      echo "" >> "${profile}"
+      echo "# Added by agents-sandbox installer" >> "${profile}"
+      echo "${path_line}" >> "${profile}"
+      echo "Added ${INSTALL_DIR} to PATH in ${profile}"
+    fi
+    # Make it available in the current process for the rest of this script.
+    export PATH="${INSTALL_DIR}:${PATH}"
+  fi
+}
+
+_ensure_path
 
 # ---------------------------------------------------------------------------
 # Setup service for the current OS


### PR DESCRIPTION
## Summary

- Replace 4-level fallback install dir detection with single fixed `~/.local/bin` (XDG standard, same as uv/pipx)
- Auto-add `~/.local/bin` to shell profile (`~/.zshrc`/`~/.bashrc`) when not in PATH
- Remove `sync_bin_copies` and multi-path version scanning logic
- Apply same changes to both `website/install.sh` and `scripts/install_local.sh`

## Test plan

- [x] Tested `website/install.sh` on macOS: installs to `~/.local/bin`, auto-writes PATH to `~/.zshrc`
- [x] Verified `agbox version` works after install
- [x] Verified duplicate runs don't add duplicate PATH entries

Close #103
