### PR TITLE
[ISSUE-148] Block gateway.docker.internal on macOS and test CAP_NET_ADMIN fail-fast

### DIFF
--- a/docs/isolation_and_security.md
+++ b/docs/isolation_and_security.md
@@ -38,7 +38,7 @@ flowchart TB
     HostFS -.-|explicit mount only| NetA
 ```
 
-- **Host network blocked — permanently.** Sandboxes cannot reach `localhost`, host services, or the local network. This will never be supported. If the agent needs databases, caches, or other dependencies, declare them as [companion containers](companion_container_guide.md) — they run on the same sandbox network and are reachable by DNS alias.
+- **Host network restricted.** Sandboxes are isolated from the host and from each other. If the agent needs databases, caches, or other dependencies, declare them as [companion containers](companion_container_guide.md) — they run on the same sandbox network and are reachable by DNS alias.
 - **Host filesystem invisible by default.** Only explicitly declared `mounts`, `copies`, and `builtin_tools` may enter the sandbox. Everything else is rejected.
 - **Internet fully available.** Outbound traffic is NAT'd via Docker bridge — agents can download packages, call APIs, and clone repos freely.
 - **Cross-sandbox isolated.** Each sandbox gets its own dedicated Docker network. Sandboxes cannot reach each other.
@@ -47,9 +47,14 @@ flowchart TB
 
 | Boundary | Mechanism | Detail |
 |----------|-----------|--------|
-| **Network** | Dedicated network + host isolation | Outbound internet via NAT; no shared bridge, no host network, no Docker socket exposure. Sandboxes are isolated from each other. Companion containers join the same sandbox network. **Linux**: an nftables rule in the `DOCKER-USER` chain drops all traffic from each sandbox subnet to any host-local address (fib destination addrtype LOCAL), blocking access via every host interface. Rules are managed via the `google/nftables` Go library (netlink syscalls, no forked processes). The daemon requires `CAP_NET_ADMIN`. **macOS**: `host.docker.internal` is overridden to `0.0.0.0` via `--add-host`, preventing containers from reaching the macOS host through Docker Desktop's DNS injection. See [Container Dependency Strategy](container_dependency_strategy.md). |
+| **Network** | Dedicated network + host isolation | Outbound internet via NAT; no shared bridge, no host network, no Docker socket exposure. Sandboxes are isolated from each other, and companion containers join the same sandbox network. Platform-specific enforcement is described below. |
 | **Filesystem** | Explicit-only ingress | Only declared `mounts`, `copies`, and `builtin_tools` (host credential and cache mounts like `claude`, `git`, `uv`) enter the sandbox. Symlink sources and path traversal are rejected. See [Container Dependency Strategy](container_dependency_strategy.md). |
 | **Process** | Non-root user + init process | `HOST_UID`/`HOST_GID` align container user with host identity. `Init: true` handles signal forwarding and zombie reaping. |
 | **Docker access** | Daemon-mediated only | Sandboxes have no Docker socket. All Docker operations go through the daemon's structured API client. |
 | **Ownership** | Namespaced labels | Daemon only manages objects under `io.github.1996fanrui.agents-sandbox.*`. User labels are prefixed to prevent collision. See [Sandbox Container Lifecycle](sandbox_container_lifecycle.md). |
 | **Cleanup** | Automatic + idempotent | Sandbox delete removes all resources; STOPPED sandboxes exceeding [`runtime.cleanup_ttl`](configuration_reference.md) are auto-deleted. Failed materialization triggers background cleanup. |
+
+## Platform-Specific Network Strategy
+
+- **Linux:** an nftables rule in the `DOCKER-USER` chain drops traffic from each sandbox subnet to host-local addresses, blocking access to host services at the network layer. The daemon requires `CAP_NET_ADMIN`.
+- **macOS:** `host.docker.internal` and `gateway.docker.internal` are overridden to `0.0.0.0` via `--add-host`, reducing access to the macOS host through Docker Desktop's stable host-discovery aliases. This is a DNS-layer best-effort control, not Linux-equivalent network-layer isolation.

--- a/internal/control/docker_runtime_dockerapi.go
+++ b/internal/control/docker_runtime_dockerapi.go
@@ -23,6 +23,11 @@ import (
 // execLogContainerDir is the container-side directory for exec log files when output redirection is enabled.
 const execLogContainerDir = "/var/log/agents-sandbox/"
 
+var macOSBlockedHostAliases = []string{
+	"host.docker.internal:0.0.0.0",
+	"gateway.docker.internal:0.0.0.0",
+}
+
 type dockerMount struct {
 	Source   string
 	Target   string
@@ -131,12 +136,10 @@ func (backend *dockerRuntimeBackend) dockerContainerCreate(ctx context.Context, 
 	hostConfig := &container.HostConfig{
 		Init:   ptrTo(true),
 		Mounts: hostMounts,
-		// Map host.docker.internal to 0.0.0.0 so that any attempt to reach
-		// the host via this well-known DNS name is black-holed.  On macOS this
-		// is the primary isolation mechanism; on Linux nftables rules handle
-		// the heavier lifting, but the extra-host entry is harmless and
-		// provides defence-in-depth.
-		ExtraHosts: []string{"host.docker.internal:0.0.0.0"},
+		// Black-hole Docker Desktop's stable host-discovery aliases on macOS.
+		// This is a DNS-layer best-effort control; Linux host isolation is
+		// enforced separately via nftables on the sandbox network.
+		ExtraHosts: append([]string(nil), macOSBlockedHostAliases...),
 	}
 	var networkingConfig *network.NetworkingConfig
 	if spec.NetworkName != "" {

--- a/internal/control/service_stage2_runtime_contracts_test.go
+++ b/internal/control/service_stage2_runtime_contracts_test.go
@@ -171,8 +171,11 @@ func TestDockerLabelsPassthrough(t *testing.T) {
 		runtimedocker.LabelUserPrefix + "env":   "dev",
 	})
 
-	// Verify all containers have the host.docker.internal:0.0.0.0 extra host entry.
-	wantExtraHosts := []string{"host.docker.internal:0.0.0.0"}
+	// Verify all containers carry the Docker Desktop host-discovery overrides.
+	wantExtraHosts := []string{
+		"host.docker.internal:0.0.0.0",
+		"gateway.docker.internal:0.0.0.0",
+	}
 	for _, name := range []string{dbContainerName, cacheContainerName, primaryContainerName} {
 		mu.Lock()
 		got := containerExtraHosts[name]

--- a/sdk/python/tests/test_real_runtime.py
+++ b/sdk/python/tests/test_real_runtime.py
@@ -55,6 +55,42 @@ RUNTIME_IMAGE = f"{RUNTIME_IMAGE_REPOSITORY}:{CODING_RUNTIME_IMAGE_TAG}"
 LATEST_RUNTIME_IMAGE = f"{RUNTIME_IMAGE_REPOSITORY}:latest"
 
 
+def test_daemon_refuses_to_start_without_cap_net_admin(tmp_path: Path) -> None:
+    if sys.platform != "linux":
+        pytest.skip("Linux-only capability check")
+    if shutil.which("go") is None:
+        pytest.skip("go is required for the daemon startup test")
+    if os.geteuid() == 0:
+        pytest.skip("root already has CAP_NET_ADMIN")
+    if _current_process_has_net_admin():
+        pytest.skip("current test process already has CAP_NET_ADMIN")
+
+    repo_root = Path(__file__).resolve().parents[3]
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+    socket_path = daemon_socket_path(runtime_dir)
+    daemon_path = _build_test_daemon(repo_root, runtime_dir, grant_net_admin=False)
+
+    process = subprocess.Popen(
+        [str(daemon_path)],
+        cwd=repo_root,
+        env=_daemon_env(runtime_dir),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        _, stderr = process.communicate(timeout=10)
+    except subprocess.TimeoutExpired as exc:
+        _terminate_process_group(process)
+        raise AssertionError("daemon should fail fast without CAP_NET_ADMIN") from exc
+
+    assert process.returncode == 1
+    assert "CAP_NET_ADMIN" in stderr
+    assert not socket_path.exists(), "daemon should not expose a socket when startup capability checks fail"
+
+
 def test_sdk_can_create_real_sandbox_and_exec(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[3]
     if shutil.which("go") is None:
@@ -269,13 +305,7 @@ def _new_client(socket_path: str | Path, **kwargs: object) -> AgentsSandboxClien
     return client
 
 
-@contextmanager
-def _running_test_daemon(
-    repo_root: Path,
-    runtime_dir: Path,
-    *,
-    env: dict[str, str] | None = None,
-) -> Iterator[None]:
+def _daemon_env(runtime_dir: Path, *, env: dict[str, str] | None = None) -> dict[str, str]:
     merged_env = os.environ.copy()
     merged_env["XDG_RUNTIME_DIR"] = str(runtime_dir)
     merged_env["XDG_DATA_HOME"] = str(runtime_dir)
@@ -283,6 +313,10 @@ def _running_test_daemon(
     merged_env["HOME"] = str(runtime_dir)
     if env is not None:
         merged_env.update(env)
+    return merged_env
+
+
+def _build_test_daemon(repo_root: Path, runtime_dir: Path, *, grant_net_admin: bool) -> Path:
     daemon_path = runtime_dir / "agboxd-test"
     subprocess.run(
         ["go", "build", "-o", str(daemon_path), "./cmd/agboxd"],
@@ -293,14 +327,26 @@ def _running_test_daemon(
         stderr=subprocess.DEVNULL,
         text=True,
     )
-    # Grant CAP_NET_ADMIN so the test daemon can manage nftables rules.
-    if sys.platform == "linux" and shutil.which("setcap") is not None:
+    if grant_net_admin and sys.platform == "linux" and shutil.which("setcap") is not None:
         subprocess.run(
             ["sudo", "-n", "setcap", "cap_net_admin+ep", str(daemon_path)],
             check=False,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
+    return daemon_path
+
+
+@contextmanager
+def _running_test_daemon(
+    repo_root: Path,
+    runtime_dir: Path,
+    *,
+    env: dict[str, str] | None = None,
+) -> Iterator[None]:
+    merged_env = _daemon_env(runtime_dir, env=env)
+    daemon_path = _build_test_daemon(repo_root, runtime_dir, grant_net_admin=True)
+    # Grant CAP_NET_ADMIN so the test daemon can manage nftables rules.
     process = subprocess.Popen(
         [str(daemon_path)],
         cwd=repo_root,
@@ -333,6 +379,22 @@ def _terminate_process_group(process: subprocess.Popen[str]) -> None:
         except ProcessLookupError:
             return
         process.wait(timeout=10)
+
+
+def _current_process_has_net_admin() -> bool:
+    if sys.platform != "linux":
+        return False
+    try:
+        status = Path("/proc/self/status").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    for line in status.splitlines():
+        if line.startswith("CapEff:"):
+            try:
+                return int(line.split(":", 1)[1].strip(), 16) & (1 << 12) != 0
+            except ValueError:
+                return False
+    return False
 
 
 def _ensure_runtime_image(repo_root: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #146 (ISSUE-144). Two gaps identified after the initial network isolation implementation:

- **`gateway.docker.internal` not blocked**: Docker Desktop injects both `host.docker.internal` and `gateway.docker.internal` as stable DNS aliases for the host. The original implementation only blocked `host.docker.internal`; this PR blocks both via `--add-host` override to `0.0.0.0`
- **CAP_NET_ADMIN startup check untested**: The daemon's fail-fast check on Linux (exit code 1 + error message when `CAP_NET_ADMIN` is missing) had no test coverage; this PR adds it

## Changes

- Extend `macOSBlockedHostAliases` to include `gateway.docker.internal:0.0.0.0`
- Add `test_daemon_refuses_to_start_without_cap_net_admin` integration test
- Refactor `_running_test_daemon` to extract `_daemon_env` and `_build_test_daemon` helpers
- Update `docs/isolation_and_security.md`: add dedicated Platform-Specific Network Strategy section, soften "permanently blocked" wording to match actual platform capabilities
- Update `TestDockerLabelsPassthrough` to assert both host aliases are present

## Test plan

- [ ] `make test` passes (Go unit tests + Python unit tests)
- [ ] `make integration-test` passes on Linux with `CAP_NET_ADMIN` granted
- [ ] `test_daemon_refuses_to_start_without_cap_net_admin` verifies daemon exits with code 1 and `CAP_NET_ADMIN` in stderr when capability is absent (Linux-only, skipped on macOS)

close #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
