### PR TITLE
[ISSUE-113] Skip gitignored external symlinks during sandbox copy instead of failing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmC
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
@@ -67,12 +68,16 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
@@ -123,6 +128,7 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=

--- a/internal/control/docker_runtime_copy.go
+++ b/internal/control/docker_runtime_copy.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	runtimedocker "github.com/1996fanrui/agents-sandbox/internal/runtime/docker"
+	ignore "github.com/sabhiram/go-gitignore"
 )
 
 func matchesExcludePattern(relativePath string, patterns []string) bool {
@@ -27,9 +28,60 @@ func matchesExcludePattern(relativePath string, patterns []string) bool {
 	return false
 }
 
-// buildCopyTar writes a tar archive of sourceRoot to w, applying exclude patterns
-// and preserving symlinks. The archive paths are relative so that CopyToContainer
-// extracts them under the target directory. The writer is always closed.
+// loadGitignore loads and compiles the .gitignore file under sourceRoot.
+// Returns nil (not an error) when no .gitignore exists.
+func loadGitignore(sourceRoot string) *ignore.GitIgnore {
+	gitignorePath := filepath.Join(sourceRoot, ".gitignore")
+	gi, err := ignore.CompileIgnoreFile(gitignorePath)
+	if err != nil {
+		return nil
+	}
+	return gi
+}
+
+// dirContainsExternalSymlink reports whether dir (an absolute path) contains
+// at least one symlink whose target resolves outside rootAbs.
+func dirContainsExternalSymlink(dir string, rootAbs string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 {
+			resolved, err := runtimedocker.ResolveLinkTarget(filepath.Join(dir, entry.Name()))
+			if err != nil {
+				continue
+			}
+			if !pathWithinRoot(rootAbs, resolved) {
+				return true
+			}
+		}
+		if entry.IsDir() {
+			if dirContainsExternalSymlink(filepath.Join(dir, entry.Name()), rootAbs) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// buildCopyTar writes a tar archive of sourceRoot to w, preserving symlinks.
+// The archive paths are relative so that CopyToContainer extracts them under
+// the target directory. The writer is always closed.
+//
+// Filtering priority for each entry during the walk:
+//  1. Exclude patterns — if the entry matches an explicit exclude pattern, skip it
+//     (SkipDir for directories). Checked first, so excluded content never triggers
+//     any downstream logic.
+//  2. Internal symlinks — symlinks whose target resolves within the source tree
+//     are preserved as-is in the tar archive.
+//  3. External symlinks + .gitignore — symlinks resolving outside the source tree
+//     are normally rejected with an error. However, if the source root contains a
+//     .gitignore and the entry's path matches a gitignore rule, the entry is
+//     silently skipped. For directory-level gitignore rules (e.g. ".generated/"),
+//     the entire directory is skipped (SkipDir) when it contains at least one
+//     external symlink. External symlinks not covered by .gitignore still cause
+//     a hard error.
 func buildCopyTar(w io.WriteCloser, sourceRoot string, excludePatterns []string) error {
 	tw := tar.NewWriter(w)
 	closeAll := func(tarErr error) error {
@@ -59,6 +111,8 @@ func buildCopyTar(w io.WriteCloser, sourceRoot string, excludePatterns []string)
 		return closeAll(err)
 	}
 
+	gi := loadGitignore(sourceRoot)
+
 	err = filepath.WalkDir(sourceRoot, func(currentPath string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -76,12 +130,19 @@ func buildCopyTar(w io.WriteCloser, sourceRoot string, excludePatterns []string)
 			}
 			return nil
 		}
+
+		// For directories matched by .gitignore that contain external symlinks,
+		// skip the entire directory to avoid partial copies of gitignored content.
+		if entry.IsDir() && gi != nil && gi.MatchesPath(relPath+"/") && dirContainsExternalSymlink(currentPath, rootAbs) {
+			return filepath.SkipDir
+		}
+
 		info, err := entry.Info()
 		if err != nil {
 			return err
 		}
 		if entry.Type()&os.ModeSymlink != 0 {
-			return writeTarSymlink(tw, currentPath, relPath, rootAbs)
+			return writeTarSymlink(tw, currentPath, relPath, rootAbs, gi)
 		}
 		if entry.IsDir() {
 			header, headerErr := tar.FileInfoHeader(info, "")
@@ -114,17 +175,21 @@ func writeTarFile(tw *tar.Writer, sourcePath string, archiveName string, info fs
 	return err
 }
 
-func writeTarSymlink(tw *tar.Writer, sourcePath string, archiveName string, sourceRootAbs string) error {
+func writeTarSymlink(tw *tar.Writer, sourcePath string, archiveName string, sourceRootAbs string, gi *ignore.GitIgnore) error {
 	linkTarget, err := os.Readlink(sourcePath)
 	if err != nil {
 		return err
 	}
-	// Reject external symlinks (those resolving outside the source tree).
+	// Reject external symlinks (those resolving outside the source tree),
+	// unless the path is covered by .gitignore.
 	resolvedTarget, err := runtimedocker.ResolveLinkTarget(sourcePath)
 	if err != nil {
 		return err
 	}
 	if !pathWithinRoot(sourceRootAbs, resolvedTarget) {
+		if gi != nil && gi.MatchesPath(archiveName) {
+			return nil
+		}
 		return fmt.Errorf("copy source contains external symlink: %s", sourcePath)
 	}
 	info, err := os.Lstat(sourcePath)

--- a/internal/control/service_runtime_test.go
+++ b/internal/control/service_runtime_test.go
@@ -132,6 +132,173 @@ func TestBuildCopyTarPreservesSymlinks(t *testing.T) {
 	}
 }
 
+// extractTarNames reads all entries from a tar stream and returns a set of archive names.
+func extractTarNames(t *testing.T, r io.Reader) map[string]bool {
+	t.Helper()
+	tr := tar.NewReader(r)
+	names := make(map[string]bool)
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			break
+		}
+		names[header.Name] = true
+	}
+	return names
+}
+
+// mkFile creates a file with the given content under parent.
+func mkFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+}
+
+// TestBuildCopyTarGitignoreSkipsExternalSymlinks builds a complex directory tree:
+//
+//	sourceRoot/
+//	  .gitignore              # contains: .generated/
+//	  keep.txt                # regular file -> INCLUDED
+//	  internal-link.txt       # symlink to keep.txt (internal) -> INCLUDED
+//	  top-external.txt        # external symlink, NOT gitignored -> ERROR
+//	  .generated/             # directory gitignored, contains external symlink
+//	    build.txt             # regular file -> INCLUDED (gitignore only filters external symlinks)
+//	    report.txt            # internal symlink -> INCLUDED
+//	    external-ref.txt      # external symlink -> whole dir SKIPPED
+//	  docs/                   # NOT gitignored, no external symlinks
+//	    readme.md             # regular file -> INCLUDED
+//	  vendor/                 # gitignored (vendor/), but NO external symlinks -> INCLUDED normally
+//	    lib.go                # regular file -> INCLUDED
+func TestBuildCopyTarGitignoreSkipsExternalSymlinks(t *testing.T) {
+	sourceRoot := t.TempDir()
+	externalRoot := t.TempDir()
+	mkFile(t, filepath.Join(externalRoot, "external.txt"), "external-content")
+
+	// .gitignore: ignore .generated/ and vendor/
+	mkFile(t, filepath.Join(sourceRoot, ".gitignore"), ".generated/\nvendor/\n")
+
+	// Regular files
+	mkFile(t, filepath.Join(sourceRoot, "keep.txt"), "keep")
+	mkFile(t, filepath.Join(sourceRoot, "docs", "readme.md"), "readme")
+	mkFile(t, filepath.Join(sourceRoot, "vendor", "lib.go"), "package lib")
+
+	// .generated/ directory with mixed content
+	mkFile(t, filepath.Join(sourceRoot, ".generated", "build.txt"), "build-output")
+	// Internal symlink inside .generated/
+	if err := os.Symlink(
+		filepath.Join(sourceRoot, ".generated", "build.txt"),
+		filepath.Join(sourceRoot, ".generated", "report.txt"),
+	); err != nil {
+		t.Fatalf("Symlink failed: %v", err)
+	}
+	// External symlink inside .generated/ -> triggers directory-level skip
+	if err := os.Symlink(
+		filepath.Join(externalRoot, "external.txt"),
+		filepath.Join(sourceRoot, ".generated", "external-ref.txt"),
+	); err != nil {
+		t.Fatalf("Symlink failed: %v", err)
+	}
+
+	// Internal symlink at top level
+	if err := os.Symlink("keep.txt", filepath.Join(sourceRoot, "internal-link.txt")); err != nil {
+		t.Fatalf("Symlink failed: %v", err)
+	}
+
+	// --- Case 1: .generated/ (gitignored + has external symlink) -> entire dir skipped ---
+	pr, pw := io.Pipe()
+	go func() {
+		_ = buildCopyTar(pw, sourceRoot, nil)
+	}()
+	names := extractTarNames(t, pr)
+
+	// Regular files and internal symlinks should be present
+	for _, expected := range []string{"keep.txt", "internal-link.txt", "docs/", "docs/readme.md", "vendor/", "vendor/lib.go"} {
+		if !names[expected] {
+			t.Errorf("expected %q in tar archive, got entries: %v", expected, names)
+		}
+	}
+	// .generated/ directory and all its contents should be skipped
+	for _, excluded := range []string{".generated/", ".generated/build.txt", ".generated/report.txt", ".generated/external-ref.txt"} {
+		if names[excluded] {
+			t.Errorf("expected %q to be skipped (gitignored dir with external symlink), but found in tar", excluded)
+		}
+	}
+
+	// --- Case 2: top-level external symlink NOT in gitignore -> still errors ---
+	if err := os.Symlink(
+		filepath.Join(externalRoot, "external.txt"),
+		filepath.Join(sourceRoot, "top-external.txt"),
+	); err != nil {
+		t.Fatalf("Symlink failed: %v", err)
+	}
+	pr2, pw2 := io.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, pr2) }()
+	err := buildCopyTar(pw2, sourceRoot, nil)
+	if err == nil || !strings.Contains(err.Error(), "external symlink") {
+		t.Fatalf("expected external symlink error for top-external.txt, got: %v", err)
+	}
+}
+
+// TestBuildCopyTarGitignoreFileLevel verifies that a gitignore rule matching
+// a specific file (not a directory) skips only that external symlink file.
+func TestBuildCopyTarGitignoreFileLevel(t *testing.T) {
+	sourceRoot := t.TempDir()
+	externalRoot := t.TempDir()
+	mkFile(t, filepath.Join(externalRoot, "secret.txt"), "secret")
+
+	// .gitignore ignores a specific file pattern
+	mkFile(t, filepath.Join(sourceRoot, ".gitignore"), "ignored-link.txt\n")
+	mkFile(t, filepath.Join(sourceRoot, "normal.txt"), "normal")
+
+	// External symlink matching gitignore -> skipped
+	if err := os.Symlink(
+		filepath.Join(externalRoot, "secret.txt"),
+		filepath.Join(sourceRoot, "ignored-link.txt"),
+	); err != nil {
+		t.Fatalf("Symlink failed: %v", err)
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		_ = buildCopyTar(pw, sourceRoot, nil)
+	}()
+	names := extractTarNames(t, pr)
+
+	if !names["normal.txt"] {
+		t.Fatal("expected normal.txt in tar")
+	}
+	if names["ignored-link.txt"] {
+		t.Fatal("expected ignored-link.txt to be skipped (gitignored external symlink)")
+	}
+}
+
+// TestBuildCopyTarNoGitignore verifies the original behavior is preserved
+// when no .gitignore exists.
+func TestBuildCopyTarNoGitignore(t *testing.T) {
+	sourceRoot := t.TempDir()
+	externalRoot := t.TempDir()
+	mkFile(t, filepath.Join(externalRoot, "target.txt"), "target")
+
+	mkFile(t, filepath.Join(sourceRoot, "ok.txt"), "ok")
+	if err := os.Symlink(
+		filepath.Join(externalRoot, "target.txt"),
+		filepath.Join(sourceRoot, "bad-link.txt"),
+	); err != nil {
+		t.Fatalf("Symlink failed: %v", err)
+	}
+
+	pr, pw := io.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, pr) }()
+	err := buildCopyTar(pw, sourceRoot, nil)
+	if err == nil || !strings.Contains(err.Error(), "external symlink") {
+		t.Fatalf("expected external symlink error without .gitignore, got: %v", err)
+	}
+}
+
 func TestPrepareExecOutputPaths(t *testing.T) {
 	root := t.TempDir()
 	paths, err := prepareExecOutputPaths(root, "{sandbox_id}/{exec_id}", map[string]string{


### PR DESCRIPTION
## Summary

- Skip external symlinks covered by `.gitignore` during sandbox copy tar building, instead of failing the entire sandbox creation
- Support both directory-level (`.generated/`) and file-level (`ignored-link.txt`) gitignore rules
- Add `dirContainsExternalSymlink` to enable directory-level SkipDir when a gitignored directory contains external symlinks
- Add comprehensive tests covering: directory-level skip, file-level skip, no-gitignore fallback, and top-level external symlink rejection

Close #113

## Test plan

- [x] Existing `TestBuildCopyTarRejectsExternalSymlink` still passes (no regression)
- [x] Existing `TestBuildCopyTarPreservesSymlinks` still passes (internal symlinks preserved)
- [x] Existing `TestBuildCopyTarAppliesExcludePatterns` still passes (exclude priority unchanged)
- [x] New `TestBuildCopyTarGitignoreSkipsExternalSymlinks` — complex directory tree with gitignored dir containing external symlink → entire dir skipped; non-gitignored external symlink → error
- [x] New `TestBuildCopyTarGitignoreFileLevel` — file-level gitignore rule skips individual external symlink
- [x] New `TestBuildCopyTarNoGitignore` — no `.gitignore` present → original error behavior preserved
- [x] All Go and Python tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
