### PR TITLE
[ISSUE-111] Add macOS to CI test matrix for multi-platform coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Add matrix strategy to CI workflow to run tests on both `ubuntu-latest` and `macos-latest`
- Ensures multi-platform compatibility is validated in CI

## Test plan
- [ ] CI passes on ubuntu-latest
- [ ] CI passes on macos-latest

Close #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
