### PR TITLE
[ISSUE-185] Add OpenCode as a built-in tooling capability with XDG mounts

### DIFF
--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -46,7 +46,7 @@ The northbound API may override only a narrow subset of behavior:
 | Primary sandbox image | Yes | Every sandbox request must provide its own runtime image; this is not a daemon config default |
 | Generic mounts | Yes | Each sandbox may bind explicit host paths to explicit container targets. `source` and `target` support `~` prefix: `source` expands to the host user's home directory; `target` expands to the container user's home directory. `~username` syntax is not supported. |
 | Generic copies | Yes | Each sandbox may copy explicit host files or trees into explicit container targets. `source` and `target` support `~` prefix: `source` expands to the host user's home directory; `target` expands to the container user's home directory. `~username` syntax is not supported. |
-| Built-in resources | Yes | Each sandbox may request daemon-defined resource shortcuts such as `claude`, `codex`, `git`, `uv`, `npm`, or `apt` |
+| Built-in resources | Yes | Each sandbox may request daemon-defined resource shortcuts such as `claude`, `codex`, `opencode`, `git`, `uv`, `npm`, or `apt` |
 | Caller-provided `config_yaml` | Yes | Inline YAML configuration; when provided, field-level values from `CreateSpec` override the YAML (RFC 7396 merge semantics) |
 | Caller-provided `sandbox_id` | Yes | If omitted, the daemon reserves a UUID v4 before accepting the request |
 | Caller-provided `exec_id` | Yes | If omitted, the daemon reserves a UUID v4 before accepting the request |

--- a/internal/control/service_create_validation_test.go
+++ b/internal/control/service_create_validation_test.go
@@ -578,6 +578,31 @@ func TestCreateSandboxRejectsUnknownBuiltinToolsBeforeRuntime(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxAcceptsOpenCodeBuiltinTool(t *testing.T) {
+	runtime := &capturingRuntimeBackend{}
+	client := newBufconnClient(t, ServiceConfig{
+		TransitionDelay: 5 * time.Millisecond,
+		PollInterval:    2 * time.Millisecond,
+		runtimeBackend:  runtime,
+	})
+
+	createResp, err := client.CreateSandbox(context.Background(), &agboxv1.CreateSandboxRequest{
+		SandboxId: "session-opencode-builtin",
+		CreateSpec: &agboxv1.CreateSpec{
+			Image:        "ghcr.io/agents-sandbox/coding-runtime:test",
+			BuiltinTools: []string{"opencode"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox with opencode builtin tool failed: %v", err)
+	}
+	waitForSandboxState(t, client, createResp.GetSandbox().GetSandboxId(), agboxv1.SandboxState_SANDBOX_STATE_READY)
+
+	if got := runtime.lastCreateSpec.GetBuiltinTools(); len(got) != 1 || got[0] != "opencode" {
+		t.Fatalf("unexpected builtin tools passed to runtime: %v", got)
+	}
+}
+
 func TestCreateSandboxRejectsInvalidCompanionContainerSpecsBeforeRuntime(t *testing.T) {
 	runtime := &capturingRuntimeBackend{}
 	client := newBufconnClient(t, ServiceConfig{

--- a/internal/profile/capabilities.go
+++ b/internal/profile/capabilities.go
@@ -22,30 +22,33 @@ const ContainerUserHome = "/home/agbox"
 type MountID string
 
 const (
-	MountIDClaude        MountID = ".claude"
-	MountIDClaudeJSON    MountID = ".claude.json"
-	MountIDCodex         MountID = ".codex"
-	MountIDAgents        MountID = ".agents"
-	MountIDGHAuth        MountID = "gh-auth"
-	MountIDSSHAgent      MountID = "ssh-agent"
-	MountIDSSHKnownHosts MountID = "ssh-known-hosts"
-	MountIDUVCache       MountID = "uv-cache"
-	MountIDUVData        MountID = "uv-data"
-	MountIDNPM           MountID = "npm"
-	MountIDApt           MountID = "apt"
-	MountIDPulseAudio    MountID = "pulse-audio"
+	MountIDClaude         MountID = ".claude"
+	MountIDClaudeJSON     MountID = ".claude.json"
+	MountIDCodex          MountID = ".codex"
+	MountIDAgents         MountID = ".agents"
+	MountIDGHAuth         MountID = "gh-auth"
+	MountIDSSHAgent       MountID = "ssh-agent"
+	MountIDSSHKnownHosts  MountID = "ssh-known-hosts"
+	MountIDUVCache        MountID = "uv-cache"
+	MountIDUVData         MountID = "uv-data"
+	MountIDNPM            MountID = "npm"
+	MountIDApt            MountID = "apt"
+	MountIDPulseAudio     MountID = "pulse-audio"
+	MountIDOpenCodeConfig MountID = "opencode-config"
+	MountIDOpenCodeData   MountID = "opencode-data"
 )
 
 // ToolID is the canonical identifier for a tooling capability.
 type ToolID string
 
 const (
-	ToolIDClaude ToolID = "claude"
-	ToolIDCodex  ToolID = "codex"
-	ToolIDGit    ToolID = "git"
-	ToolIDUV     ToolID = "uv"
-	ToolIDNPM    ToolID = "npm"
-	ToolIDApt    ToolID = "apt"
+	ToolIDClaude   ToolID = "claude"
+	ToolIDCodex    ToolID = "codex"
+	ToolIDGit      ToolID = "git"
+	ToolIDUV       ToolID = "uv"
+	ToolIDNPM      ToolID = "npm"
+	ToolIDApt      ToolID = "apt"
+	ToolIDOpenCode ToolID = "opencode"
 )
 
 // MacOSKeychainCredential declares that a credential file may be absent from
@@ -173,6 +176,20 @@ var capabilityMounts = buildMountIndex([]CapabilityMount{
 		Mode:            CapabilityModeSocket,
 		Optional:        true,
 	},
+	{
+		ID:              MountIDOpenCodeConfig,
+		DefaultHostPath: "~/.config/opencode",
+		ContainerTarget: path.Join(ContainerUserHome, ".config/opencode"),
+		Mode:            CapabilityModeReadWrite,
+		Optional:        true,
+	},
+	{
+		ID:              MountIDOpenCodeData,
+		DefaultHostPath: "~/.local/share/opencode",
+		ContainerTarget: path.Join(ContainerUserHome, ".local/share/opencode"),
+		Mode:            CapabilityModeReadWrite,
+		Optional:        true,
+	},
 })
 
 func buildMountIndex(mounts []CapabilityMount) map[MountID]CapabilityMount {
@@ -184,12 +201,13 @@ func buildMountIndex(mounts []CapabilityMount) map[MountID]CapabilityMount {
 }
 
 var builtInToolingCapabilities = map[ToolID]ToolingCapability{
-	ToolIDClaude: {MountIDs: []MountID{MountIDClaude, MountIDClaudeJSON, MountIDPulseAudio}},
-	ToolIDCodex:  {MountIDs: []MountID{MountIDCodex, MountIDAgents}},
-	ToolIDGit:    {MountIDs: []MountID{MountIDSSHAgent, MountIDGHAuth, MountIDSSHKnownHosts}},
-	ToolIDUV:     {MountIDs: []MountID{MountIDUVCache, MountIDUVData}},
-	ToolIDNPM:    {MountIDs: []MountID{MountIDNPM}},
-	ToolIDApt:    {MountIDs: []MountID{MountIDApt}},
+	ToolIDClaude:   {MountIDs: []MountID{MountIDClaude, MountIDClaudeJSON, MountIDPulseAudio}},
+	ToolIDCodex:    {MountIDs: []MountID{MountIDCodex, MountIDAgents}},
+	ToolIDGit:      {MountIDs: []MountID{MountIDSSHAgent, MountIDGHAuth, MountIDSSHKnownHosts}},
+	ToolIDUV:       {MountIDs: []MountID{MountIDUVCache, MountIDUVData}},
+	ToolIDNPM:      {MountIDs: []MountID{MountIDNPM}},
+	ToolIDApt:      {MountIDs: []MountID{MountIDApt}},
+	ToolIDOpenCode: {MountIDs: []MountID{MountIDOpenCodeConfig, MountIDOpenCodeData}},
 }
 
 func BuiltInToolingCapabilities() []ToolingCapability {

--- a/internal/profile/capabilities_test.go
+++ b/internal/profile/capabilities_test.go
@@ -7,13 +7,13 @@ import (
 
 func TestBuiltInToolingCapabilitiesExposeRequiredIDs(t *testing.T) {
 	capabilities := BuiltInToolingCapabilities()
-	if len(capabilities) != 6 {
-		t.Fatalf("unexpected capability count: got %d want 6", len(capabilities))
+	if len(capabilities) != 7 {
+		t.Fatalf("unexpected capability count: got %d want 7", len(capabilities))
 	}
 
 	expectedToolIDs := []string{
 		string(ToolIDApt), string(ToolIDClaude), string(ToolIDCodex),
-		string(ToolIDGit), string(ToolIDNPM), string(ToolIDUV),
+		string(ToolIDGit), string(ToolIDNPM), string(ToolIDOpenCode), string(ToolIDUV),
 	}
 	for _, toolID := range expectedToolIDs {
 		capability, ok := CapabilityByID(toolID)
@@ -80,6 +80,49 @@ func TestGitMountsAllAuthResources(t *testing.T) {
 	}
 	if capability.MountIDs[0] != MountIDSSHAgent || capability.MountIDs[1] != MountIDGHAuth || capability.MountIDs[2] != MountIDSSHKnownHosts {
 		t.Fatalf("unexpected git mount IDs: %v", capability.MountIDs)
+	}
+}
+
+func TestOpenCodeMountsBothDirs(t *testing.T) {
+	capability, ok := CapabilityByID(string(ToolIDOpenCode))
+	if !ok {
+		t.Fatal("missing tool capability opencode")
+	}
+	if len(capability.MountIDs) != 2 {
+		t.Fatalf("expected opencode to have 2 mount IDs, got %d", len(capability.MountIDs))
+	}
+	if capability.MountIDs[0] != MountIDOpenCodeConfig || capability.MountIDs[1] != MountIDOpenCodeData {
+		t.Fatalf("unexpected opencode mount IDs: %v", capability.MountIDs)
+	}
+}
+
+func TestOpenCodeMountAttributes(t *testing.T) {
+	tests := []struct {
+		mountID          MountID
+		wantHostPath     string
+		wantTargetSuffix string
+	}{
+		{MountIDOpenCodeConfig, "~/.config/opencode", ".config/opencode"},
+		{MountIDOpenCodeData, "~/.local/share/opencode", ".local/share/opencode"},
+	}
+	for _, tt := range tests {
+		mount, ok := MountByID(tt.mountID)
+		if !ok {
+			t.Fatalf("missing mount %s", tt.mountID)
+		}
+		if mount.DefaultHostPath != tt.wantHostPath {
+			t.Fatalf("mount %s: unexpected DefaultHostPath: got %q want %q", tt.mountID, mount.DefaultHostPath, tt.wantHostPath)
+		}
+		wantTarget := path.Join(ContainerUserHome, tt.wantTargetSuffix)
+		if mount.ContainerTarget != wantTarget {
+			t.Fatalf("mount %s: unexpected ContainerTarget: got %q want %q", tt.mountID, mount.ContainerTarget, wantTarget)
+		}
+		if mount.Mode != CapabilityModeReadWrite {
+			t.Fatalf("mount %s: unexpected Mode: got %q want %q", tt.mountID, mount.Mode, CapabilityModeReadWrite)
+		}
+		if !mount.Optional {
+			t.Fatalf("mount %s: expected Optional to be true", tt.mountID)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Add OpenCode as a first-class built-in tooling capability alongside `claude`, `codex`, `git`, `uv`, `npm`, and `apt`.

Two new capability mounts provide host-to-container bind mounts for OpenCode's XDG directories:

| MountID | DefaultHostPath | ContainerTarget | Mode | Optional |
|---------|----------------|-----------------|------|----------|
| `opencode-config` | `~/.config/opencode` | `$ContainerUserHome/.config/opencode` | `read_write` | `true` |
| `opencode-data` | `~/.local/share/opencode` | `$ContainerUserHome/.local/share/opencode` | `read_write` | `true` |

Both mounts are `Optional: true` so hosts that have never run OpenCode will not cause sandbox creation to fail.

## Changes

- **`internal/profile/capabilities.go`**: New `MountIDOpenCodeConfig`, `MountIDOpenCodeData` constants; new `ToolIDOpenCode` constant; two mount entries; one tooling capability entry.
- **`internal/profile/capabilities_test.go`**: Updated expected count (6→7), added `TestOpenCodeMountsBothDirs` and `TestOpenCodeMountAttributes`.
- **`internal/control/service_create_validation_test.go`**: Added `TestCreateSandboxAcceptsOpenCodeBuiltinTool` proving the daemon validation chain accepts `opencode`.
- **`docs/configuration_reference.md`**: Added `opencode` to the built-in resources enumeration.

## Test Evidence

- `go build ./...` ✅
- `go test ./... -count=1` all packages OK ✅
- Profile tests: 8/8 PASS (including `TestOpenCodeMountsBothDirs`, `TestOpenCodeMountAttributes`)
- Daemon validation: `TestCreateSandboxAcceptsOpenCodeBuiltinTool` PASS, `TestCreateSandboxRejectsUnknownBuiltinToolsBeforeRuntime` PASS
- No hardcoded `/home/agbox/.config/opencode` or `/home/agbox/.local/share/opencode` in source code

Closes #185
