### PR TITLE
[ISSUE-158] Add --yaml-file and --sandbox-id flags to sandbox create

### DIFF
--- a/cmd/agbox/cmd_sandbox.go
+++ b/cmd/agbox/cmd_sandbox.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ func newSandboxCreateCommand() *cobra.Command {
 		labels     []string
 		idleTTLStr string
 		jsonOutput bool
+		yamlFile   string
+		sandboxID  string
 	)
 
 	cmd := &cobra.Command{
@@ -56,9 +59,23 @@ func newSandboxCreateCommand() *cobra.Command {
 			}
 
 			parsed := sandboxCreateArgs{
-				image:  image,
-				labels: labelMap,
-				json:   jsonOutput,
+				image:     image,
+				labels:    labelMap,
+				json:      jsonOutput,
+				sandboxID: sandboxID,
+			}
+
+			if yamlFile != "" {
+				data, err := os.ReadFile(yamlFile)
+				if err != nil {
+					return runtimeErrorf("read yaml file %s: %v", yamlFile, err)
+				}
+				parsed.configYAML = data
+				// When --yaml-file is provided but --image is not explicitly set,
+				// clear the default image so the server uses the YAML config.
+				if !cmd.Flags().Changed("image") {
+					parsed.image = ""
+				}
 			}
 
 			if idleTTLStr != "" {
@@ -86,6 +103,8 @@ func newSandboxCreateCommand() *cobra.Command {
 	cmd.Flags().StringArrayVar(&labels, "label", nil, "Label in key=value form (repeatable)")
 	cmd.Flags().StringVar(&idleTTLStr, "idle-ttl", "", "Idle TTL duration (e.g. 5m, 0 to disable)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	cmd.Flags().StringVar(&yamlFile, "yaml-file", "", "Path to YAML configuration file")
+	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID (must be unique)")
 
 	return cmd
 }

--- a/cmd/agbox/sandbox.go
+++ b/cmd/agbox/sandbox.go
@@ -43,10 +43,12 @@ type sandboxExecClient interface {
 }
 
 type sandboxCreateArgs struct {
-	image   string
-	labels  map[string]string
-	idleTTL *time.Duration
-	json    bool
+	image      string
+	labels     map[string]string
+	idleTTL    *time.Duration
+	json       bool
+	configYAML []byte
+	sandboxID  string
 }
 
 type sandboxListArgs struct {
@@ -82,6 +84,8 @@ func runSandboxCreate(ctx context.Context, client sandboxExecClient, parsed sand
 	}
 	response, err := client.CreateSandbox(ctx, &agboxv1.CreateSandboxRequest{
 		CreateSpec: createSpec,
+		SandboxId:  parsed.sandboxID,
+		ConfigYaml: parsed.configYAML,
 	})
 	if err != nil {
 		return runtimeErrorf("create sandbox: %v", err)

--- a/cmd/agbox/sandbox_list_get_test.go
+++ b/cmd/agbox/sandbox_list_get_test.go
@@ -1,0 +1,340 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
+)
+
+func TestSandboxList(t *testing.T) {
+	service := &fakeSandboxService{
+		listFn: func(_ context.Context, request *agboxv1.ListSandboxesRequest) (*agboxv1.ListSandboxesResponse, error) {
+			selector := request.GetLabelSelector()
+			switch {
+			case len(selector) == 0 && !request.GetIncludeDeleted():
+				return &agboxv1.ListSandboxesResponse{
+					Sandboxes: []*agboxv1.SandboxHandle{
+						{SandboxId: "sandbox-a", State: agboxv1.SandboxState_SANDBOX_STATE_READY, Labels: map[string]string{"team": "backend", "env": "dev"}},
+						{SandboxId: "sandbox-b", State: agboxv1.SandboxState_SANDBOX_STATE_PENDING, Labels: map[string]string{"team": "frontend", "env": "dev"}},
+						{SandboxId: "sandbox-c", State: agboxv1.SandboxState_SANDBOX_STATE_STOPPED, Labels: map[string]string{"team": "backend", "env": "prod"}},
+					},
+				}, nil
+			case len(selector) == 0 && request.GetIncludeDeleted():
+				return &agboxv1.ListSandboxesResponse{
+					Sandboxes: []*agboxv1.SandboxHandle{
+						{SandboxId: "sandbox-a", State: agboxv1.SandboxState_SANDBOX_STATE_READY, Labels: map[string]string{"team": "backend", "env": "dev"}},
+						{SandboxId: "sandbox-deleted", State: agboxv1.SandboxState_SANDBOX_STATE_DELETED, Labels: map[string]string{"team": "backend", "env": "archived"}},
+					},
+				}, nil
+			case selector["env"] == "dev" && selector["team"] == "backend":
+				return &agboxv1.ListSandboxesResponse{
+					Sandboxes: []*agboxv1.SandboxHandle{
+						{SandboxId: "sandbox-a", State: agboxv1.SandboxState_SANDBOX_STATE_READY, Labels: map[string]string{"team": "backend", "env": "dev"}},
+					},
+				}, nil
+			case selector["env"] == "qa":
+				return &agboxv1.ListSandboxesResponse{}, nil
+			default:
+				t.Fatalf("unexpected label selector: %#v", selector)
+				return nil, nil
+			}
+		},
+	}
+
+	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "list")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("unexpected output lines: %#v", lines)
+	}
+	if !strings.Contains(lines[0], "SANDBOX ID") || !strings.Contains(lines[0], "CREATED") || !strings.Contains(lines[0], "STATUS") || !strings.Contains(lines[0], "LABELS") || !strings.Contains(lines[0], "ERROR") {
+		t.Fatalf("unexpected header line: %q", lines[0])
+	}
+	if !strings.Contains(stdout, "sandbox-a") || !strings.Contains(stdout, "sandbox-b") || !strings.Contains(stdout, "sandbox-c") {
+		t.Fatalf("unexpected stdout %q", stdout)
+	}
+	if !strings.Contains(stdout, "env=dev,team=backend") {
+		t.Fatalf("labels were not sorted in stdout %q", stdout)
+	}
+
+	stdout, stderr, exitCode = runCLIWithSandboxServer(t, service, "sandbox", "list", "--label", "env=dev", "--label", "team=backend")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "sandbox-a") || strings.Contains(stdout, "sandbox-b") || strings.Contains(stdout, "sandbox-c") {
+		t.Fatalf("unexpected filtered stdout %q", stdout)
+	}
+	if got := service.listReq.GetLabelSelector(); got["env"] != "dev" || got["team"] != "backend" {
+		t.Fatalf("unexpected list request selector: %#v", got)
+	}
+
+	stdout, stderr, exitCode = runCLIWithSandboxServer(t, service, "sandbox", "list", "--label", "env=qa")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	emptyLines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	if len(emptyLines) != 1 {
+		t.Fatalf("unexpected empty output: %#v", emptyLines)
+	}
+	if !strings.Contains(emptyLines[0], "SANDBOX ID") || !strings.Contains(emptyLines[0], "CREATED") || !strings.Contains(emptyLines[0], "STATUS") || !strings.Contains(emptyLines[0], "LABELS") || !strings.Contains(emptyLines[0], "ERROR") {
+		t.Fatalf("unexpected header line: %q", emptyLines[0])
+	}
+}
+
+func TestSandboxListJSON(t *testing.T) {
+	service := &fakeSandboxService{
+		listFn: func(_ context.Context, request *agboxv1.ListSandboxesRequest) (*agboxv1.ListSandboxesResponse, error) {
+			if request.GetIncludeDeleted() {
+				t.Fatal("include_deleted should be false")
+			}
+			return &agboxv1.ListSandboxesResponse{
+				Sandboxes: []*agboxv1.SandboxHandle{
+					{SandboxId: "sandbox-a", State: agboxv1.SandboxState_SANDBOX_STATE_READY},
+				},
+			}, nil
+		},
+	}
+
+	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "list", "--json")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "\n  \"sandboxes\"") {
+		t.Fatalf("JSON is not pretty-printed with proto names: %q", stdout)
+	}
+	var payload struct {
+		Sandboxes []map[string]any `json:"sandboxes"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v", err)
+	}
+	if len(payload.Sandboxes) != 1 {
+		t.Fatalf("unexpected sandboxes payload: %#v", payload.Sandboxes)
+	}
+
+	stdout, stderr, exitCode = runCLIWithSandboxServer(t, &fakeSandboxService{
+		listFn: func(_ context.Context, _ *agboxv1.ListSandboxesRequest) (*agboxv1.ListSandboxesResponse, error) {
+			return &agboxv1.ListSandboxesResponse{}, nil
+		},
+	}, "sandbox", "list", "--json")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v", err)
+	}
+	if len(payload.Sandboxes) != 0 {
+		t.Fatalf("unexpected empty payload: %#v", payload.Sandboxes)
+	}
+}
+
+func TestSandboxListIncludeDeleted(t *testing.T) {
+	service := &fakeSandboxService{
+		listFn: func(_ context.Context, request *agboxv1.ListSandboxesRequest) (*agboxv1.ListSandboxesResponse, error) {
+			if request.GetIncludeDeleted() {
+				return &agboxv1.ListSandboxesResponse{
+					Sandboxes: []*agboxv1.SandboxHandle{
+						{SandboxId: "sandbox-deleted", State: agboxv1.SandboxState_SANDBOX_STATE_DELETED},
+					},
+				}, nil
+			}
+			return &agboxv1.ListSandboxesResponse{
+				Sandboxes: []*agboxv1.SandboxHandle{
+					{SandboxId: "sandbox-ready", State: agboxv1.SandboxState_SANDBOX_STATE_READY},
+				},
+			}, nil
+		},
+	}
+
+	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "list")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if strings.Contains(stdout, "sandbox-deleted") {
+		t.Fatalf("deleted sandbox should not be listed by default: %q", stdout)
+	}
+
+	stdout, stderr, exitCode = runCLIWithSandboxServer(t, service, "sandbox", "list", "--include-deleted")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "sandbox-deleted") {
+		t.Fatalf("unexpected stdout %q", stdout)
+	}
+	if !service.listReq.GetIncludeDeleted() {
+		t.Fatal("include_deleted flag was not forwarded")
+	}
+}
+
+func TestSandboxGet(t *testing.T) {
+	service := &fakeSandboxService{
+		getFn: func(_ context.Context, request *agboxv1.GetSandboxRequest) (*agboxv1.GetSandboxResponse, error) {
+			if request.GetSandboxId() != "sandbox-123" {
+				t.Fatalf("unexpected sandbox id: %q", request.GetSandboxId())
+			}
+			return &agboxv1.GetSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:         "sandbox-123",
+					State:             agboxv1.SandboxState_SANDBOX_STATE_READY,
+					LastEventSequence: 7,
+					Labels:            map[string]string{"team": "backend", "env": "dev"},
+					CompanionContainers: []*agboxv1.CompanionContainerSpec{
+						{Name: "db", Image: "postgres:16"},
+						{Name: "cache", Image: "redis:7"},
+					},
+				},
+			}, nil
+		},
+	}
+
+	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "get", "sandbox-123")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	want := []string{
+		"sandbox_id=sandbox-123",
+		"state=Ready",
+		"image=",
+		"created_at=",
+		`labels={"env":"dev","team":"backend"}`,
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("unexpected line count: %v", lines)
+	}
+	for index, line := range lines {
+		if !strings.HasPrefix(line, want[index]) {
+			t.Fatalf("unexpected line %d: got %q want prefix %q", index, line, want[index])
+		}
+	}
+
+	service = &fakeSandboxService{
+		getFn: func(_ context.Context, request *agboxv1.GetSandboxRequest) (*agboxv1.GetSandboxResponse, error) {
+			if request.GetSandboxId() != "sandbox-empty" {
+				t.Fatalf("unexpected sandbox id: %q", request.GetSandboxId())
+			}
+			return &agboxv1.GetSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId: "sandbox-empty",
+					State:     agboxv1.SandboxState_SANDBOX_STATE_PENDING,
+				},
+			}, nil
+		},
+	}
+	stdout, stderr, exitCode = runCLIWithSandboxServer(t, service, "sandbox", "get", "sandbox-empty")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	lines = strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	want = []string{
+		"sandbox_id=sandbox-empty",
+		"state=Pending",
+		"image=",
+		"created_at=",
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("unexpected line count: %v", lines)
+	}
+	for index, line := range lines {
+		if !strings.HasPrefix(line, want[index]) {
+			t.Fatalf("unexpected line %d: got %q want prefix %q", index, line, want[index])
+		}
+	}
+}
+
+func TestSandboxGetFailed(t *testing.T) {
+	service := &fakeSandboxService{
+		getFn: func(_ context.Context, request *agboxv1.GetSandboxRequest) (*agboxv1.GetSandboxResponse, error) {
+			return &agboxv1.GetSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:    "sandbox-fail",
+					State:        agboxv1.SandboxState_SANDBOX_STATE_FAILED,
+					ErrorCode:    "CONTAINER_NOT_RUNNING",
+					ErrorMessage: "primary container not running",
+				},
+			}, nil
+		},
+	}
+	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "get", "sandbox-fail")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "error_code=CONTAINER_NOT_RUNNING") {
+		t.Fatalf("expected error_code in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "error_message=primary container not running") {
+		t.Fatalf("expected error_message in output, got %q", stdout)
+	}
+}
+
+func TestSandboxGetJSON(t *testing.T) {
+	service := &fakeSandboxService{
+		getFn: func(_ context.Context, request *agboxv1.GetSandboxRequest) (*agboxv1.GetSandboxResponse, error) {
+			if request.GetSandboxId() != "sandbox-123" {
+				t.Fatalf("unexpected sandbox id: %q", request.GetSandboxId())
+			}
+			return &agboxv1.GetSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:           "sandbox-123",
+					State:               agboxv1.SandboxState_SANDBOX_STATE_READY,
+					LastEventSequence:   7,
+					Labels:              map[string]string{"env": "dev"},
+					CompanionContainers: []*agboxv1.CompanionContainerSpec{},
+				},
+			}, nil
+		},
+	}
+
+	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "get", "sandbox-123", "--json")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "\n  \"sandbox\": {") {
+		t.Fatalf("JSON is not pretty-printed with proto names: %q", stdout)
+	}
+	var payload struct {
+		Sandbox map[string]any `json:"sandbox"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v", err)
+	}
+	for _, key := range []string{"sandbox_id", "state", "last_event_sequence", "labels", "companion_containers"} {
+		if _, ok := payload.Sandbox[key]; !ok {
+			t.Fatalf("missing field %q in JSON: %#v", key, payload.Sandbox)
+		}
+	}
+	if payload.Sandbox["sandbox_id"] != "sandbox-123" {
+		t.Fatalf("unexpected sandbox_id: %#v", payload.Sandbox["sandbox_id"])
+	}
+	if payload.Sandbox["state"] != "SANDBOX_STATE_READY" {
+		t.Fatalf("unexpected state: %#v", payload.Sandbox["state"])
+	}
+	if payload.Sandbox["last_event_sequence"] != "7" {
+		t.Fatalf("unexpected last_event_sequence: %#v", payload.Sandbox["last_event_sequence"])
+	}
+}
+
+func TestSandboxGetMissingSandboxID(t *testing.T) {
+	_, stderr, exitCode := runCLIWithSandboxServer(t, &fakeSandboxService{}, "sandbox", "get")
+	if exitCode != exitCodeUsageError {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stderr, "accepts 1 arg(s)") {
+		t.Fatalf("unexpected stderr %q", stderr)
+	}
+}
+
+func TestSandboxGetRejectsUnknownFlag(t *testing.T) {
+	_, stderr, exitCode := runCLIWithSandboxServer(t, &fakeSandboxService{}, "sandbox", "get", "--unknown")
+	if exitCode != exitCodeUsageError {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stderr, "unknown flag: --unknown") {
+		t.Fatalf("unexpected stderr %q", stderr)
+	}
+}

--- a/cmd/agbox/sandbox_test.go
+++ b/cmd/agbox/sandbox_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -316,336 +318,6 @@ func TestSandboxCreateBadLabel(t *testing.T) {
 	}
 }
 
-func TestSandboxList(t *testing.T) {
-	service := &fakeSandboxService{
-		listFn: func(_ context.Context, request *agboxv1.ListSandboxesRequest) (*agboxv1.ListSandboxesResponse, error) {
-			selector := request.GetLabelSelector()
-			switch {
-			case len(selector) == 0 && !request.GetIncludeDeleted():
-				return &agboxv1.ListSandboxesResponse{
-					Sandboxes: []*agboxv1.SandboxHandle{
-						{SandboxId: "sandbox-a", State: agboxv1.SandboxState_SANDBOX_STATE_READY, Labels: map[string]string{"team": "backend", "env": "dev"}},
-						{SandboxId: "sandbox-b", State: agboxv1.SandboxState_SANDBOX_STATE_PENDING, Labels: map[string]string{"team": "frontend", "env": "dev"}},
-						{SandboxId: "sandbox-c", State: agboxv1.SandboxState_SANDBOX_STATE_STOPPED, Labels: map[string]string{"team": "backend", "env": "prod"}},
-					},
-				}, nil
-			case len(selector) == 0 && request.GetIncludeDeleted():
-				return &agboxv1.ListSandboxesResponse{
-					Sandboxes: []*agboxv1.SandboxHandle{
-						{SandboxId: "sandbox-a", State: agboxv1.SandboxState_SANDBOX_STATE_READY, Labels: map[string]string{"team": "backend", "env": "dev"}},
-						{SandboxId: "sandbox-deleted", State: agboxv1.SandboxState_SANDBOX_STATE_DELETED, Labels: map[string]string{"team": "backend", "env": "archived"}},
-					},
-				}, nil
-			case selector["env"] == "dev" && selector["team"] == "backend":
-				return &agboxv1.ListSandboxesResponse{
-					Sandboxes: []*agboxv1.SandboxHandle{
-						{SandboxId: "sandbox-a", State: agboxv1.SandboxState_SANDBOX_STATE_READY, Labels: map[string]string{"team": "backend", "env": "dev"}},
-					},
-				}, nil
-			case selector["env"] == "qa":
-				return &agboxv1.ListSandboxesResponse{}, nil
-			default:
-				t.Fatalf("unexpected label selector: %#v", selector)
-				return nil, nil
-			}
-		},
-	}
-
-	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "list")
-	if exitCode != exitCodeSuccess {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
-	if len(lines) != 4 {
-		t.Fatalf("unexpected output lines: %#v", lines)
-	}
-	if !strings.Contains(lines[0], "SANDBOX ID") || !strings.Contains(lines[0], "CREATED") || !strings.Contains(lines[0], "STATUS") || !strings.Contains(lines[0], "LABELS") || !strings.Contains(lines[0], "ERROR") {
-		t.Fatalf("unexpected header line: %q", lines[0])
-	}
-	if !strings.Contains(stdout, "sandbox-a") || !strings.Contains(stdout, "sandbox-b") || !strings.Contains(stdout, "sandbox-c") {
-		t.Fatalf("unexpected stdout %q", stdout)
-	}
-	if !strings.Contains(stdout, "env=dev,team=backend") {
-		t.Fatalf("labels were not sorted in stdout %q", stdout)
-	}
-
-	stdout, stderr, exitCode = runCLIWithSandboxServer(t, service, "sandbox", "list", "--label", "env=dev", "--label", "team=backend")
-	if exitCode != exitCodeSuccess {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	if !strings.Contains(stdout, "sandbox-a") || strings.Contains(stdout, "sandbox-b") || strings.Contains(stdout, "sandbox-c") {
-		t.Fatalf("unexpected filtered stdout %q", stdout)
-	}
-	if got := service.listReq.GetLabelSelector(); got["env"] != "dev" || got["team"] != "backend" {
-		t.Fatalf("unexpected list request selector: %#v", got)
-	}
-
-	stdout, stderr, exitCode = runCLIWithSandboxServer(t, service, "sandbox", "list", "--label", "env=qa")
-	if exitCode != exitCodeSuccess {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	emptyLines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
-	if len(emptyLines) != 1 {
-		t.Fatalf("unexpected empty output: %#v", emptyLines)
-	}
-	if !strings.Contains(emptyLines[0], "SANDBOX ID") || !strings.Contains(emptyLines[0], "CREATED") || !strings.Contains(emptyLines[0], "STATUS") || !strings.Contains(emptyLines[0], "LABELS") || !strings.Contains(emptyLines[0], "ERROR") {
-		t.Fatalf("unexpected header line: %q", emptyLines[0])
-	}
-}
-
-func TestSandboxListJSON(t *testing.T) {
-	service := &fakeSandboxService{
-		listFn: func(_ context.Context, request *agboxv1.ListSandboxesRequest) (*agboxv1.ListSandboxesResponse, error) {
-			if request.GetIncludeDeleted() {
-				t.Fatal("include_deleted should be false")
-			}
-			return &agboxv1.ListSandboxesResponse{
-				Sandboxes: []*agboxv1.SandboxHandle{
-					{SandboxId: "sandbox-a", State: agboxv1.SandboxState_SANDBOX_STATE_READY},
-				},
-			}, nil
-		},
-	}
-
-	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "list", "--json")
-	if exitCode != exitCodeSuccess {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	if !strings.Contains(stdout, "\n  \"sandboxes\"") {
-		t.Fatalf("JSON is not pretty-printed with proto names: %q", stdout)
-	}
-	var payload struct {
-		Sandboxes []map[string]any `json:"sandboxes"`
-	}
-	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
-		t.Fatalf("stdout is not valid JSON: %v", err)
-	}
-	if len(payload.Sandboxes) != 1 {
-		t.Fatalf("unexpected sandboxes payload: %#v", payload.Sandboxes)
-	}
-
-	stdout, stderr, exitCode = runCLIWithSandboxServer(t, &fakeSandboxService{
-		listFn: func(_ context.Context, _ *agboxv1.ListSandboxesRequest) (*agboxv1.ListSandboxesResponse, error) {
-			return &agboxv1.ListSandboxesResponse{}, nil
-		},
-	}, "sandbox", "list", "--json")
-	if exitCode != exitCodeSuccess {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
-		t.Fatalf("stdout is not valid JSON: %v", err)
-	}
-	if len(payload.Sandboxes) != 0 {
-		t.Fatalf("unexpected empty payload: %#v", payload.Sandboxes)
-	}
-}
-
-func TestSandboxListIncludeDeleted(t *testing.T) {
-	service := &fakeSandboxService{
-		listFn: func(_ context.Context, request *agboxv1.ListSandboxesRequest) (*agboxv1.ListSandboxesResponse, error) {
-			if request.GetIncludeDeleted() {
-				return &agboxv1.ListSandboxesResponse{
-					Sandboxes: []*agboxv1.SandboxHandle{
-						{SandboxId: "sandbox-deleted", State: agboxv1.SandboxState_SANDBOX_STATE_DELETED},
-					},
-				}, nil
-			}
-			return &agboxv1.ListSandboxesResponse{
-				Sandboxes: []*agboxv1.SandboxHandle{
-					{SandboxId: "sandbox-ready", State: agboxv1.SandboxState_SANDBOX_STATE_READY},
-				},
-			}, nil
-		},
-	}
-
-	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "list")
-	if exitCode != exitCodeSuccess {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	if strings.Contains(stdout, "sandbox-deleted") {
-		t.Fatalf("deleted sandbox should not be listed by default: %q", stdout)
-	}
-
-	stdout, stderr, exitCode = runCLIWithSandboxServer(t, service, "sandbox", "list", "--include-deleted")
-	if exitCode != exitCodeSuccess {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	if !strings.Contains(stdout, "sandbox-deleted") {
-		t.Fatalf("unexpected stdout %q", stdout)
-	}
-	if !service.listReq.GetIncludeDeleted() {
-		t.Fatal("include_deleted flag was not forwarded")
-	}
-}
-
-func TestSandboxGet(t *testing.T) {
-	service := &fakeSandboxService{
-		getFn: func(_ context.Context, request *agboxv1.GetSandboxRequest) (*agboxv1.GetSandboxResponse, error) {
-			if request.GetSandboxId() != "sandbox-123" {
-				t.Fatalf("unexpected sandbox id: %q", request.GetSandboxId())
-			}
-			return &agboxv1.GetSandboxResponse{
-				Sandbox: &agboxv1.SandboxHandle{
-					SandboxId:         "sandbox-123",
-					State:             agboxv1.SandboxState_SANDBOX_STATE_READY,
-					LastEventSequence: 7,
-					Labels:            map[string]string{"team": "backend", "env": "dev"},
-					CompanionContainers: []*agboxv1.CompanionContainerSpec{
-						{Name: "db", Image: "postgres:16"},
-						{Name: "cache", Image: "redis:7"},
-					},
-				},
-			}, nil
-		},
-	}
-
-	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "get", "sandbox-123")
-	if exitCode != exitCodeSuccess {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
-	want := []string{
-		"sandbox_id=sandbox-123",
-		"state=Ready",
-		"image=",
-		"created_at=",
-		`labels={"env":"dev","team":"backend"}`,
-	}
-	if len(lines) != len(want) {
-		t.Fatalf("unexpected line count: %v", lines)
-	}
-	for index, line := range lines {
-		if !strings.HasPrefix(line, want[index]) {
-			t.Fatalf("unexpected line %d: got %q want prefix %q", index, line, want[index])
-		}
-	}
-
-	service = &fakeSandboxService{
-		getFn: func(_ context.Context, request *agboxv1.GetSandboxRequest) (*agboxv1.GetSandboxResponse, error) {
-			if request.GetSandboxId() != "sandbox-empty" {
-				t.Fatalf("unexpected sandbox id: %q", request.GetSandboxId())
-			}
-			return &agboxv1.GetSandboxResponse{
-				Sandbox: &agboxv1.SandboxHandle{
-					SandboxId: "sandbox-empty",
-					State:     agboxv1.SandboxState_SANDBOX_STATE_PENDING,
-				},
-			}, nil
-		},
-	}
-	stdout, stderr, exitCode = runCLIWithSandboxServer(t, service, "sandbox", "get", "sandbox-empty")
-	if exitCode != exitCodeSuccess {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	lines = strings.Split(strings.TrimRight(stdout, "\n"), "\n")
-	want = []string{
-		"sandbox_id=sandbox-empty",
-		"state=Pending",
-		"image=",
-		"created_at=",
-	}
-	if len(lines) != len(want) {
-		t.Fatalf("unexpected line count: %v", lines)
-	}
-	for index, line := range lines {
-		if !strings.HasPrefix(line, want[index]) {
-			t.Fatalf("unexpected line %d: got %q want prefix %q", index, line, want[index])
-		}
-	}
-}
-
-func TestSandboxGetFailed(t *testing.T) {
-	service := &fakeSandboxService{
-		getFn: func(_ context.Context, request *agboxv1.GetSandboxRequest) (*agboxv1.GetSandboxResponse, error) {
-			return &agboxv1.GetSandboxResponse{
-				Sandbox: &agboxv1.SandboxHandle{
-					SandboxId:    "sandbox-fail",
-					State:        agboxv1.SandboxState_SANDBOX_STATE_FAILED,
-					ErrorCode:    "CONTAINER_NOT_RUNNING",
-					ErrorMessage: "primary container not running",
-				},
-			}, nil
-		},
-	}
-	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "get", "sandbox-fail")
-	if exitCode != exitCodeSuccess {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	if !strings.Contains(stdout, "error_code=CONTAINER_NOT_RUNNING") {
-		t.Fatalf("expected error_code in output, got %q", stdout)
-	}
-	if !strings.Contains(stdout, "error_message=primary container not running") {
-		t.Fatalf("expected error_message in output, got %q", stdout)
-	}
-}
-
-func TestSandboxGetJSON(t *testing.T) {
-	service := &fakeSandboxService{
-		getFn: func(_ context.Context, request *agboxv1.GetSandboxRequest) (*agboxv1.GetSandboxResponse, error) {
-			if request.GetSandboxId() != "sandbox-123" {
-				t.Fatalf("unexpected sandbox id: %q", request.GetSandboxId())
-			}
-			return &agboxv1.GetSandboxResponse{
-				Sandbox: &agboxv1.SandboxHandle{
-					SandboxId:           "sandbox-123",
-					State:               agboxv1.SandboxState_SANDBOX_STATE_READY,
-					LastEventSequence:   7,
-					Labels:              map[string]string{"env": "dev"},
-					CompanionContainers: []*agboxv1.CompanionContainerSpec{},
-				},
-			}, nil
-		},
-	}
-
-	stdout, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "get", "sandbox-123", "--json")
-	if exitCode != exitCodeSuccess {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	if !strings.Contains(stdout, "\n  \"sandbox\": {") {
-		t.Fatalf("JSON is not pretty-printed with proto names: %q", stdout)
-	}
-	var payload struct {
-		Sandbox map[string]any `json:"sandbox"`
-	}
-	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
-		t.Fatalf("stdout is not valid JSON: %v", err)
-	}
-	for _, key := range []string{"sandbox_id", "state", "last_event_sequence", "labels", "companion_containers"} {
-		if _, ok := payload.Sandbox[key]; !ok {
-			t.Fatalf("missing field %q in JSON: %#v", key, payload.Sandbox)
-		}
-	}
-	if payload.Sandbox["sandbox_id"] != "sandbox-123" {
-		t.Fatalf("unexpected sandbox_id: %#v", payload.Sandbox["sandbox_id"])
-	}
-	if payload.Sandbox["state"] != "SANDBOX_STATE_READY" {
-		t.Fatalf("unexpected state: %#v", payload.Sandbox["state"])
-	}
-	if payload.Sandbox["last_event_sequence"] != "7" {
-		t.Fatalf("unexpected last_event_sequence: %#v", payload.Sandbox["last_event_sequence"])
-	}
-}
-
-func TestSandboxGetMissingSandboxID(t *testing.T) {
-	_, stderr, exitCode := runCLIWithSandboxServer(t, &fakeSandboxService{}, "sandbox", "get")
-	if exitCode != exitCodeUsageError {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	if !strings.Contains(stderr, "accepts 1 arg(s)") {
-		t.Fatalf("unexpected stderr %q", stderr)
-	}
-}
-
-func TestSandboxGetRejectsUnknownFlag(t *testing.T) {
-	_, stderr, exitCode := runCLIWithSandboxServer(t, &fakeSandboxService{}, "sandbox", "get", "--unknown")
-	if exitCode != exitCodeUsageError {
-		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
-	}
-	if !strings.Contains(stderr, "unknown flag: --unknown") {
-		t.Fatalf("unexpected stderr %q", stderr)
-	}
-}
-
 func TestSandboxCreateIdleTTL(t *testing.T) {
 	t.Parallel()
 
@@ -745,6 +417,163 @@ func withCreateWaitMocks(service *fakeSandboxService, sandboxID string) {
 		service.subscribeEventsPayload = []*agboxv1.SandboxEvent{
 			{SandboxId: sandboxID, Sequence: 2, SandboxState: agboxv1.SandboxState_SANDBOX_STATE_READY},
 		}
+	}
+}
+
+func TestSandboxCreateWithYAMLFile(t *testing.T) {
+	yamlContent := []byte("runtime:\n  image: my-image:latest\n")
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(yamlPath, yamlContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	service := &fakeSandboxService{
+		createFn: func(_ context.Context, request *agboxv1.CreateSandboxRequest) (*agboxv1.CreateSandboxResponse, error) {
+			return &agboxv1.CreateSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:         "sandbox-yaml",
+					State:             agboxv1.SandboxState_SANDBOX_STATE_PENDING,
+					LastEventSequence: 1,
+				},
+			}, nil
+		},
+	}
+	withCreateWaitMocks(service, "sandbox-yaml")
+
+	_, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "create", "--yaml-file", yamlPath)
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if string(service.createReq.GetConfigYaml()) != string(yamlContent) {
+		t.Fatalf("expected config yaml %q, got %q", yamlContent, service.createReq.GetConfigYaml())
+	}
+	if service.createReq.GetCreateSpec().GetImage() != "" {
+		t.Fatalf("expected empty image when --yaml-file is used without --image, got %q", service.createReq.GetCreateSpec().GetImage())
+	}
+}
+
+func TestSandboxCreateWithYAMLFileAndImageOverride(t *testing.T) {
+	yamlContent := []byte("runtime:\n  image: default-image:latest\n")
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(yamlPath, yamlContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	service := &fakeSandboxService{
+		createFn: func(_ context.Context, request *agboxv1.CreateSandboxRequest) (*agboxv1.CreateSandboxResponse, error) {
+			return &agboxv1.CreateSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:         "sandbox-yaml-img",
+					State:             agboxv1.SandboxState_SANDBOX_STATE_PENDING,
+					LastEventSequence: 1,
+				},
+			}, nil
+		},
+	}
+	withCreateWaitMocks(service, "sandbox-yaml-img")
+
+	_, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "create", "--yaml-file", yamlPath, "--image", "custom:latest")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if string(service.createReq.GetConfigYaml()) != string(yamlContent) {
+		t.Fatalf("expected config yaml %q, got %q", yamlContent, service.createReq.GetConfigYaml())
+	}
+	if service.createReq.GetCreateSpec().GetImage() != "custom:latest" {
+		t.Fatalf("expected image %q, got %q", "custom:latest", service.createReq.GetCreateSpec().GetImage())
+	}
+}
+
+func TestSandboxCreateYAMLFileNotFound(t *testing.T) {
+	_, stderr, exitCode := runCLIWithSandboxServer(t, &fakeSandboxService{}, "sandbox", "create", "--yaml-file", "/nonexistent/path.yaml")
+	if exitCode != exitCodeRuntimeError {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stderr, "/nonexistent/path.yaml") {
+		t.Fatalf("expected file path in stderr, got %q", stderr)
+	}
+}
+
+func TestSandboxCreateWithYAMLFileNoLabelNoIdleTTL(t *testing.T) {
+	yamlContent := []byte("runtime:\n  idle_ttl: 30m\nlabels:\n  env: prod\n")
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(yamlPath, yamlContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	service := &fakeSandboxService{
+		createFn: func(_ context.Context, request *agboxv1.CreateSandboxRequest) (*agboxv1.CreateSandboxResponse, error) {
+			return &agboxv1.CreateSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:         "sandbox-yaml-defaults",
+					State:             agboxv1.SandboxState_SANDBOX_STATE_PENDING,
+					LastEventSequence: 1,
+				},
+			}, nil
+		},
+	}
+	withCreateWaitMocks(service, "sandbox-yaml-defaults")
+
+	_, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "create", "--yaml-file", yamlPath)
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	// Without explicit --label, labels should be empty (not override YAML labels).
+	if len(service.createReq.GetCreateSpec().GetLabels()) != 0 {
+		t.Fatalf("expected empty labels when --label not set, got %v", service.createReq.GetCreateSpec().GetLabels())
+	}
+	// Without explicit --idle-ttl, IdleTtl should be nil (not override YAML idle_ttl).
+	if service.createReq.GetCreateSpec().GetIdleTtl() != nil {
+		t.Fatalf("expected nil idle_ttl when --idle-ttl not set, got %v", service.createReq.GetCreateSpec().GetIdleTtl())
+	}
+}
+
+func TestSandboxCreateWithSandboxID(t *testing.T) {
+	service := &fakeSandboxService{
+		createFn: func(_ context.Context, request *agboxv1.CreateSandboxRequest) (*agboxv1.CreateSandboxResponse, error) {
+			return &agboxv1.CreateSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:         "my-sandbox",
+					State:             agboxv1.SandboxState_SANDBOX_STATE_PENDING,
+					LastEventSequence: 1,
+				},
+			}, nil
+		},
+	}
+	withCreateWaitMocks(service, "my-sandbox")
+
+	_, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "create", "--sandbox-id", "my-sandbox")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if service.createReq.GetSandboxId() != "my-sandbox" {
+		t.Fatalf("expected sandbox id %q, got %q", "my-sandbox", service.createReq.GetSandboxId())
+	}
+}
+
+func TestSandboxCreateWithEmptySandboxID(t *testing.T) {
+	service := &fakeSandboxService{
+		createFn: func(_ context.Context, request *agboxv1.CreateSandboxRequest) (*agboxv1.CreateSandboxResponse, error) {
+			return &agboxv1.CreateSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:         "auto-generated-id",
+					State:             agboxv1.SandboxState_SANDBOX_STATE_PENDING,
+					LastEventSequence: 1,
+				},
+			}, nil
+		},
+	}
+	withCreateWaitMocks(service, "auto-generated-id")
+
+	_, stderr, exitCode := runCLIWithSandboxServer(t, service, "sandbox", "create", "--sandbox-id", "")
+	if exitCode != exitCodeSuccess {
+		t.Fatalf("unexpected exit code %d stderr=%q", exitCode, stderr)
+	}
+	if service.createReq.GetSandboxId() != "" {
+		t.Fatalf("expected empty sandbox id, got %q", service.createReq.GetSandboxId())
 	}
 }
 

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -47,6 +47,7 @@ The northbound API may override only a narrow subset of behavior:
 | Generic mounts | Yes | Each sandbox may bind explicit host paths to explicit container targets. `source` and `target` support `~` prefix: `source` expands to the host user's home directory; `target` expands to the container user's home directory. `~username` syntax is not supported. |
 | Generic copies | Yes | Each sandbox may copy explicit host files or trees into explicit container targets. `source` and `target` support `~` prefix: `source` expands to the host user's home directory; `target` expands to the container user's home directory. `~username` syntax is not supported. |
 | Built-in resources | Yes | Each sandbox may request daemon-defined resource shortcuts such as `claude`, `codex`, `git`, `uv`, `npm`, or `apt` |
+| Caller-provided `config_yaml` | Yes | Inline YAML configuration; when provided, field-level values from `CreateSpec` override the YAML (RFC 7396 merge semantics) |
 | Caller-provided `sandbox_id` | Yes | If omitted, the daemon reserves a UUID v4 before accepting the request |
 | Caller-provided `exec_id` | Yes | If omitted, the daemon reserves a UUID v4 before accepting the request |
 | `companion_containers` | Yes | Each sandbox declares companion containers started concurrently with the primary container |


### PR DESCRIPTION
## Summary

- Add `--yaml-file <path>` flag to `agbox sandbox create` that reads a YAML configuration file and passes its content as `config_yaml` in the CreateSandboxRequest
- Add `--sandbox-id <id>` flag to allow callers to specify a sandbox ID
- When `--yaml-file` is used without explicit `--image`, the default image is cleared to prevent overriding YAML config
- Empty `--sandbox-id` is treated as unset (proto3 zero-value semantics)
- Document `config_yaml` in the Request-Time Overrides table of configuration_reference.md

## Test plan

- [x] `TestSandboxCreateWithYAMLFile` — YAML-only create, image cleared
- [x] `TestSandboxCreateWithYAMLFileAndImageOverride` — YAML + explicit --image
- [x] `TestSandboxCreateYAMLFileNotFound` — file not found error
- [x] `TestSandboxCreateWithYAMLFileNoLabelNoIdleTTL` — labels/idle-ttl don't override YAML
- [x] `TestSandboxCreateWithSandboxID` — sandbox ID passed through
- [x] `TestSandboxCreateWithEmptySandboxID` — empty string treated as unset
- [x] All existing tests continue to pass

Close #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
