### PR TITLE
[ISSUE-159] Grant passwordless sudo to runtime user

### DIFF
--- a/images/coding-runtime/Dockerfile
+++ b/images/coding-runtime/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     gosu \
+    sudo \
     openssh-client \
     ripgrep \
     sox \

--- a/images/coding-runtime/entrypoint.sh
+++ b/images/coding-runtime/entrypoint.sh
@@ -39,6 +39,9 @@ fi
 
 mkdir -p "$USER_HOME"
 chown "$HOST_UID:$HOST_GID" "$USER_HOME" /workspace
+# Grant passwordless sudo so the runtime user can install system packages.
+echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/runtime-user
+chmod 440 /etc/sudoers.d/runtime-user
 
 for dir in "$USER_HOME/.claude" "$USER_HOME/.codex" "$USER_HOME/.agents" "$USER_HOME/.cache" "$USER_HOME/.npm" "$USER_HOME/.config"; do
     if [ -d "$dir" ]; then


### PR DESCRIPTION
## Summary

- Grant passwordless sudo to the runtime user (agbox) in the coding-runtime image
- Install `sudo` via apt in the Dockerfile and configure `/etc/sudoers.d/runtime-user` with `NOPASSWD:ALL` in `entrypoint.sh`
- This allows the runtime user to install system packages (e.g. `sudo npm install -g <package>`) without permission errors

## Why sudo instead of chown

Chown-ing specific directories (e.g. `/usr/local/lib/node_modules`) is a whack-a-mole approach. The container has a single non-root user and the sandbox isolation boundary is at the host network namespace level, so granting sudo inside the container adds no security risk.

## Test plan

- [ ] Build coding-runtime image
- [ ] `agbox exec run <sandbox> -- sudo npm install -g cowsay` → exit 0
- [ ] `agbox exec run <sandbox> -- cowsay hello` → output renders

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
