### PR TITLE
[ISSUE-171] Set Docker RestartPolicy=unless-stopped on sandbox containers

### DIFF
--- a/docs/sandbox_container_lifecycle.md
+++ b/docs/sandbox_container_lifecycle.md
@@ -130,6 +130,7 @@ flowchart LR
 - Cleanup uses structured Docker Engine API calls with idempotent not-found handling.
 - STOPPED sandboxes that have exceeded `runtime.cleanup_ttl` are automatically deleted by the `cleanupLoop`: Docker resources are removed and the sandbox record is purged from the database.
 - After `SANDBOX_DELETED`, the daemon retains the event stream for `runtime.cleanup_ttl` before removing retained history.
+- Containers are created with Docker `RestartPolicy=unless-stopped`, so previously-running sandboxes come back automatically after a host or Docker daemon restart, while sandboxes stopped via `agbox sandbox stop` remain stopped until `ResumeSandbox`.
 
 ## Reconciliation
 

--- a/internal/control/docker_runtime_dockerapi.go
+++ b/internal/control/docker_runtime_dockerapi.go
@@ -163,6 +163,11 @@ func (backend *dockerRuntimeBackend) dockerContainerCreate(ctx context.Context, 
 		// This is a DNS-layer best-effort control; Linux host isolation is
 		// enforced separately via nftables on the sandbox network.
 		ExtraHosts: append([]string(nil), macOSBlockedHostAliases...),
+		// Auto-recover containers after host reboot or Docker daemon restart.
+		// Explicit `docker stop` (e.g. via agbox sandbox stop) is still honored:
+		// "unless-stopped" only skips restart for containers that were in the
+		// stopped state, so stopped sandboxes stay stopped across reboots.
+		RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 	}
 	var networkingConfig *network.NetworkingConfig
 	if spec.NetworkName != "" {

--- a/internal/control/docker_runtime_restart_policy_test.go
+++ b/internal/control/docker_runtime_restart_policy_test.go
@@ -1,0 +1,115 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+)
+
+// TestDockerRestartPolicyUnlessStopped verifies that both primary and companion
+// containers are created with RestartPolicy=unless-stopped so Docker auto-recovers
+// them after host reboot / daemon restart while still honoring explicit stop.
+func TestDockerRestartPolicyUnlessStopped(t *testing.T) {
+	sandboxID := "restart-policy"
+	networkName := dockerNetworkName(sandboxID)
+	companionContainerName := dockerCompanionContainerName(sandboxID, "db")
+	primaryContainerName := dockerPrimaryContainerName(sandboxID)
+
+	var mu sync.Mutex
+	restartPolicies := make(map[string]container.RestartPolicy)
+	backend := newDockerRuntimeBackendForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/v1.44")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/images/") && strings.HasSuffix(path, "/json"):
+			writeDockerJSON(t, w, map[string]string{"Id": "sha256:test"})
+		case r.Method == http.MethodPost && path == "/networks/create":
+			writeDockerJSON(t, w, map[string]string{"Id": "network-1"})
+		case r.Method == http.MethodGet && path == "/networks/"+networkName:
+			writeDockerJSON(t, w, network.Inspect{
+				ID: "abc123def456",
+				IPAM: network.IPAM{
+					Config: []network.IPAMConfig{
+						{Subnet: "172.18.0.0/16", Gateway: "172.18.0.1"},
+					},
+				},
+				Options: map[string]string{
+					"com.docker.network.bridge.name": "br-abc123def456",
+				},
+			})
+		case r.Method == http.MethodPost && path == "/containers/create":
+			var request struct {
+				HostConfig struct {
+					RestartPolicy container.RestartPolicy `json:"RestartPolicy"`
+				} `json:"HostConfig"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode container create request failed: %v", err)
+			}
+			name := r.URL.Query().Get("name")
+			mu.Lock()
+			restartPolicies[name] = request.HostConfig.RestartPolicy
+			mu.Unlock()
+			writeDockerJSON(t, w, map[string]string{"Id": name})
+		case r.Method == http.MethodPost && strings.HasPrefix(path, "/containers/") && strings.HasSuffix(path, "/start"):
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && path == "/containers/"+companionContainerName+"/json":
+			writeDockerJSON(t, w, container.InspectResponse{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					State: &container.State{
+						Running: true,
+						Status:  "running",
+						Health:  &container.Health{Status: "healthy"},
+					},
+				},
+			})
+		case r.Method == http.MethodGet && path == "/containers/"+primaryContainerName+"/json":
+			writeDockerJSON(t, w, container.InspectResponse{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					State: &container.State{Running: true, Status: "running"},
+				},
+			})
+		default:
+			t.Fatalf("unexpected Docker API request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	if _, err := backend.CreateSandbox(context.Background(), &sandboxRecord{
+		handle: &agboxv1.SandboxHandle{SandboxId: sandboxID},
+		createSpec: &agboxv1.CreateSpec{
+			Image: "ghcr.io/agents-sandbox/coding-runtime:test",
+		},
+		companionContainers: []*agboxv1.CompanionContainerSpec{
+			{
+				Name:  "db",
+				Image: "postgres:16",
+				Healthcheck: &agboxv1.HealthcheckConfig{
+					Test: []string{"CMD", "true"},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateSandbox failed: %v", err)
+	}
+
+	want := container.RestartPolicy{Name: container.RestartPolicyUnlessStopped}
+	for _, name := range []string{primaryContainerName, companionContainerName} {
+		mu.Lock()
+		got, ok := restartPolicies[name]
+		mu.Unlock()
+		if !ok {
+			t.Fatalf("container %s: no RestartPolicy captured", name)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("container %s: unexpected RestartPolicy: got=%+v want=%+v", name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Set Docker `RestartPolicy=unless-stopped` on `HostConfig` in the single `dockerContainerCreate` code path, which is shared by both primary and companion containers. Docker brings containers back after a host reboot or Docker daemon restart, while explicit `agbox sandbox stop` is still honored (stopped containers stay stopped across reboots).
- Add `TestDockerRestartPolicyUnlessStopped` that intercepts `/containers/create` via a mock Docker HTTP server and asserts `HostConfig.RestartPolicy.Name == "unless-stopped"` for both a primary container and a companion container.
- Align lifecycle docs: the create-path rule in `docs/sandbox_container_lifecycle.md` no longer claims companions are never restarted, and the companion startup rules in `docs/container_dependency_strategy.md` point to the new `Host Reboot and Docker Daemon Restart` section.

Close #171

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/control/... -count=1 -timeout=180s`
- [x] Negative verification: before the code change, the new test fails with `unexpected RestartPolicy: got={Name:} want={Name:unless-stopped}`; after the change it passes.
- [x] L2 live verification via `docker inspect` on a real container created with `--restart unless-stopped` shows `RestartPolicy = {Name: unless-stopped, MaximumRetryCount: 0}`.
- [ ] L3 (human-only): real host reboot — both "previously running" sandboxes resume automatically, and sandboxes stopped via `agbox sandbox stop` remain stopped across the reboot.
