### PR TITLE
[ISSUE-177] images: add paseo-runtime image

### DIFF
--- a/.github/workflows/publish-paseo-runtime.yml
+++ b/.github/workflows/publish-paseo-runtime.yml
@@ -1,0 +1,71 @@
+name: Publish Paseo Runtime
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version to publish, for example 1.2.3 or v1.2.3
+        required: true
+        type: string
+  push:
+    tags:
+      - "image-paseo-v*"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/agents-sandbox/paseo-runtime
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          set -e
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            raw_version="${GITHUB_REF_NAME}"
+          else
+            raw_version="${{ inputs.version }}"
+          fi
+
+          version="${raw_version#image-paseo-v}"
+          version="${version#v}"
+          if [ -z "${version}" ]; then
+            echo "Release version cannot be empty." >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push paseo runtime
+        uses: docker/build-push-action@v6
+        with:
+          context: images/paseo-runtime
+          file: images/paseo-runtime/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.IMAGE_NAME }}:latest

--- a/images/paseo-runtime/Dockerfile
+++ b/images/paseo-runtime/Dockerfile
@@ -1,0 +1,50 @@
+FROM ghcr.io/agents-sandbox/coding-runtime:latest
+
+# Extra CLI tools useful in a long-lived dev sandbox.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        vim less tree jq procps \
+        iproute2 net-tools htop tmux \
+        zsh fzf \
+    && rm -rf /var/lib/apt/lists/*
+
+# Atuin: SQLite-backed shell history with fuzzy search. Install the static
+# binary system-wide so every user picks it up from PATH.
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) atuin_arch=x86_64-unknown-linux-musl ;; \
+        arm64) atuin_arch=aarch64-unknown-linux-musl ;; \
+        *) echo "unsupported arch ${TARGETARCH}"; exit 1 ;; \
+    esac; \
+    atuin_url="https://github.com/atuinsh/atuin/releases/latest/download/atuin-${atuin_arch}.tar.gz"; \
+    curl -fsSL "${atuin_url}" -o /tmp/atuin.tgz; \
+    tar -xzf /tmp/atuin.tgz -C /tmp; \
+    mv /tmp/atuin-${atuin_arch}/atuin /usr/local/bin/atuin; \
+    chmod +x /usr/local/bin/atuin; \
+    rm -rf /tmp/atuin.tgz /tmp/atuin-${atuin_arch}
+
+# oh-my-zsh + plugins, seeded into /etc/skel. The runtime entrypoint creates
+# the agbox user with `useradd -m`, which copies /etc/skel/* into its home.
+RUN git clone --depth=1 https://github.com/ohmyzsh/ohmyzsh.git /etc/skel/.oh-my-zsh \
+    && git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions \
+        /etc/skel/.oh-my-zsh/custom/plugins/zsh-autosuggestions \
+    && git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting \
+        /etc/skel/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting \
+    && cp /etc/skel/.oh-my-zsh/templates/zshrc.zsh-template /etc/skel/.zshrc \
+    && sed -i 's|^plugins=.*|plugins=(git docker zsh-autosuggestions zsh-syntax-highlighting)|' \
+        /etc/skel/.zshrc \
+    && printf '\n# atuin: replace Ctrl-R and Up-arrow with the full-screen search UI\neval "$(atuin init zsh)"\n' \
+        >> /etc/skel/.zshrc
+
+# Agent CLIs on top of claude-code / codex already present in the base image.
+RUN npm install -g opencode-ai @getpaseo/cli
+
+# Seed a quickstart README into new user homes via /etc/skel.
+COPY skel/quickstart /etc/skel/quickstart
+
+# Override the base entrypoint to create agbox with zsh as its default shell
+# and to sync oh-my-zsh assets into an existing agbox home (volume-reused case).
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["/bin/zsh"]

--- a/images/paseo-runtime/entrypoint.sh
+++ b/images/paseo-runtime/entrypoint.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Usage:
+#   Build this image and run it through agents-sandbox or Docker with HOST_UID
+#   and HOST_GID set.
+#
+# Required env vars:
+#   HOST_UID
+#   HOST_GID
+#
+# Creates a non-root agbox user with zsh as the default shell, grants
+# passwordless sudo, and seeds oh-my-zsh into the user home when missing.
+set -e
+
+if [ -z "$HOST_UID" ] || [ -z "$HOST_GID" ]; then
+    echo "ERROR: HOST_UID and HOST_GID must be set" >&2
+    exit 1
+fi
+
+USERNAME="agbox"
+USER_HOME="/home/agbox"
+USER_SHELL="/bin/zsh"
+
+if ! getent group "$HOST_GID" >/dev/null 2>&1; then
+    groupadd -g "$HOST_GID" "$USERNAME"
+fi
+
+if ! getent passwd "$HOST_UID" >/dev/null 2>&1; then
+    useradd -m -s "$USER_SHELL" -u "$HOST_UID" -g "$HOST_GID" -d "$USER_HOME" "$USERNAME"
+else
+    EXISTING_USER=$(getent passwd "$HOST_UID" | cut -d: -f1)
+    if [ "$EXISTING_USER" != "$USERNAME" ]; then
+        usermod -l "$USERNAME" "$EXISTING_USER" 2>/dev/null || true
+        EXISTING_USER="$USERNAME"
+    fi
+    if [ "$(getent passwd "$HOST_UID" | cut -d: -f6)" != "$USER_HOME" ]; then
+        usermod -d "$USER_HOME" -m "$EXISTING_USER" 2>/dev/null || true
+    fi
+    usermod -s "$USER_SHELL" "$EXISTING_USER" 2>/dev/null || true
+    USERNAME="$EXISTING_USER"
+fi
+
+mkdir -p "$USER_HOME"
+chown "$HOST_UID:$HOST_GID" "$USER_HOME" /workspace
+echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/runtime-user
+chmod 440 /etc/sudoers.d/runtime-user
+
+# Seed oh-my-zsh for users whose home was created before this image (volume reuse).
+if [ ! -d "$USER_HOME/.oh-my-zsh" ] && [ -d /etc/skel/.oh-my-zsh ]; then
+    cp -r /etc/skel/.oh-my-zsh "$USER_HOME/.oh-my-zsh"
+    chown -R "$HOST_UID:$HOST_GID" "$USER_HOME/.oh-my-zsh"
+fi
+if [ ! -f "$USER_HOME/.zshrc" ] && [ -f /etc/skel/.zshrc ]; then
+    cp /etc/skel/.zshrc "$USER_HOME/.zshrc"
+    chown "$HOST_UID:$HOST_GID" "$USER_HOME/.zshrc"
+fi
+if [ ! -d "$USER_HOME/quickstart" ] && [ -d /etc/skel/quickstart ]; then
+    cp -r /etc/skel/quickstart "$USER_HOME/quickstart"
+    chown -R "$HOST_UID:$HOST_GID" "$USER_HOME/quickstart"
+fi
+
+for dir in "$USER_HOME/.claude" "$USER_HOME/.codex" "$USER_HOME/.agents" "$USER_HOME/.cache" "$USER_HOME/.npm" "$USER_HOME/.config" "$USER_HOME/.local" "$USER_HOME/.local/share"; do
+    if [ -d "$dir" ]; then
+        chown "$HOST_UID:$HOST_GID" "$dir" 2>/dev/null || true
+    fi
+done
+
+export HOME="$USER_HOME"
+export USER="$USERNAME"
+export SHELL="$USER_SHELL"
+
+if [ -S "/ssh-agent" ]; then
+    chmod 666 /ssh-agent
+fi
+
+exec gosu "$HOST_UID:$HOST_GID" "$@"

--- a/images/paseo-runtime/skel/quickstart/README.md
+++ b/images/paseo-runtime/skel/quickstart/README.md
@@ -1,0 +1,55 @@
+# Quickstart
+
+This sandbox is the result of combining two projects:
+
+- **agents-sandbox** — provides the isolated container, the `agbox` user, mounts, and the tool capabilities (`claude`, `codex`, `npm`, `uv`, `apt`).
+- **paseo** — provides the in-browser UI. The paseo daemon runs as this container's main process and relays through `app.paseo.sh`.
+
+You don't need to start anything manually. The daemon is already running on `0.0.0.0:6767` inside the container.
+
+## Open the web UI
+
+Run this on the host that manages your sandbox (not inside the container):
+
+```
+paseo-stack url <your-name>
+```
+
+Open the printed `https://app.paseo.sh/#offer=...` link in a browser. The relay bridges your browser to the in-container daemon — no host ports are published.
+
+## Agent CLIs available inside
+
+- `claude`  — Claude Code
+- `codex`   — OpenAI Codex CLI
+- `opencode`
+- `paseo`
+
+Example:
+
+```
+claude
+codex
+opencode
+paseo --help
+```
+
+## Shell
+
+Default shell is `zsh` with oh-my-zsh (`git`, `docker`, `zsh-autosuggestions`, `zsh-syntax-highlighting` plugins). Shell history is backed by `atuin` — press `Ctrl-R` for fuzzy search.
+
+## Where things live
+
+- `~/.paseo/`  — paseo daemon state (persisted via a host mount).
+- `~/.claude/`, `~/.codex/`, `~/.agents/`, `~/.npm/`  — per-tool state, mounted from the host so it survives container restarts.
+- `/workspace` — working directory, mounted from the host.
+
+## Upgrading the agent CLIs
+
+All four CLIs are baked into the image. To pick up a newer version without rebuilding the image:
+
+```
+npm install -g @anthropic-ai/claude-code
+npm install -g @openai/codex
+npm install -g opencode-ai
+npm install -g @getpaseo/cli
+```


### PR DESCRIPTION
## Summary

- Add `images/paseo-runtime/` — a new image layering agent CLIs (`opencode-ai`, `@getpaseo/cli`) and common dev sandbox tooling on top of `coding-runtime:latest`.
- Ship a dedicated `entrypoint.sh` that sets `zsh` as the default shell for `agbox`, exports `SHELL=/bin/zsh`, and seeds `~/.oh-my-zsh` / `~/.zshrc` for volume-reused homes. Passwordless sudo is preserved from the base logic.
- Add `.github/workflows/publish-paseo-runtime.yml` mirroring the coding-runtime pipeline: triggered by `image-paseo-v*` tags or manual dispatch, publishes `ghcr.io/agents-sandbox/paseo-runtime` (`linux/amd64`, `linux/arm64`).

## What's included

Extra apt packages: `vim less tree jq procps iproute2 net-tools htop tmux zsh fzf`.

Shell experience: Atuin (history) + oh-my-zsh with plugins `git docker zsh-autosuggestions zsh-syntax-highlighting` seeded into `/etc/skel` and copied into existing agbox homes at startup.

Agent CLIs: `opencode-ai` and `@getpaseo/cli` installed globally via npm on top of the base image's `claude-code` / `codex`.

## Image size

| Image | Size |
| --- | --- |
| `coding-runtime:latest` | 788 MB |
| `paseo-runtime:latest` (this PR) | 3.01 GB |

The bulk of the delta is the two new npm packages.

## Test plan

- [x] `docker build -t ghcr.io/agents-sandbox/paseo-runtime:latest images/paseo-runtime` succeeds.
- [x] `docker run -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) ghcr.io/agents-sandbox/paseo-runtime:latest ...` creates `agbox` with `/bin/zsh`, `SHELL=/bin/zsh`, passwordless sudo, and a usable oh-my-zsh (tested `ll`, `sudo -n whoami`, `which paseo opencode claude codex`).
- [x] First-run (new home) and volume-reuse (pre-existing `/home/agbox`) both land with a working `~/.oh-my-zsh` and `~/.zshrc`.

Closes #177
