### PR TITLE
[ISSUE-120] Add Quick Start, Companion Container Guide, and rename service terminology in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agents Sandbox
 
-**Full power for your AI agents. Full safety for the host.**
+**Full power for your agents. Full safety for your machine.**
 
 - **Unrestricted AI agent** — Agents install anything, run anything, break anything. Zero permission prompts, zero manual approvals.
 - **Untouchable host** — No host filesystem access. No host network access. No exceptions. A bad command destroys only the disposable sandbox, never your machine.
@@ -131,6 +131,12 @@ asyncio.run(main())
 ```
 
 For full examples, see `examples/`.
+
+## Learn More
+
+- Agent needs databases, caches, or other dependencies for debugging? See [Companion Container Guide](docs/companion_container_guide.md)
+- Want reusable sandbox environments as YAML? See [Declarative YAML Config](docs/declarative_yaml_config.md)
+- Tuning daemon behavior (idle TTL, cleanup, log level)? See [Configuration Reference](docs/configuration_reference.md)
 
 ## Repository Layout
 

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -35,10 +35,10 @@ flowchart LR
 ### Primary request and event flow
 
 1. A client sends a gRPC request over the Unix socket.
-2. The service performs synchronous fail-fast validation for create inputs, service declarations, builtin resource IDs, historical ID reuse, and exec command shape.
+2. The service performs synchronous fail-fast validation for create inputs, companion container declarations, builtin resource IDs, historical ID reuse, and exec command shape.
 3. During `CreateSandbox` and `CreateExec`, the daemon reserves the final ID in the persistent historical ID registry before accepting the request. When the caller omits an ID, the daemon generates and reserves a UUID v4 first.
 4. `CreateSandbox`, `ResumeSandbox`, `StopSandbox`, `DeleteSandbox`, and `CreateExec` return as accepted operations while the daemon continues convergence asynchronously.
-5. The runtime backend performs Docker-side work and reports results back to the service. Required services gate readiness; optional services start in parallel and report asynchronously without blocking sandbox readiness.
+5. The runtime backend performs Docker-side work and reports results back to the control service. Companion containers start in parallel with the primary container and report asynchronously without blocking sandbox readiness.
 6. The service persists ordered events and configs before updating in-memory state, exposes numeric ordering through event sequences, and performs full restart recovery by reconciling persisted state with Docker inspect results.
 7. The high-level SDKs and CLI optionally wait by combining an authoritative baseline read with `SubscribeSandboxEvents`.
 
@@ -46,7 +46,7 @@ flowchart LR
 
 ### Sandbox lifecycle management
 
-Each sandbox gets one primary container, one dedicated Docker network, zero or more service containers (required and optional), and ordered lifecycle and exec events. The CLI supports daemon reachability checks, sandbox creation/inspection/deletion, label-based fleet operations, and ad hoc command execution.
+Each sandbox gets one primary container, one dedicated Docker network, zero or more companion containers, and ordered lifecycle and exec events. The CLI supports daemon reachability checks, sandbox creation/inspection/deletion, label-based fleet operations, and ad hoc command execution.
 
 ### Command execution and direct output consumption
 
@@ -54,11 +54,11 @@ Exec creation is asynchronous at the protocol layer. Exec stdout and stderr are 
 
 ### Filesystem ingress and built-in resources
 
-Sandbox creation supports three public filesystem ingress modes: `mounts` (explicit bind mounts), `copies` (daemon-owned copied content), and `builtin_tools` (daemon-defined resource shortcuts). Services are declared as `required_services` or `optional_services` and become sibling containers on the sandbox network. See [Container Dependency Strategy](container_dependency_strategy.md) for details.
+Sandbox creation supports three public filesystem ingress modes: `mounts` (explicit bind mounts), `copies` (daemon-owned copied content), and `builtin_tools` (daemon-defined resource shortcuts). Companion containers are declared as `companion_containers` and become sibling containers on the sandbox network. See [Container Dependency Strategy](container_dependency_strategy.md) for details.
 
 ### Event subscription and replay
 
-The daemon exposes a per-sandbox ordered event stream with full replay, daemon-issued sequence anchors for incremental replay, and monotonic `sequence` numbers per sandbox. Each event carries typed details (sandbox phase, exec, or service). `CreateSandbox` returns a handle with a daemon-issued `last_event_sequence` cursor that seeds incremental subscription without a snapshot/subscription race.
+The daemon exposes a per-sandbox ordered event stream with full replay, daemon-issued sequence anchors for incremental replay, and monotonic `sequence` numbers per sandbox. Each event carries typed details (sandbox phase, exec, or companion container). `CreateSandbox` returns a handle with a daemon-issued `last_event_sequence` cursor that seeds incremental subscription without a snapshot/subscription race.
 
 ### SDK layering and integration choices
 

--- a/docs/companion_container_guide.md
+++ b/docs/companion_container_guide.md
@@ -1,0 +1,59 @@
+# Companion Container Guide
+
+When the agent needs to debug or develop against external dependencies (databases, caches, message queues, etc.), declare them as companion containers.
+
+They run as sibling containers on the same dedicated network, start in parallel with the primary container, and never block sandbox readiness. A healthy companion emits `COMPANION_CONTAINER_READY`; a failed companion emits `COMPANION_CONTAINER_FAILED` — the sandbox continues normally either way.
+
+## CompanionContainerSpec Fields
+
+The YAML key (e.g. `postgres`) becomes the companion container `name` and the DNS network alias — the primary container reaches companions by name (e.g. `postgres:5432`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `image` | string | Container image for the companion container (required) |
+| `envs` | map | Environment variables passed to the companion container |
+| `healthcheck` | HealthcheckConfig | How the daemon determines the companion is healthy (see below) |
+| `post_start_on_primary` | list of string | Commands executed on the **primary** container after this companion becomes healthy. Requires `healthcheck` to be defined. |
+
+### HealthcheckConfig Fields
+
+Duration fields accept duration strings (e.g. `"5s"`, `"1m30s"`).
+
+| Field | Description |
+|-------|-------------|
+| `test` | Healthcheck command (e.g. `["CMD-SHELL", "pg_isready -U postgres"]`) |
+| `interval` | Time between checks |
+| `timeout` | Single check timeout |
+| `retries` | Max consecutive failures before unhealthy |
+| `start_period` | Grace period — failures during this window do not count toward retries |
+| `start_interval` | Check interval during `start_period` (can be shorter than `interval`) |
+
+## Example
+
+```yaml
+companion_containers:
+  postgres:
+    image: postgres:16-alpine
+    envs:
+      POSTGRES_DB: app_local
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      start_period: 20s
+      start_interval: 1s
+      retries: 12
+    # Seed test data after DB is healthy
+    post_start_on_primary:
+      - "psql -h postgres -U postgres -c 'CREATE TABLE users (id serial, name text)'"
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping"]
+      interval: 5s
+      start_period: 10s
+      start_interval: 1s
+      retries: 6
+```
+
+For YAML schema overview and SDK usage, see [Declarative YAML Config](declarative_yaml_config.md). For startup flow internals, see [Container Dependency Strategy](container_dependency_strategy.md).

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -12,7 +12,7 @@ If a change adds, removes, renames, or changes the default of a config key, upda
 - Secrets stay outside the repository and outside generated documentation.
 - Daemon runtime paths are fixed platform paths, not operator-tunable config.
 
-Northbound request fields are not part of this configuration surface. Request-time lifecycle inputs such as image selection, filesystem ingress (`mounts`, `copies`, `builtin_tools`), and service declarations belong to the RPC contract, not to `config.toml`.
+Northbound request fields are not part of this configuration surface. Request-time lifecycle inputs such as image selection, filesystem ingress (`mounts`, `copies`, `builtin_tools`), and companion container declarations belong to the RPC contract, not to `config.toml`.
 
 The AgentsSandbox daemon always derives its runtime paths internally and then auto-loads the platform-default `config.toml` if it exists. There is no CLI flag, environment variable, or config key that overrides the socket path, lock path, config path, or ID store path.
 
@@ -49,8 +49,7 @@ The northbound API may override only a narrow subset of behavior:
 | Built-in resources | Yes | Each sandbox may request daemon-defined resource shortcuts such as `claude`, `codex`, `git`, `uv`, `npm`, or `apt` |
 | Caller-provided `sandbox_id` | Yes | If omitted, the daemon reserves a UUID v4 before accepting the request |
 | Caller-provided `exec_id` | Yes | If omitted, the daemon reserves a UUID v4 before accepting the request |
-| `required_services` | Yes | Each sandbox declares the services that must become healthy before the primary is reported ready |
-| `optional_services` | Yes | Each sandbox declares the services whose initial startup result is reported without blocking readiness |
+| `companion_containers` | Yes | Each sandbox declares companion containers started concurrently with the primary container |
 | `runtime.idle_ttl` | Yes | `CreateSpec.idle_ttl` overrides the global threshold per sandbox. `nil` (unset) uses the daemon global default; `0` disables idle stop for that sandbox. |
 | `runtime.cleanup_ttl` | No | Cleanup policy stays daemon-owned |
 | Resource limits | No | V1 does not support request-scoped resource limits |

--- a/docs/container_dependency_strategy.md
+++ b/docs/container_dependency_strategy.md
@@ -66,48 +66,36 @@ When an imported runtime image needs host-backed authentication material, `HOST_
 - Directory trees with escaping symlinks are bind-mounted directly from the host path.
 - Socket resources such as `ssh-agent` are forwarded only when the host path is a real Unix socket.
 
-## Service Model
+## Companion Container Model
 
-Services are declared through `ServiceSpec` and split into `required_services` and `optional_services`.
-
-`ServiceSpec` fields: `name` (stable service name, also used as `network_alias`), `image`, `envs`, `healthcheck`, `post_start_on_primary` (hook commands on primary after service becomes healthy).
-
-| Category | Startup | Failure |
-|----------|---------|---------|
-| `required_services` | Must be healthy before primary is READY | Fails entire sandbox materialization |
-| `optional_services` | Started in parallel with primary | Emits `SANDBOX_SERVICE_FAILED` for initial attempt only; not restarted in V1 |
+For companion container field definitions and usage scenarios, see [Companion Container Guide](companion_container_guide.md).
 
 ## Startup Strategy
 
 ```mermaid
 flowchart TB
     A[Create dedicated network] --> B[Materialize filesystem inputs and built-in resources]
-    B --> C[Create required service containers]
+    B --> S[Create companion containers]
     B --> D[Create primary container]
-    B --> O[Create optional service containers]
-    C --> E[Start required services serially; wait for each healthcheck]
+    S --> P[Start all companion containers in parallel with primary]
     D --> F[Start primary container]
-    O --> P[Start optional services in parallel with primary]
-    E --> G[All required services healthy]
-    G --> H[Run post_start_on_primary hooks for required services]
-    F --> H
-    H --> I[Emit SANDBOX_SERVICE_READY per required service]
-    P --> Q[Emit SANDBOX_SERVICE_READY or SANDBOX_SERVICE_FAILED per optional service]
-    I --> J[Emit sandbox ready event]
+    P --> Q[Emit COMPANION_CONTAINER_READY or COMPANION_CONTAINER_FAILED per companion]
+    P --> H[Run post_start_on_primary hooks after companion healthy]
+    F --> R[Emit sandbox ready event]
 ```
 
 Startup rules:
-- `post_start_on_primary` is valid only for `required_services`; `optional_services` must reject it during synchronous validation.
-- Parallel startup of optional services must not weaken isolation or readiness checks for required services.
-- Service startup, health inspection, and hook execution must stay on structured Docker API paths.
+- All companion containers start concurrently with the primary container and do not block sandbox READY.
+- `post_start_on_primary` requires `healthcheck` to be defined on the companion container.
+- Companion container startup, health inspection, and hook execution must stay on structured Docker API paths.
 
 ## Permissions and Runtime User Model
 
-The runtime must execute under a non-root user inside the sandbox. Bind-mounted writable paths must remain writable to that runtime user. The daemon must not rely on root-only behavior for normal exec, lifecycle, or service orchestration.
+The runtime must execute under a non-root user inside the sandbox. Bind-mounted writable paths must remain writable to that runtime user. The daemon must not rely on root-only behavior for normal exec, lifecycle, or companion container orchestration.
 
 ## Cleanup and Ownership
 
-`agents-sandbox` owns cleanup for resources carrying the `io.github.1996fanrui.agents-sandbox.*` label namespace: primary containers, service containers, dedicated networks, and event/artifact files.
+`agents-sandbox` owns cleanup for resources carrying the `io.github.1996fanrui.agents-sandbox.*` label namespace: primary containers, companion containers, dedicated networks, and event/artifact files.
 
 Docker objects without these labels are never inspected, stopped, or removed by the daemon. Ownership must be derivable from runtime state plus namespaced labels without requiring an external product database snapshot. Cleanup continues on daemon-owned contexts rather than request-scoped cancellation.
 

--- a/docs/daemon_state_management.md
+++ b/docs/daemon_state_management.md
@@ -38,7 +38,7 @@ Actual condition of Docker containers and networks. Never written to bbolt; obta
 |-------|--------------|
 | Container running/exited/OOM status | `docker inspect {container_name}` |
 | Container exit code | `docker inspect {container_name}` |
-| Service health status | `docker inspect {container_name}` → `.State.Health` |
+| Companion container health status | `docker inspect {container_name}` → `.State.Health` |
 | Network exists | `docker network inspect {network_name}` |
 
 ## Category C — Derived / Rebuilt State
@@ -49,13 +49,13 @@ Recomputed on startup from Category A and B.
 |-------|-------------|
 | Network name | `agbox-net-{sanitize(sandbox_id)}` |
 | Primary container name | `agbox-primary-{sanitize(sandbox_id)}` |
-| Service container name | `agbox-svc-{sanitize(sandbox_id)}-{sanitize(service_name)}` |
+| Companion container name | `agbox-companion-{sanitize(sandbox_id)}-{sanitize(name)}` |
 | Exec ID → Sandbox ID mapping | Enumerate `exec-config:{sandbox_id}` buckets |
 | `deletedAtRecorded` flag | Presence check in `sandbox-deleted-at` |
 | `lastTerminalRunFinishedAt` | Latest terminal exec event timestamp; falls back to `createdAt` when no exec history exists |
 | `nextSequence` | `MaxSequence()` over `events:{sandbox_id}` |
 | `context.CancelFunc` per exec | New cancel context for running execs |
-| `optionalServiceStarts` channels | Re-inspect optional service containers |
+| `companionContainerStarts` channels | Re-inspect companion containers |
 | `SandboxHandle.ErrorCode`, `ErrorMessage`, `StateChangedAt` | Last `SANDBOX_FAILED` event's `SandboxPhaseDetails` (error fields); last state-matching event's `OccurredAt` (timestamp) |
 | `sandboxRuntimeState` | Container names + runtime status from Docker |
 

--- a/docs/declarative_yaml_config.md
+++ b/docs/declarative_yaml_config.md
@@ -27,7 +27,7 @@ labels:
 envs:
   APP_ENV: production
 
-required_services:
+companion_containers:
   postgres:
     image: postgres:16-alpine
     envs:
@@ -40,7 +40,6 @@ required_services:
       retries: 12
     post_start_on_primary: ["psql -U postgres -c 'CREATE EXTENSION IF NOT EXISTS vector'"]
 
-optional_services:
   redis:
     image: redis:7-alpine
     healthcheck:
@@ -59,8 +58,7 @@ optional_services:
 | `copies` | `CreateSpec.copies` | list of CopySpec | Files to copy into the container |
 | `mounts` | `CreateSpec.mounts` | list of MountSpec | Bind mounts from host to container |
 | `builtin_tools` | `CreateSpec.builtin_tools` | list of string | Built-in resources to provision |
-| `required_services` | `CreateSpec.required_services` | map of ServiceSpec | Services that must be healthy before READY |
-| `optional_services` | `CreateSpec.optional_services` | map of ServiceSpec | Services started concurrently, not blocking READY |
+| `companion_containers` | `CreateSpec.companion_containers` | map of CompanionContainerSpec | Companion containers started concurrently with the primary container |
 | `labels` | `CreateSpec.labels` | map of string | Labels attached to the sandbox |
 | `envs` | `CreateSpec.envs` | map of string | Env vars on primary container, inherited by all execs |
 | `idle_ttl` | `CreateSpec.idle_ttl` | duration string | Per-sandbox idle TTL override. Omit to use the global daemon default. Set to `"0"` to disable idle stop for this sandbox. |
@@ -73,22 +71,9 @@ optional_services:
 
 `source` (absolute host path), `target` (absolute container path), `writable` (default: false). For detailed mount semantics, see [Container Dependency Strategy](container_dependency_strategy.md).
 
-### ServiceSpec Fields
+### CompanionContainerSpec and HealthcheckConfig Fields
 
-Services use a map format where the YAML key becomes `ServiceSpec.name`. Fields: `image`, `envs`, `healthcheck`, `post_start_on_primary`. For service startup behavior and required vs optional semantics, see [Container Dependency Strategy](container_dependency_strategy.md).
-
-### HealthcheckConfig Fields
-
-Duration fields (`interval`, `timeout`, `start_period`, `start_interval`) accept a duration string in YAML (e.g., `"5s"`, `"1m30s"`). The daemon parses this into `google.protobuf.Duration`.
-
-| YAML Key | Description |
-|---|---|
-| `test` | Healthcheck command (e.g., `["CMD-SHELL", "pg_isready"]`) |
-| `interval` | Check interval |
-| `timeout` | Check timeout |
-| `retries` | Max retry count |
-| `start_period` | Grace period before checks count |
-| `start_interval` | Check interval during start period |
+Companion containers use a map format where the YAML key becomes the container name and network alias. For field definitions, usage scenarios, and healthcheck configuration, see [Companion Container Guide](companion_container_guide.md).
 
 ## SDK Usage
 
@@ -137,4 +122,4 @@ Sandbox-level `envs` are applied to the primary container at creation time and i
 
 YAML parsing is implemented in the daemon, not in SDKs. SDKs send raw YAML bytes via `config_yaml` in `CreateSandboxRequest`, avoiding duplicating parsing logic. The daemon uses strict parsing that rejects unknown fields.
 
-Service ordering: when converting YAML service maps to proto `repeated ServiceSpec`, services are sorted alphabetically by name. For `required_services`, this determines sequential startup order. For `optional_services`, services start concurrently regardless of sort order.
+Companion container ordering: when converting YAML companion container maps to proto `repeated CompanionContainerSpec`, entries are sorted alphabetically by name. All companion containers start concurrently.

--- a/docs/protocol_design_principles.md
+++ b/docs/protocol_design_principles.md
@@ -60,7 +60,7 @@ Sandbox image selection is a request-time input. The daemon must not supply a hi
 
 `SandboxEvent` uses an envelope + oneof model. Each event carries:
 - top-level fields: `event_id`, `sequence`, `sandbox_id`, `event_type`, `timestamp`
-- a `oneof details` discriminator with one of: `SandboxPhaseDetails` (lifecycle transitions, errors, reason), `ExecEventDetails` (exec state, exit code, errors), or `ServiceEventDetails` (service name, errors)
+- a `oneof details` discriminator with one of: `SandboxPhaseDetails` (lifecycle transitions, errors, reason), `ExecEventDetails` (exec state, exit code, errors), or `CompanionContainerEventDetails` (companion container name, errors)
 
 The top-level `sandbox_state` reflects the sandbox state when the event was emitted. SDKs must dispatch on the active `details` field, not on `event_type` alone.
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,0 +1,76 @@
+# Quick Start
+
+Prerequisites: Docker and curl.
+
+## Install
+
+```bash
+curl -fsSL https://agents-sandbox.com/install.sh | bash
+```
+
+This installs `agboxd` (daemon) and `agbox` (CLI), then starts the daemon as a user service.
+
+## Run an AI Agent in a Sandbox
+
+```bash
+# Claude Code — full permissions, fully isolated
+agbox agent claude
+
+# Codex
+agbox agent codex
+
+# Any custom command
+agbox agent --command "aider --yes" --builtin-tool git --builtin-tool uv
+```
+
+The agent gets unrestricted permissions inside the sandbox. Your host stays untouched. On exit, the sandbox is automatically deleted.
+
+## CLI Workflow
+
+```bash
+# Create a sandbox
+agbox sandbox create --image ghcr.io/agents-sandbox/coding-runtime:latest --label project=demo
+
+# Run a command
+agbox sandbox exec <sandbox_id> -- python -c "print('hello')"
+
+# Inspect
+agbox sandbox list
+agbox sandbox get <sandbox_id>
+
+# Clean up
+agbox sandbox delete <sandbox_id>
+```
+
+See [CLI Reference](cli_reference.md) for all commands and flags.
+
+## SDK Workflow
+
+```python
+import asyncio
+from agents_sandbox import AgentsSandboxClient
+
+async def main() -> None:
+    async with AgentsSandboxClient() as client:
+        sandbox = await client.create_sandbox(
+            image="ghcr.io/agents-sandbox/coding-runtime:latest",
+        )
+        try:
+            result = await client.run(
+                sandbox.sandbox_id,
+                ("python", "-c", "print('hello from sandbox')"),
+            )
+            print(result.stdout_log_path)
+        finally:
+            await client.delete_sandbox(sandbox.sandbox_id)
+
+asyncio.run(main())
+```
+
+See [Python SDK](sdk_python_usage.md) and [Go SDK](sdk_go_usage.md) for full SDK documentation.
+
+## What's Next
+
+- [Declarative YAML Config](declarative_yaml_config.md) — define sandbox environments as YAML
+- [Companion Container Guide](companion_container_guide.md) — add databases, caches, and other companion containers to your sandbox
+- [Configuration Reference](configuration_reference.md) — daemon configuration keys

--- a/docs/sandbox_container_lifecycle.md
+++ b/docs/sandbox_container_lifecycle.md
@@ -1,6 +1,6 @@
 # Sandbox Container Lifecycle
 
-This document describes the runtime lifecycle contract owned by `agents-sandbox`: primary sandbox container, dedicated network, service containers, runtime event stream, exec output redirection, and cleanup/reconciliation.
+This document describes the runtime lifecycle contract owned by `agents-sandbox`: primary sandbox container, dedicated network, companion containers, runtime event stream, exec output redirection, and cleanup/reconciliation.
 
 ## Runtime Resources
 
@@ -8,7 +8,7 @@ This document describes the runtime lifecycle contract owned by `agents-sandbox`
 |----------|-------|
 | Primary container | Main execution target for `CreateExec` |
 | Dedicated network | One per sandbox; shared bridge and host network are not supported |
-| Service containers | Required and optional services declared via `ServiceSpec`, on the same network |
+| Companion containers | Declared via `CompanionContainerSpec`, on the same network |
 | Persistent event history | Stored in bbolt; lifecycle and exec events survive daemon restart until retention cleanup |
 | Exec output artifacts | Files under the configured artifact root |
 | Exec log bind-mount | `{ArtifactOutputRoot}/{sandbox_id}/` → `/var/log/agents-sandbox/` (rw); each exec writes `{exec_id}.stdout.log` and `{exec_id}.stderr.log` |
@@ -44,8 +44,8 @@ All lifecycle convergence must be observable through `SubscribeSandboxEvents`. T
 |------------|----------|
 | Create accepted | `SANDBOX_ACCEPTED` |
 | Materialization in progress | `SANDBOX_PREPARING` |
-| Required service ready | `SANDBOX_SERVICE_READY` |
-| Optional service fails | `SANDBOX_SERVICE_FAILED` |
+| Companion container ready | `COMPANION_CONTAINER_READY` |
+| Companion container fails | `COMPANION_CONTAINER_FAILED` |
 | Create or resume succeeds | `SANDBOX_READY` |
 | Create/resume/stop/delete fails | `SANDBOX_FAILED` |
 
@@ -82,19 +82,18 @@ flowchart TB
     C --> D[Create dedicated network]
     D --> E[Materialize filesystem inputs and built-in resources]
     E --> E1[Create exec log directory and bind-mount into primary container]
-    E1 --> F[Create required and optional service containers]
-    F --> G[Start and wait each required service healthy]
-    G --> H[Start primary and optional services]
-    H --> I[Run post_start_on_primary for required services]
+    E1 --> F[Create companion containers]
+    F --> G[Start primary and all companion containers in parallel]
+    G --> H[Run post_start_on_primary after each companion healthy]
     I --> J[Persist runtime handles]
-    J --> K[Emit SANDBOX_SERVICE_READY / SANDBOX_SERVICE_FAILED]
+    J --> K[Emit COMPANION_CONTAINER_READY / COMPANION_CONTAINER_FAILED]
     K --> L[Emit SANDBOX_READY]
 ```
 
 Create-path rules:
 - `CreateSandbox` returns immediately after acceptance; the caller must not infer readiness from the response alone.
-- The daemon must fail fast on invalid mounts, copies, unknown builtin_tools, invalid service declarations, or unsafe artifact targets. Duplicate `sandbox_id` returns a specific error code.
-- Optional services only report initial create/start result in V1; not restarted or runtime-monitored after readiness.
+- The daemon must fail fast on invalid mounts, copies, unknown builtin_tools, invalid companion container declarations, or unsafe artifact targets. Duplicate `sandbox_id` returns a specific error code.
+- Companion containers only report initial create/start result in V1; not restarted or runtime-monitored after readiness.
 - If materialization fails after resources exist, cleanup continues on a daemon-owned background context with bounded timeout.
 
 ## Resume Path
@@ -125,4 +124,4 @@ flowchart LR
 
 ## Reconciliation
 
-The daemon owns runtime reconciliation for resources under its namespace: idle sandboxes eligible for stop, resources left after failed materialization, orphaned service containers, and dedicated networks without live runtime membership. Reconciliation uses structured audit logs and explicit action reasons, deriving decisions from structured Docker metadata and recorded runtime state.
+The daemon owns runtime reconciliation for resources under its namespace: idle sandboxes eligible for stop, resources left after failed materialization, orphaned companion containers, and dedicated networks without live runtime membership. Reconciliation uses structured audit logs and explicit action reasons, deriving decisions from structured Docker metadata and recorded runtime state.

--- a/docs/sdk_go_usage.md
+++ b/docs/sdk_go_usage.md
@@ -56,7 +56,7 @@ type SandboxHandle struct {
     SandboxID, Image  string
     State             SandboxState
     LastEventSequence uint64
-    RequiredServices, OptionalServices []ServiceSpec
+    CompanionContainers []CompanionContainerSpec
     Labels            map[string]string
     CreatedAt         time.Time
     ErrorCode         *string
@@ -77,7 +77,7 @@ type ExecHandle struct {
 }
 ```
 
-`ServiceSpec` uses `Envs` (not `Environment`); `HealthcheckConfig` uses `*time.Duration` for duration fields.
+`CompanionContainerSpec` uses `Envs` (not `Environment`); `HealthcheckConfig` uses `*time.Duration` for duration fields.
 
 `ListActiveExecs` uses the option pattern: pass `WithSandboxID` to filter by sandbox.
 

--- a/docs/sdk_python_usage.md
+++ b/docs/sdk_python_usage.md
@@ -5,9 +5,9 @@
 ```python
 from agents_sandbox import (
     AgentsSandboxClient,
+    CompanionContainerSpec,
     HealthcheckConfig,
     MountSpec,
-    ServiceSpec,
 )
 
 async with AgentsSandboxClient() as client:
@@ -29,8 +29,7 @@ class SandboxHandle:
     sandbox_id: str
     state: SandboxState
     last_event_sequence: int
-    required_services: tuple[ServiceSpec, ...]
-    optional_services: tuple[ServiceSpec, ...]
+    companion_containers: tuple[CompanionContainerSpec, ...]
     labels: Mapping[str, str]
     created_at: datetime | None
     image: str
@@ -39,11 +38,11 @@ class SandboxHandle:
     state_changed_at: datetime | None
 ```
 
-`ServiceSpec` uses `envs` (not `environment`); `HealthcheckConfig` uses `timedelta` for duration fields:
+`CompanionContainerSpec` uses `envs` (not `environment`); `HealthcheckConfig` uses `timedelta` for duration fields:
 
 ```python
 @dataclass
-class ServiceSpec:
+class CompanionContainerSpec:
     name: str
     image: str
     envs: Mapping[str, str]
@@ -81,8 +80,8 @@ sandbox = await client.create_sandbox(
     image="ghcr.io/agents-sandbox/coding-runtime:latest",
     sandbox_id="demo-sandbox",
     mounts=(MountSpec(source="/path/to/workspace", target="/workspace", writable=True),),
-    required_services=(
-        ServiceSpec(
+    companion_containers=(
+        CompanionContainerSpec(
             name="postgres",
             image="postgres:16",
             healthcheck=HealthcheckConfig(
@@ -92,8 +91,8 @@ sandbox = await client.create_sandbox(
             ),
             post_start_on_primary=("python -c \"print('seeded')\"",),
         ),
+        CompanionContainerSpec(name="redis", image="redis:7"),
     ),
-    optional_services=(ServiceSpec(name="redis", image="redis:7"),),
     wait=False,
 )
 ```
@@ -122,7 +121,7 @@ print(result.stdout_log_path)
 
 ## Subscription
 
-`subscribe_sandbox_events` is a public advanced API returning an async iterator of events with `event_type`, `sequence`, and typed sub-structs (`sandbox_phase`, `exec`, `service`):
+`subscribe_sandbox_events` is a public advanced API returning an async iterator of events with `event_type`, `sequence`, and typed sub-structs (`sandbox_phase`, `exec`, `companion_container`):
 
 ```python
 async for event in client.subscribe_sandbox_events(sandbox_id, from_sequence=0):

--- a/docs/theme.json
+++ b/docs/theme.json
@@ -11,6 +11,7 @@
     {
       "text": "Overview",
       "items": [
+        { "text": "Quick Start", "link": "/quick_start" },
         { "text": "Architecture Overview", "link": "/architecture_overview" },
         { "text": "Why Not Built-in Sandboxes", "link": "/why_not_builtin_sandboxes" }
       ]
@@ -18,6 +19,8 @@
     {
       "text": "Usage Guides",
       "items": [
+        { "text": "CLI Reference", "link": "/cli_reference" },
+        { "text": "Companion Container Guide", "link": "/companion_container_guide" },
         { "text": "Declarative YAML Config", "link": "/declarative_yaml_config" },
         { "text": "Python SDK", "link": "/sdk_python_usage" },
         { "text": "Go SDK", "link": "/sdk_go_usage" }

--- a/sdk/python/tests/test_smoke_public_api.py
+++ b/sdk/python/tests/test_smoke_public_api.py
@@ -336,10 +336,9 @@ def test_public_docs_use_converged_python_sdk_api() -> None:
 
     assert "AgentsSandboxClient()" in public_docs["README.md"]
     assert "AgentsSandboxClient()" in public_docs["docs/sdk_python_usage.md"]
-    assert "ServiceSpec" in public_docs["docs/sdk_python_usage.md"]
+    assert "CompanionContainerSpec" in public_docs["docs/sdk_python_usage.md"]
     assert "HealthcheckConfig" in public_docs["docs/sdk_python_usage.md"]
-    assert "required_services" in public_docs["docs/sdk_python_usage.md"]
-    assert "optional_services" in public_docs["docs/sdk_python_usage.md"]
+    assert "companion_containers" in public_docs["docs/sdk_python_usage.md"]
     assert "sandbox_id=" in public_docs["docs/sdk_python_usage.md"]
     assert "exec_id=" in public_docs["docs/sdk_python_usage.md"]
     assert "from_sequence=0" in public_docs["docs/sdk_python_usage.md"]


### PR DESCRIPTION
## Summary

- Add `docs/quick_start.md` — minimal install-to-running path for new users
- Add `docs/companion_container_guide.md` — explains companion containers for debugging with external dependencies
- Replace `required_services` / `optional_services` / `ServiceSpec` with unified `companion_containers` / `CompanionContainerSpec` across all 12 docs
- Update `theme.json` sidebar: add Quick Start (Overview), CLI Reference and Companion Container Guide (Usage Guides)
- Add "Learn More" section to README
- Update doc consistency test to match new terminology

Docs-only change (plus one test fix). Code-side rename tracked in #119.

Close #120

## Test plan

- [x] All pre-commit hooks pass (lint, proto consistency, Go tests, Python tests)
- [x] `grep -r` confirms no old terminology (`ServiceSpec`, `required_services`, `optional_services`, `SANDBOX_SERVICE`, `service_guide`) remains in docs/
