### PR TITLE
[ISSUE-107] Migrate check_no_ignored_files to shared agent-guardrails hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 #
 # Usage:
-#   This hook rejects staged files that match Git ignore rules, then runs the
-#   project test suite before allowing the commit.
+#   This hook runs the project test suite before allowing the commit.
 #   Install with: git config core.hooksPath .githooks
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-"${SCRIPT_DIR}/../scripts/lints/check_no_ignored_files.sh" --staged
 "${SCRIPT_DIR}/../scripts/run_test.sh"

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ go.work.sum
 requirements/
 CLAUDE.md
 AGENTS.md
-scripts/lints/check_no_ignored_files.sh
 
 # Python
 __pycache__/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,11 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/1996fanrui/agent-guardrails
-    rev: ec190582ef95eb8a011f3b8f5aa27db365da43f3
+    rev: de227ff7ee36d8e955916a50abe3f02f20f17583
     hooks:
       - id: lint-file-line-count
       - id: lint-no-chinese
         exclude: '(^|/)requirements(/|$)|(^|/)(AGENTS|CLAUDE)\.md$'
       - id: lint-shell-portability
       - id: lint-enum-redundant-string
+      - id: lint-no-ignored-files


### PR DESCRIPTION
## Summary

- Replace local `scripts/lints/check_no_ignored_files.sh` with shared `lint-no-ignored-files` hook from agent-guardrails
- Update agent-guardrails rev to `de227ff7ee36d8e955916a50abe3f02f20f17583`
- Remove script reference from `.githooks/pre-commit` and `.gitignore`

Close #107

## Test plan

- [x] `pre-commit run --all-files` passes with new hook
- [x] All Go and Python tests pass
