### PR TITLE
[ISSUE-140] Mount ~/.ssh/known_hosts (rw) by default for git tool

### DIFF
--- a/docs/container_dependency_strategy.md
+++ b/docs/container_dependency_strategy.md
@@ -30,14 +30,14 @@ Tools are the user-facing names passed in `builtin_tools`. Each tool resolves to
 |------|--------------------------------------------------------|
 | `claude` | `~/.claude` → `/home/agbox/.claude` (rw), `~/.claude.json` → `/home/agbox/.claude.json` (rw), `$XDG_RUNTIME_DIR/pulse/native` → `/pulse-audio` (socket forwarding, when host socket exists) |
 | `codex` | `~/.codex` → `/home/agbox/.codex` (rw), `~/.agents` → `/home/agbox/.agents` (rw) |
-| `git` | `SSH_AUTH_SOCK` → `/ssh-agent` (socket forwarding), `~/.config/gh` → `/home/agbox/.config/gh` (read-only) |
+| `git` | `SSH_AUTH_SOCK` → `/ssh-agent` (socket forwarding), `~/.config/gh` → `/home/agbox/.config/gh` (read-only), `~/.ssh/known_hosts` → `/home/agbox/.ssh/known_hosts` (read-write) |
 | `uv` | `~/.cache/uv` → `/home/agbox/.cache/uv` (rw), `~/.local/share/uv` → `/home/agbox/.local/share/uv` (rw) |
 | `npm` | `~/.npm` → `/home/agbox/.npm` (read-write) |
 | `apt` | `~/.cache/agents-sandbox-apt` → `/var/cache/apt/archives` (read-write) |
 
 Notes:
 - `codex` mounts both `~/.codex` and `~/.agents`; `~/.agents` is the shared agents state directory.
-- `git` bundles SSH agent forwarding and GitHub CLI auth; requesting `git` is equivalent to requesting both.
+- `git` bundles SSH agent forwarding, GitHub CLI auth, and SSH known-hosts; requesting `git` is equivalent to requesting all three.
 - `uv` mounts both the package cache and the data directory holding Python interpreters and globally installed tools.
 - `claude` includes optional PulseAudio socket forwarding for voice support; the mount is silently skipped when the host socket does not exist.
 

--- a/internal/profile/capabilities.go
+++ b/internal/profile/capabilities.go
@@ -22,17 +22,18 @@ const ContainerUserHome = "/home/agbox"
 type MountID string
 
 const (
-	MountIDClaude     MountID = ".claude"
-	MountIDClaudeJSON MountID = ".claude.json"
-	MountIDCodex      MountID = ".codex"
-	MountIDAgents     MountID = ".agents"
-	MountIDGHAuth     MountID = "gh-auth"
-	MountIDSSHAgent   MountID = "ssh-agent"
-	MountIDUVCache    MountID = "uv-cache"
-	MountIDUVData     MountID = "uv-data"
-	MountIDNPM        MountID = "npm"
-	MountIDApt        MountID = "apt"
-	MountIDPulseAudio MountID = "pulse-audio"
+	MountIDClaude        MountID = ".claude"
+	MountIDClaudeJSON    MountID = ".claude.json"
+	MountIDCodex         MountID = ".codex"
+	MountIDAgents        MountID = ".agents"
+	MountIDGHAuth        MountID = "gh-auth"
+	MountIDSSHAgent      MountID = "ssh-agent"
+	MountIDSSHKnownHosts MountID = "ssh-known-hosts"
+	MountIDUVCache       MountID = "uv-cache"
+	MountIDUVData        MountID = "uv-data"
+	MountIDNPM           MountID = "npm"
+	MountIDApt           MountID = "apt"
+	MountIDPulseAudio    MountID = "pulse-audio"
 )
 
 // ToolID is the canonical identifier for a tooling capability.
@@ -44,7 +45,7 @@ const (
 	ToolIDGit    ToolID = "git"
 	ToolIDUV     ToolID = "uv"
 	ToolIDNPM    ToolID = "npm"
-	ToolIDApt ToolID = "apt"
+	ToolIDApt    ToolID = "apt"
 )
 
 // MacOSKeychainCredential declares that a credential file may be absent from
@@ -129,6 +130,13 @@ var capabilityMounts = buildMountIndex([]CapabilityMount{
 		Mode:            CapabilityModeSocket,
 		Optional:        true,
 	},
+	{
+		ID:              MountIDSSHKnownHosts,
+		DefaultHostPath: "~/.ssh/known_hosts",
+		ContainerTarget: path.Join(ContainerUserHome, ".ssh/known_hosts"),
+		Mode:            CapabilityModeReadWrite,
+		Optional:        true,
+	},
 	// uv-cache holds downloaded packages; uv-data holds uv-managed Python interpreters and global tools.
 	{
 		ID:              MountIDUVCache,
@@ -178,7 +186,7 @@ func buildMountIndex(mounts []CapabilityMount) map[MountID]CapabilityMount {
 var builtInToolingCapabilities = map[ToolID]ToolingCapability{
 	ToolIDClaude: {MountIDs: []MountID{MountIDClaude, MountIDClaudeJSON, MountIDPulseAudio}},
 	ToolIDCodex:  {MountIDs: []MountID{MountIDCodex, MountIDAgents}},
-	ToolIDGit:    {MountIDs: []MountID{MountIDSSHAgent, MountIDGHAuth}},
+	ToolIDGit:    {MountIDs: []MountID{MountIDSSHAgent, MountIDGHAuth, MountIDSSHKnownHosts}},
 	ToolIDUV:     {MountIDs: []MountID{MountIDUVCache, MountIDUVData}},
 	ToolIDNPM:    {MountIDs: []MountID{MountIDNPM}},
 	ToolIDApt:    {MountIDs: []MountID{MountIDApt}},

--- a/internal/profile/capabilities_test.go
+++ b/internal/profile/capabilities_test.go
@@ -1,6 +1,9 @@
 package profile
 
-import "testing"
+import (
+	"path"
+	"testing"
+)
 
 func TestBuiltInToolingCapabilitiesExposeRequiredIDs(t *testing.T) {
 	capabilities := BuiltInToolingCapabilities()
@@ -67,15 +70,35 @@ func TestClaudeMountsIncludePulseAudio(t *testing.T) {
 	}
 }
 
-func TestGitMountsBothAuthResources(t *testing.T) {
+func TestGitMountsAllAuthResources(t *testing.T) {
 	capability, ok := CapabilityByID(string(ToolIDGit))
 	if !ok {
 		t.Fatal("missing tool capability git")
 	}
-	if len(capability.MountIDs) != 2 {
-		t.Fatalf("expected git to have 2 mount IDs, got %d", len(capability.MountIDs))
+	if len(capability.MountIDs) != 3 {
+		t.Fatalf("expected git to have 3 mount IDs, got %d", len(capability.MountIDs))
 	}
-	if capability.MountIDs[0] != MountIDSSHAgent || capability.MountIDs[1] != MountIDGHAuth {
+	if capability.MountIDs[0] != MountIDSSHAgent || capability.MountIDs[1] != MountIDGHAuth || capability.MountIDs[2] != MountIDSSHKnownHosts {
 		t.Fatalf("unexpected git mount IDs: %v", capability.MountIDs)
+	}
+}
+
+func TestSSHKnownHostsMountAttributes(t *testing.T) {
+	mount, ok := MountByID(MountIDSSHKnownHosts)
+	if !ok {
+		t.Fatal("missing mount ssh-known-hosts")
+	}
+	if mount.DefaultHostPath != "~/.ssh/known_hosts" {
+		t.Fatalf("unexpected DefaultHostPath: got %q want %q", mount.DefaultHostPath, "~/.ssh/known_hosts")
+	}
+	want := path.Join(ContainerUserHome, ".ssh/known_hosts")
+	if mount.ContainerTarget != want {
+		t.Fatalf("unexpected ContainerTarget: got %q want %q", mount.ContainerTarget, want)
+	}
+	if mount.Mode != CapabilityModeReadWrite {
+		t.Fatalf("unexpected Mode: got %q want %q", mount.Mode, CapabilityModeReadWrite)
+	}
+	if !mount.Optional {
+		t.Fatal("expected Optional to be true")
 	}
 }


### PR DESCRIPTION
## Summary

- Add `~/.ssh/known_hosts` as a default read-write mount for the `git` built-in tool, so SSH connections inside the sandbox work without manual `ssh-keyscan` workarounds.
- The mount is optional and silently skipped when the file does not exist on the host.
- Update `container_dependency_strategy.md` to document the new mount.

## Test plan

- [x] `TestGitMountsAllAuthResources` verifies git tool now has 3 mount IDs
- [x] `TestSSHKnownHostsMountAttributes` verifies mount path, target, mode (rw), and optional flag
- [x] All existing tests pass (`go test ./...`)
- [ ] (Manual) Create sandbox with git tool, verify `~/.ssh/known_hosts` is mounted and SSH to github.com works without `ssh-keyscan`

Close #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
