### PR TITLE
[ISSUE-109] Unify socket path across platforms and fix macOS test isolation

### DIFF
--- a/cmd/agbox/main_test.go
+++ b/cmd/agbox/main_test.go
@@ -71,12 +71,19 @@ func TestCLIUsesFixedSocketPath(t *testing.T) {
 }
 
 func TestVersionCommandsPreserveExistingOutput(t *testing.T) {
+	// Point to a non-existent runtime dir so the test never connects to a
+	// real running daemon, which would change the expected output.
+	isolatedEnv := func(key string) (string, bool) {
+		if key == "XDG_RUNTIME_DIR" {
+			return t.TempDir(), true
+		}
+		return "", false
+	}
+
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	exitCode := run(context.Background(), nil, &stdout, &stderr, func(string) (string, bool) {
-		return "", false
-	})
+	exitCode := run(context.Background(), nil, &stdout, &stderr, isolatedEnv)
 	if exitCode != exitCodeSuccess {
 		t.Fatalf("unexpected exit code %d", exitCode)
 	}
@@ -90,9 +97,7 @@ func TestVersionCommandsPreserveExistingOutput(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	exitCode = run(context.Background(), []string{"version"}, &stdout, &stderr, func(string) (string, bool) {
-		return "", false
-	})
+	exitCode = run(context.Background(), []string{"version"}, &stdout, &stderr, isolatedEnv)
 	if exitCode != exitCodeSuccess {
 		t.Fatalf("unexpected exit code %d", exitCode)
 	}

--- a/cmd/agbox/test_helpers.go
+++ b/cmd/agbox/test_helpers.go
@@ -15,7 +15,14 @@ import (
 func startSandboxTestServer(t *testing.T, service agboxv1.SandboxServiceServer) (string, func(string) (string, bool)) {
 	t.Helper()
 
-	tempDir := t.TempDir()
+	// Use a short temp dir to keep the Unix socket path under the 104-char
+	// macOS limit. t.TempDir() produces paths too long for socket binding.
+	tempDir, err := os.MkdirTemp("/tmp", "agbox-test-")
+	if err != nil {
+		t.Fatalf("mkdtemp failed: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
 	lookupEnv := func(key string) (string, bool) {
 		switch key {
 		case "XDG_RUNTIME_DIR":

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -20,8 +20,8 @@ The AgentsSandbox daemon always derives its runtime paths internally and then au
 
 | Resource | Linux | macOS |
 |----------|-------|-------|
-| Socket | `$XDG_RUNTIME_DIR/agbox/agboxd.sock` | `~/Library/Application Support/agbox/run/agboxd.sock` |
-| Host lock | `$XDG_RUNTIME_DIR/agbox/agboxd.lock` | `~/Library/Application Support/agbox/run/agboxd.lock` |
+| Socket | `$XDG_RUNTIME_DIR/agbox/agboxd.sock` | `~/Library/Application Support/agbox/agboxd.sock` |
+| Host lock | `$XDG_RUNTIME_DIR/agbox/agboxd.lock` | `~/Library/Application Support/agbox/agboxd.lock` |
 | Config | `$XDG_CONFIG_HOME/agents-sandbox/config.toml`, or `~/.config/agents-sandbox/config.toml` when `XDG_CONFIG_HOME` is unset | `~/Library/Application Support/agents-sandbox/config.toml` |
 | Historical ID store | `$XDG_DATA_HOME/agents-sandbox/ids.db`, or `~/.local/share/agents-sandbox/ids.db` when `XDG_DATA_HOME` is unset | `~/Library/Application Support/agents-sandbox/ids.db` |
 

--- a/internal/control/service_lifecycle_persistence_test.go
+++ b/internal/control/service_lifecycle_persistence_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -285,7 +286,13 @@ func TestJoinServiceClosersClosesRuntimeBeforeRegistry(t *testing.T) {
 }
 
 func TestNewServiceDoesNotRequireReachableDockerDaemonAtConstruction(t *testing.T) {
-	t.Setenv("DOCKER_HOST", "unix://"+filepath.Join(t.TempDir(), "nonexistent-docker.sock"))
+	// Use a short temp path to stay under the macOS 104-char Unix socket limit.
+	shortDir, err := os.MkdirTemp("/tmp", "agbox-dock-")
+	if err != nil {
+		t.Fatalf("mkdtemp failed: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(shortDir) })
+	t.Setenv("DOCKER_HOST", "unix://"+filepath.Join(shortDir, "docker.sock"))
 
 	service, closer, err := NewService(ServiceConfig{Logger: slog.Default()})
 	if err != nil {

--- a/internal/control/service_validation.go
+++ b/internal/control/service_validation.go
@@ -174,7 +174,13 @@ func prepareExecOutputPrefix(root string, template string, fields map[string]str
 	if err := os.MkdirAll(rootAbs, 0o755); err != nil {
 		return "", err
 	}
-	targetPrefix := filepath.Join(rootAbs, cleanRelative)
+	// Resolve symlinks on the root so that the containment check compares
+	// real paths on both sides (e.g. macOS /var -> /private/var).
+	rootReal, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		return "", err
+	}
+	targetPrefix := filepath.Join(rootReal, cleanRelative)
 	parentPath := filepath.Dir(targetPrefix)
 	if err := os.MkdirAll(parentPath, 0o755); err != nil {
 		return "", err
@@ -183,7 +189,7 @@ func prepareExecOutputPrefix(root string, template string, fields map[string]str
 	if err != nil {
 		return "", err
 	}
-	if !pathWithinRoot(rootAbs, parentRealPath) {
+	if !pathWithinRoot(rootReal, parentRealPath) {
 		return "", errArtifactPathEscapesRoot
 	}
 	return targetPrefix, nil

--- a/internal/platform/dirs.go
+++ b/internal/platform/dirs.go
@@ -27,13 +27,14 @@ func ConfigDir(lookupEnv LookupEnv) string {
 }
 
 func configDirForGOOS(goos string, lookupEnv LookupEnv) string {
+	// Explicit override via lookupEnv takes precedence on all platforms.
+	if v, ok := lookupEnvValue(lookupEnv, "XDG_CONFIG_HOME"); ok && v != "" {
+		return v
+	}
 	switch goos {
 	case "darwin":
 		return macAppSupportDir()
 	default:
-		if v, ok := lookupEnvValue(lookupEnv, "XDG_CONFIG_HOME"); ok && v != "" {
-			return v
-		}
 		if home := homeDir(); home != "" {
 			return filepath.Join(home, ".config")
 		}
@@ -50,13 +51,14 @@ func DataDir(lookupEnv LookupEnv) string {
 }
 
 func dataDirForGOOS(goos string, lookupEnv LookupEnv) string {
+	// Explicit override via lookupEnv takes precedence on all platforms.
+	if v, ok := lookupEnvValue(lookupEnv, "XDG_DATA_HOME"); ok && v != "" {
+		return v
+	}
 	switch goos {
 	case "darwin":
 		return macAppSupportDir()
 	default:
-		if v, ok := lookupEnvValue(lookupEnv, "XDG_DATA_HOME"); ok && v != "" {
-			return v
-		}
 		if home := homeDir(); home != "" {
 			return filepath.Join(home, ".local", "share")
 		}
@@ -73,13 +75,14 @@ func RuntimeDir(lookupEnv LookupEnv) string {
 }
 
 func runtimeDirForGOOS(goos string, lookupEnv LookupEnv) string {
+	// Explicit override via lookupEnv takes precedence on all platforms.
+	if v, ok := lookupEnvValue(lookupEnv, "XDG_RUNTIME_DIR"); ok && v != "" {
+		return v
+	}
 	switch goos {
 	case "darwin":
 		return macAppSupportDir()
 	default:
-		if v, ok := lookupEnvValue(lookupEnv, "XDG_RUNTIME_DIR"); ok && v != "" {
-			return v
-		}
 		return ""
 	}
 }
@@ -154,18 +157,13 @@ func execLogRootForGOOS(goos string, lookupEnv LookupEnv) string {
 
 func runtimeRootPathForGOOS(goos string, lookupEnv LookupEnv) (string, error) {
 	runtimeDir := runtimeDirForGOOS(goos, lookupEnv)
-	switch goos {
-	case "darwin":
-		if runtimeDir == "" {
+	if runtimeDir == "" {
+		if goos == "darwin" {
 			return "", fmt.Errorf("resolve runtime path: application support directory is unavailable on %s", goos)
 		}
-		return filepath.Join(runtimeDir, RuntimeDirName, "run"), nil
-	default:
-		if runtimeDir == "" {
-			return "", fmt.Errorf("resolve runtime path: XDG_RUNTIME_DIR is required on %s", goos)
-		}
-		return filepath.Join(runtimeDir, RuntimeDirName), nil
+		return "", fmt.Errorf("resolve runtime path: XDG_RUNTIME_DIR is required on %s", goos)
 	}
+	return filepath.Join(runtimeDir, RuntimeDirName), nil
 }
 
 func lookupEnvValue(lookupEnv LookupEnv, key string) (string, bool) {

--- a/internal/platform/dirs_test.go
+++ b/internal/platform/dirs_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestDataDirUsesXDGDataHome(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("XDG not applicable on macOS")
-	}
 	dir := DataDir(func(key string) (string, bool) {
 		if key == "XDG_DATA_HOME" {
 			return "/custom/data", true
@@ -37,9 +34,6 @@ func TestDataDirFallsBackToHome(t *testing.T) {
 }
 
 func TestConfigDirUsesXDGConfigHome(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("XDG not applicable on macOS")
-	}
 	dir := ConfigDir(func(key string) (string, bool) {
 		if key == "XDG_CONFIG_HOME" {
 			return "/custom/config", true
@@ -52,9 +46,6 @@ func TestConfigDirUsesXDGConfigHome(t *testing.T) {
 }
 
 func TestRuntimeDirUsesXDGRuntimeDir(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("XDG not applicable on macOS")
-	}
 	dir := RuntimeDir(func(key string) (string, bool) {
 		if key == "XDG_RUNTIME_DIR" {
 			return "/run/user/1000", true
@@ -105,25 +96,16 @@ func TestFixedPlatformPaths(t *testing.T) {
 			wantStore: filepath.Join("/tmp/data", "agents-sandbox", "ids.db"),
 		},
 		{
+			// When lookupEnv provides XDG overrides, darwin also respects them.
 			goos:      "darwin",
-			wantSock:  filepath.Join("/home/fanrui", "Library", "Application Support", "agbox", "run", "agboxd.sock"),
-			wantLock:  filepath.Join("/home/fanrui", "Library", "Application Support", "agbox", "run", "agboxd.lock"),
-			wantCfg:   filepath.Join("/home/fanrui", "Library", "Application Support", "agents-sandbox", "config.toml"),
-			wantStore: filepath.Join("/home/fanrui", "Library", "Application Support", "agents-sandbox", "ids.db"),
+			wantSock:  filepath.Join("/run/user/1000", "agbox", "agboxd.sock"),
+			wantLock:  filepath.Join("/run/user/1000", "agbox", "agboxd.lock"),
+			wantCfg:   filepath.Join("/tmp/config", "agents-sandbox", "config.toml"),
+			wantStore: filepath.Join("/tmp/data", "agents-sandbox", "ids.db"),
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.goos, func(t *testing.T) {
-			if tc.goos == "darwin" {
-				homeDir, err := os.UserHomeDir()
-				if err != nil {
-					t.Fatalf("UserHomeDir returned error: %v", err)
-				}
-				tc.wantSock = filepath.Join(homeDir, "Library", "Application Support", "agbox", "run", "agboxd.sock")
-				tc.wantLock = filepath.Join(homeDir, "Library", "Application Support", "agbox", "run", "agboxd.lock")
-				tc.wantCfg = filepath.Join(homeDir, "Library", "Application Support", "agents-sandbox", "config.toml")
-				tc.wantStore = filepath.Join(homeDir, "Library", "Application Support", "agents-sandbox", "ids.db")
-			}
 			socketPath, err := socketPathForGOOS(tc.goos, lookupEnv)
 			if err != nil {
 				t.Fatalf("socketPathForGOOS returned error: %v", err)
@@ -186,13 +168,26 @@ func TestExecLogRootFallsBackToHome(t *testing.T) {
 	}
 }
 
-func TestExecLogRootDarwin(t *testing.T) {
+func TestExecLogRootDarwinDefault(t *testing.T) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatalf("UserHomeDir returned error: %v", err)
 	}
 	root := execLogRootForGOOS("darwin", func(string) (string, bool) { return "", false })
 	want := filepath.Join(homeDir, "Library", "Application Support", "agents-sandbox", "exec-logs")
+	if root != want {
+		t.Fatalf("expected %q, got %q", want, root)
+	}
+}
+
+func TestExecLogRootDarwinWithOverride(t *testing.T) {
+	root := execLogRootForGOOS("darwin", func(key string) (string, bool) {
+		if key == "XDG_DATA_HOME" {
+			return "/custom/data", true
+		}
+		return "", false
+	})
+	want := filepath.Join("/custom/data", "agents-sandbox", "exec-logs")
 	if root != want {
 		t.Fatalf("expected %q, got %q", want, root)
 	}

--- a/sdk/python/src/agents_sandbox/client.py
+++ b/sdk/python/src/agents_sandbox/client.py
@@ -52,6 +52,10 @@ def _resolve_default_socket_path(
 ) -> str:
     lookup = os.environ.get if lookup_env is None else lookup_env
     resolved_system = platform.system() if system is None else system
+    # Explicit XDG_RUNTIME_DIR override takes precedence on all platforms.
+    runtime_dir = lookup("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        return os.path.join(runtime_dir, "agbox", "agboxd.sock")
     if resolved_system == "Darwin":
         resolved_home = home_dir or os.path.expanduser("~")
         if resolved_home:
@@ -60,14 +64,9 @@ def _resolve_default_socket_path(
                 "Library",
                 "Application Support",
                 "agbox",
-                "run",
                 "agboxd.sock",
             )
-    else:
-        runtime_dir = lookup("XDG_RUNTIME_DIR")
-        if runtime_dir:
-            return os.path.join(runtime_dir, "agbox", "agboxd.sock")
-        raise RuntimeError("XDG_RUNTIME_DIR is required to resolve the AgentsSandbox socket path on Linux")
+    raise RuntimeError("XDG_RUNTIME_DIR is required to resolve the AgentsSandbox socket path on Linux")
 
 
 def _validate_optional_id(field_name: str, value: str | None) -> str | None:

--- a/sdk/python/tests/smoke_support.py
+++ b/sdk/python/tests/smoke_support.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import signal
 import subprocess
+import tempfile
 import time
 
 import grpc
@@ -127,14 +128,22 @@ def _new_client(socket_path: str | Path, **kwargs: object) -> AgentsSandboxClien
     return client
 
 
+def daemon_socket_path(runtime_dir: Path) -> Path:
+    """Compute the daemon socket path for a given XDG_RUNTIME_DIR.
+
+    Mirrors Go's platform.SocketPath: <runtime_dir>/agbox/agboxd.sock
+    (unified across all platforms).
+    """
+    return runtime_dir / "agbox" / "agboxd.sock"
+
+
 @contextmanager
 def _running_test_daemon(
     repo_root: Path,
-    socket_path: Path,
+    runtime_dir: Path,
     *,
     env: dict[str, str] | None = None,
 ) -> Iterator[subprocess.Popen[str]]:
-    runtime_dir = socket_path.parent.parent
     merged_env = os.environ.copy()
     merged_env["XDG_RUNTIME_DIR"] = str(runtime_dir)
     merged_env["HOME"] = str(runtime_dir.parent)
@@ -194,19 +203,29 @@ async def _wait_for_ping(socket_path: Path) -> None:
 
 @contextmanager
 def _running_server(
-    socket_path: Path,
+    socket_name: str,
     servicer: service_pb2_grpc.SandboxServiceServicer,
-) -> Iterator[None]:
+) -> Iterator[Path]:
+    """Start a gRPC server on a Unix socket and yield the socket path.
+
+    Uses a short temp directory to stay under the macOS 104-char socket path limit.
+    """
+    short_dir = tempfile.mkdtemp(prefix="agbox-")
+    actual_socket = Path(short_dir) / socket_name
+
     server = grpc.server(ThreadPoolExecutor(max_workers=4))
     service_pb2_grpc.add_SandboxServiceServicer_to_server(servicer, server)
-    bound = server.add_insecure_port(f"unix://{socket_path}")
+    bound = server.add_insecure_port(f"unix://{actual_socket}")
     if bound == 0:
-        raise AssertionError(f"failed to bind unix socket: {socket_path}")
+        raise AssertionError(f"failed to bind unix socket: {actual_socket}")
     server.start()
     try:
-        yield
+        yield actual_socket
     finally:
         server.stop(grace=0).wait()
+        import shutil
+
+        shutil.rmtree(short_dir, ignore_errors=True)
 
 
 class _RecordingSandboxService(service_pb2_grpc.SandboxServiceServicer):

--- a/sdk/python/tests/test_real_runtime.py
+++ b/sdk/python/tests/test_real_runtime.py
@@ -8,6 +8,7 @@ import os
 import signal
 import shutil
 import subprocess
+import tempfile
 import time
 
 import pytest
@@ -18,6 +19,8 @@ from agents_sandbox import (
     SandboxClientError,
 )
 from agents_sandbox._grpc_client import SandboxGrpcClient
+from tests.smoke_support import daemon_socket_path
+
 
 RUNTIME_IMAGE_REPOSITORY = "ghcr.io/agents-sandbox/coding-runtime"
 CODING_RUNTIME_VERSION_TAG = os.environ.get("CODING_RUNTIME_VERSION_TAG", "0.1.0")
@@ -38,23 +41,26 @@ def test_sdk_can_create_real_sandbox_and_exec(tmp_path: Path) -> None:
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    socket_path = tmp_path / "runtime" / "agbox" / "agboxd.sock"
-    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    runtime_dir = Path(tempfile.mkdtemp(prefix="agbox-"))
+    socket_path = daemon_socket_path(runtime_dir)
     _ensure_runtime_image(repo_root)
     _cleanup_runtime_resources("real-runtime-exec")
 
     sandbox_id = ""
-    with _running_test_daemon(repo_root, socket_path):
-        try:
-            sandbox_id = asyncio.run(
-                _run_real_runtime_exec_flow(
-                    socket_path=socket_path,
-                    workspace=workspace,
+    try:
+        with _running_test_daemon(repo_root, runtime_dir):
+            try:
+                sandbox_id = asyncio.run(
+                    _run_real_runtime_exec_flow(
+                        socket_path=socket_path,
+                        workspace=workspace,
+                    )
                 )
-            )
-            _wait_for_container_absent(_primary_container_name(sandbox_id))
-        finally:
-            _cleanup_runtime_resources(sandbox_id or "real-runtime-exec")
+                _wait_for_container_absent(_primary_container_name(sandbox_id))
+            finally:
+                _cleanup_runtime_resources(sandbox_id or "real-runtime-exec")
+    finally:
+        shutil.rmtree(runtime_dir, ignore_errors=True)
 
 
 def test_sdk_rejects_empty_image_in_real_runtime(tmp_path: Path) -> None:
@@ -66,19 +72,22 @@ def test_sdk_rejects_empty_image_in_real_runtime(tmp_path: Path) -> None:
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    socket_path = tmp_path / "runtime" / "agbox" / "agboxd.sock"
-    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    runtime_dir = Path(tempfile.mkdtemp(prefix="agbox-"))
+    socket_path = daemon_socket_path(runtime_dir)
     _cleanup_runtime_resources("real-runtime-empty-image")
 
-    with _running_test_daemon(repo_root, socket_path):
-        with pytest.raises(SandboxClientError):
-            asyncio.run(
-                _run_real_runtime_create_with_image(
-                    socket_path=socket_path,
-                    workspace=workspace,
-                    image="",
+    try:
+        with _running_test_daemon(repo_root, runtime_dir):
+            with pytest.raises(SandboxClientError):
+                asyncio.run(
+                    _run_real_runtime_create_with_image(
+                        socket_path=socket_path,
+                        workspace=workspace,
+                        image="",
+                    )
                 )
-            )
+    finally:
+        shutil.rmtree(runtime_dir, ignore_errors=True)
 
 
 def test_sdk_can_project_claude_directory_with_symlink(tmp_path: Path) -> None:
@@ -97,28 +106,31 @@ def test_sdk_can_project_claude_directory_with_symlink(tmp_path: Path) -> None:
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    socket_path = tmp_path / "runtime" / "agbox" / "agboxd.sock"
-    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    runtime_dir = Path(tempfile.mkdtemp(prefix="agbox-"))
+    socket_path = daemon_socket_path(runtime_dir)
     go_cache = tmp_path / "go-cache"
     go_cache.mkdir()
     _ensure_runtime_image(repo_root)
     _cleanup_runtime_resources("real-runtime-claude")
 
     sandbox_id = ""
-    with _running_test_daemon(
-        repo_root,
-        socket_path,
-        env={"HOME": str(fake_home), "GOCACHE": str(go_cache)},
-    ):
-        try:
-            sandbox_id = asyncio.run(
-                _run_real_runtime_projection_flow(
-                    socket_path=socket_path,
-                    workspace=workspace,
+    try:
+        with _running_test_daemon(
+            repo_root,
+            runtime_dir,
+            env={"HOME": str(fake_home), "GOCACHE": str(go_cache)},
+        ):
+            try:
+                sandbox_id = asyncio.run(
+                    _run_real_runtime_projection_flow(
+                        socket_path=socket_path,
+                        workspace=workspace,
+                    )
                 )
-            )
-        finally:
-            _cleanup_runtime_resources(sandbox_id or "real-runtime-claude")
+            finally:
+                _cleanup_runtime_resources(sandbox_id or "real-runtime-claude")
+    finally:
+        shutil.rmtree(runtime_dir, ignore_errors=True)
 
 
 async def _run_real_runtime_exec_flow(*, socket_path: Path, workspace: Path) -> str:
@@ -225,14 +237,15 @@ def _new_client(socket_path: str | Path, **kwargs: object) -> AgentsSandboxClien
 @contextmanager
 def _running_test_daemon(
     repo_root: Path,
-    socket_path: Path,
+    runtime_dir: Path,
     *,
     env: dict[str, str] | None = None,
 ) -> Iterator[None]:
-    runtime_dir = socket_path.parent.parent if socket_path.parent.name == "agbox" else socket_path.parent
     merged_env = os.environ.copy()
     merged_env["XDG_RUNTIME_DIR"] = str(runtime_dir)
-    merged_env["HOME"] = str(runtime_dir.parent)
+    merged_env["XDG_DATA_HOME"] = str(runtime_dir)
+    merged_env["XDG_CONFIG_HOME"] = str(runtime_dir)
+    merged_env["HOME"] = str(runtime_dir)
     if env is not None:
         merged_env.update(env)
     daemon_path = runtime_dir / "agboxd-test"

--- a/sdk/python/tests/test_smoke_error_integration.py
+++ b/sdk/python/tests/test_smoke_error_integration.py
@@ -36,9 +36,9 @@ def test_sdk_maps_error_info_reasons_to_public_exceptions(
 ) -> None:
     servicer = _ErrorSandboxService(reason=reason)
 
-    with _running_server(tmp_path / f"{reason.lower()}.sock", servicer):
+    with _running_server(f"{reason.lower()}.sock", servicer) as socket_path:
         async def run_test() -> None:
-            client = _new_client(tmp_path / f"{reason.lower()}.sock")
+            client = _new_client(socket_path)
             if reason in {"EXEC_NOT_FOUND", "EXEC_ALREADY_TERMINAL"}:
                 await client.cancel_exec("exec-1")
             elif reason == "EXEC_ID_ALREADY_EXISTS":

--- a/sdk/python/tests/test_smoke_public_api.py
+++ b/sdk/python/tests/test_smoke_public_api.py
@@ -225,7 +225,7 @@ def test_default_socket_path_resolution_matches_daemon_rules(monkeypatch: pytest
         system="Darwin",
         lookup_env=lambda _key: None,
         home_dir="/Users/tester",
-    ) == "/Users/tester/Library/Application Support/agbox/run/agboxd.sock"
+    ) == "/Users/tester/Library/Application Support/agbox/agboxd.sock"
     with pytest.raises(RuntimeError, match="XDG_RUNTIME_DIR"):
         _resolve_default_socket_path(
             system="Linux",
@@ -347,8 +347,8 @@ def test_public_docs_use_converged_python_sdk_api() -> None:
 def test_public_async_client_round_trips_over_unix_socket(tmp_path: Path) -> None:
     servicer = _RecordingSandboxService()
 
-    with _running_server(tmp_path / "sandbox.sock", servicer):
-        result = asyncio.run(_exercise_public_client(tmp_path / "sandbox.sock"))
+    with _running_server("sandbox.sock", servicer) as socket_path:
+        result = asyncio.run(_exercise_public_client(socket_path))
 
     assert result["ping"].daemon == "agboxd"
     # create_sandbox with wait=False returns state from CreateSandboxResponse (PENDING).


### PR DESCRIPTION
## Summary

- Unify socket path suffix across macOS and Linux: all platforms now use `<RuntimeDir>/agbox/agboxd.sock`, removing the darwin-specific `run/` subdirectory. This eliminates per-platform path duplication in every SDK.
- Let XDG environment overrides (`XDG_RUNTIME_DIR`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`) take precedence on all platforms (including macOS), enabling proper test isolation via env injection.
- Fix Python test daemon to isolate `HOME`, `XDG_DATA_HOME`, and `XDG_CONFIG_HOME` per test run, preventing cross-run bbolt ID store contamination.
- Fix Go tests to use short `/tmp` paths for Unix sockets (macOS 104-char limit) and resolve `/var` → `/private/var` symlink in artifact path validation.

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [x] All Python SDK tests pass (53 passed, 1 skipped)
- [x] Pre-commit hooks pass including proto consistency check
- [x] `scripts/run_test.sh` passes end-to-end
- [x] Verified no residual `agbox/run` references in codebase or docs

Close #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
