### PR TITLE
[ISSUE-190] Add self-upgrade example for agent-driven service upgrades

### DIFF
--- a/examples/self-upgrade/README.md
+++ b/examples/self-upgrade/README.md
@@ -1,0 +1,43 @@
+# Self-Upgrade Example
+
+The sandbox uses an `unless-stopped` restart policy: killing the main process
+causes the container to restart automatically, picking up whatever is now
+installed. This makes **install new version + kill main process** a sufficient
+upgrade primitive — no external orchestration needed.
+
+## How it works
+
+```
+Main process (sandbox command):  http-server@14.0.0   ← passive, just serves
+Agent        (exec into sandbox): upgrade script       ← decides to upgrade
+```
+
+The upgrade flow:
+
+1. Sandbox starts with `http-server@14.0.0` as the main process
+2. Agent installs `http-server@14.1.1` and kills the main process
+3. Container restarts automatically with the new version running
+
+The main process is completely passive — it has no knowledge of the upgrade.
+The agent is the sole decision-maker.
+
+The example script also reads the version before and after to make the
+transition visible in the output — that is for demonstration only, not part
+of the upgrade flow itself.
+
+## Run
+
+```bash
+uv run --directory sdk/python python examples/self-upgrade/main.py
+```
+
+Expected output:
+
+```
+Sandbox <id> created, waiting for service to start ...
+[agent] version before upgrade: v14.0.0
+[agent] upgrading http-server 14.0.0 -> 14.1.1 and restarting ...
+[agent] waiting for container restart ...
+[agent] version after upgrade:  v14.1.1
+Sandbox <id> deleted.
+```

--- a/examples/self-upgrade/main.py
+++ b/examples/self-upgrade/main.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""
+Self-upgrade example: demonstrates how an agent triggers a live service upgrade
+inside a running sandbox without any external orchestration.
+
+Flow:
+  1. Create sandbox — installs and runs http-server@14.0.0 as the main process
+  2. Agent execs into the sandbox and confirms the running version
+  3. Agent installs http-server@14.1.1 and kills the main process
+  4. Container restarts automatically (unless-stopped policy)
+  5. Agent execs again and confirms the new version is now running
+"""
+
+import asyncio
+from pathlib import Path
+
+from agents_sandbox import AgentsSandboxClient
+
+SANDBOX_YAML = Path(__file__).parent / "sandbox.yaml"
+VERSION_CMD = ["sh", "-c", "http-server --version"]
+UPGRADE_CMD = ["sh", "-c", "sudo npm install -g http-server@14.1.1 --silent && kill $(pgrep -f 'node.*http-server')"]
+
+
+async def read_output(result) -> str:
+    return Path(result.stdout_log_path).read_text().strip() if result.stdout_log_path else ""
+
+
+async def main() -> None:
+    async with AgentsSandboxClient() as client:
+        # Step 1: create sandbox — main process installs and starts http-server@14.0.0
+        sandbox = await client.create_sandbox(config_yaml=SANDBOX_YAML.read_text())
+        sandbox_id = sandbox.sandbox_id
+        print(f"Sandbox {sandbox_id} created, waiting for service to start ...")
+        await asyncio.sleep(20)
+
+        try:
+            # Step 2: agent confirms the current version
+            result = await client.create_exec(sandbox_id, VERSION_CMD, wait=True)
+            print(f"[agent] version before upgrade: {await read_output(result)}")
+
+            # Step 3: agent upgrades the package and kills the main process
+            print("[agent] upgrading http-server 14.0.0 -> 14.1.1 and restarting ...")
+            await client.create_exec(sandbox_id, UPGRADE_CMD, wait=True)
+
+            # Step 4: wait for container to restart automatically
+            print("[agent] waiting for container restart ...")
+            await asyncio.sleep(15)
+
+            # Step 5: agent confirms the new version is running
+            result = await client.create_exec(sandbox_id, VERSION_CMD, wait=True)
+            print(f"[agent] version after upgrade:  {await read_output(result)}")
+
+        finally:
+            await client.delete_sandbox(sandbox_id)
+            print(f"Sandbox {sandbox_id} deleted.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/self-upgrade/sandbox.yaml
+++ b/examples/self-upgrade/sandbox.yaml
@@ -1,0 +1,2 @@
+image: ghcr.io/agents-sandbox/coding-runtime:latest
+command: ["sh", "-c", "sudo npm install -g http-server@14.0.0 --silent && exec http-server --port 8080"]


### PR DESCRIPTION
## Summary

Adds `examples/self-upgrade/` — a minimal, runnable example showing how an
agent upgrades its own service inside a running sandbox.

- `sandbox.yaml` — starts `http-server@14.0.0` as the main process
- `main.py` — agent execs into the sandbox, installs `http-server@14.1.1`,
  kills the main process, and confirms the new version after automatic restart
- `README.md` — explains the core primitive and expected output

The key insight documented: **install new version + kill main process** is a
sufficient upgrade primitive because the `unless-stopped` restart policy
causes the container to restart automatically and pick up whatever is now installed.

Closes #190

## Test plan

- [ ] `uv run --directory sdk/python python examples/self-upgrade/main.py` completes without error
- [ ] Output shows `version before upgrade: v14.0.0` and `version after upgrade: v14.1.1`
