### PR TITLE
[ISSUE-129] Fix landing page: remove placeholder circles and fix copy button

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -372,10 +372,6 @@
       <div><span class="oss-stat-num">Python</span><span class="oss-stat-label">SDK</span></div>
       <div><span class="oss-stat-num">Proto3</span><span class="oss-stat-label">API Protocol</span></div>
     </div>
-    <div class="oss-contributors reveal">
-      <span class="oss-avatar"></span><span class="oss-avatar"></span>
-      <span class="oss-avatar"></span><span class="oss-avatar"></span><span class="oss-avatar"></span>
-    </div>
     <button class="btn-primary reveal" onclick="window.open('https://github.com/1996fanrui/agents-sandbox','_blank')">Star on GitHub</button>
   </div>
 </section>

--- a/website/script.js
+++ b/website/script.js
@@ -126,7 +126,7 @@
 function closeMobileMenu() { document.getElementById('mobileMenu').classList.remove('open'); }
 function copyCommands() {
   navigator.clipboard.writeText(
-    'curl -fsSL https://agents-sandbox.com/install.sh | bash\nagbox agent claude'
+    'curl -fsSL https://agents-sandbox.com/install.sh | bash\nagbox agent claude\nagbox agent codex'
   ).then(function() {
     var btn = document.querySelector('.copy-btn');
     btn.textContent = 'Copied!';

--- a/website/style.css
+++ b/website/style.css
@@ -371,8 +371,6 @@ section { padding: 96px 0; }
   color: var(--primary); display: block; letter-spacing: -0.03em;
 }
 .oss-stat-label { font-size: 0.8rem; color: var(--muted); }
-.oss-contributors { display: flex; gap: 8px; justify-content: center; margin-bottom: 28px; }
-.oss-avatar { width: 32px; height: 32px; border-radius: 50%; background: var(--border); border: 2px solid var(--bg); }
 
 /* ── Scroll Reveal ── */
 .reveal { opacity:0; transform:translateY(18px); transition:opacity .55s ease,transform .55s ease; }


### PR DESCRIPTION
## Summary

- Remove 5 empty placeholder avatar circles (`.oss-avatar`) and their CSS from the Open Source section
- Fix `copyCommands()` to include all 3 displayed commands (was missing `agbox agent codex`)

## Test plan

- [ ] Verify Open Source section no longer shows gray circles
- [ ] Click "Copy" in Quick Start, paste — confirm all 3 commands are present

Close #129
