### PR TITLE
[ISSUE-187][ISSUE-188] Promote agent types to top-level commands and expose CreateSpec flags

### DIFF
--- a/cmd/agbox/agent_session.go
+++ b/cmd/agbox/agent_session.go
@@ -152,6 +152,10 @@ func runInteractiveSession(
 			Image:        defaultImage,
 			BuiltinTools: parsed.builtinTools,
 			Copies:       copies,
+			Envs:         parsed.envs,
+			CpuLimit:     parsed.cpuLimit,
+			MemoryLimit:  parsed.memoryLimit,
+			DiskLimit:    parsed.diskLimit,
 			Labels: map[string]string{
 				"created-by": "agbox-cli",
 				"agent-type": agentLabel,
@@ -273,6 +277,10 @@ func runLongRunningSession(
 			Image:        defaultImage,
 			BuiltinTools: parsed.builtinTools,
 			Copies:       copies,
+			Envs:         parsed.envs,
+			CpuLimit:     parsed.cpuLimit,
+			MemoryLimit:  parsed.memoryLimit,
+			DiskLimit:    parsed.diskLimit,
 			Labels: map[string]string{
 				"created-by": "agbox-cli",
 				"agent-type": agentLabel,

--- a/cmd/agbox/agent_session_test.go
+++ b/cmd/agbox/agent_session_test.go
@@ -630,3 +630,48 @@ func TestRunAgentSession_LongRunningNoGitConfirm(t *testing.T) {
 		t.Fatalf("expected workspace copy from %s, got %v", tmpDir, copies)
 	}
 }
+
+func TestRunAgentSessionPropagatesFlagsToCreateSpec(t *testing.T) {
+	eventCh := make(chan *agboxv1.SandboxEvent, 1)
+	mock := newReadyMock(eventCh)
+
+	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
+		return &agboxv1.CreateExecResponse{ExecId: "exec-1"}, nil
+	}
+	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
+		return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_FINISHED, 3, 0), nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
+		mode:        agentModeLongRunning,
+		command:     []string{"echo"},
+		envs:        map[string]string{"FOO": "bar", "BAZ": "qux"},
+		cpuLimit:    "2",
+		memoryLimit: "4g",
+		diskLimit:   "10g",
+	}, "test", &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	req := mock.createSandboxReq
+	if req == nil {
+		t.Fatal("expected CreateSandbox to be called")
+	}
+	spec := req.GetCreateSpec()
+
+	if spec.GetCpuLimit() != "2" {
+		t.Fatalf("expected cpu_limit=2, got %q", spec.GetCpuLimit())
+	}
+	if spec.GetMemoryLimit() != "4g" {
+		t.Fatalf("expected memory_limit=4g, got %q", spec.GetMemoryLimit())
+	}
+	if spec.GetDiskLimit() != "10g" {
+		t.Fatalf("expected disk_limit=10g, got %q", spec.GetDiskLimit())
+	}
+	envs := spec.GetEnvs()
+	if envs["FOO"] != "bar" || envs["BAZ"] != "qux" {
+		t.Fatalf("expected envs={FOO:bar, BAZ:qux}, got %v", envs)
+	}
+}

--- a/cmd/agbox/cmd_agent.go
+++ b/cmd/agbox/cmd_agent.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -8,6 +9,57 @@ import (
 
 	"github.com/spf13/cobra"
 )
+
+// agentSessionFlagVars holds the raw flag values for an agent session command.
+type agentSessionFlagVars struct {
+	rawCommand   string
+	mode         string
+	workspace    string
+	builtinTools []string
+	// Pre-reserved for ISSUE-188 (Commit 2 will consume these):
+	envs        []string
+	cpuLimit    string
+	memoryLimit string
+	diskLimit   string
+	sandboxID   string
+	// Track which flags were explicitly set by the user:
+	modeOverridden         bool
+	workspaceOverridden    bool
+	builtinToolsOverridden bool
+}
+
+// registerAgentSessionFlags registers all agent session flags on a cobra command.
+func registerAgentSessionFlags(cmd *cobra.Command, v *agentSessionFlagVars) {
+	cmd.Flags().StringVar(&v.rawCommand, "command", "", "Custom command to run (mutually exclusive with agent type)")
+	cmd.Flags().StringVar(&v.mode, "mode", "", "Session mode: interactive or long-running (default depends on agent type)")
+	cmd.Flags().StringVar(&v.workspace, "workspace", "", "Directory to copy into the sandbox as workspace")
+	cmd.Flags().StringArrayVar(&v.builtinTools, "builtin-tool", nil, "Builtin tool to install (repeatable, overrides defaults)")
+	// ISSUE-188 flags (registered now, consumed in Commit 2):
+	cmd.Flags().StringArrayVar(&v.envs, "env", nil, "Environment variable in KEY=VAL form (repeatable)")
+	cmd.Flags().StringVar(&v.cpuLimit, "cpu-limit", "", "CPU limit (Docker --cpus format, e.g. 2, 0.5)")
+	cmd.Flags().StringVar(&v.memoryLimit, "memory-limit", "", "Memory limit (Docker --memory format, e.g. 4g, 512m)")
+	cmd.Flags().StringVar(&v.diskLimit, "disk-limit", "", "Disk limit (Docker --storage-opt size= format, e.g. 10g)")
+	cmd.Flags().StringVar(&v.sandboxID, "sandbox-id", "", "Custom sandbox ID (overrides agent type default)")
+}
+
+// buildAgentSessionRunE creates the RunE function for agent session commands.
+// When agentType is non-empty (top-level commands), it skips positional arg parsing.
+func buildAgentSessionRunE(agentType string, v *agentSessionFlagVars) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		resolvedType := agentType
+		if resolvedType == "" && len(args) > 0 {
+			resolvedType = args[0]
+		}
+		v.modeOverridden = cmd.Flags().Changed("mode")
+		v.workspaceOverridden = cmd.Flags().Changed("workspace")
+		v.builtinToolsOverridden = cmd.Flags().Changed("builtin-tool")
+		parsed, err := resolveAgentSessionArgs(v, resolvedType)
+		if err != nil {
+			return err
+		}
+		return runAgentSession(cmd.Context(), parsed, cmd.OutOrStdout(), cmd.ErrOrStderr(), lookupEnvFromCmd(cmd))
+	}
+}
 
 // agentSessionArgs holds the parsed arguments for an agent session.
 type agentSessionArgs struct {
@@ -34,69 +86,45 @@ func registeredAgentNames() []string {
 }
 
 func newAgentCommand() *cobra.Command {
-	var (
-		rawCommand   string
-		mode         string
-		workspace    string
-		builtinTools []string
-	)
-
+	var v agentSessionFlagVars
 	agentNames := registeredAgentNames()
-
 	cmd := &cobra.Command{
 		Use:       "agent [agent_type]",
 		Short:     "Launch agent session",
 		Long:      "Launch agent session.\n\nAvailable agent types: " + strings.Join(agentNames, ", ") + "\nOr use --command for a custom agent.",
 		Args:      cobra.MaximumNArgs(1),
 		ValidArgs: agentNames,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			agentType := ""
-			if len(args) > 0 {
-				agentType = args[0]
-			}
-
-			modeOverridden := cmd.Flags().Changed("mode")
-			workspaceOverridden := cmd.Flags().Changed("workspace")
-			builtinToolsOverridden := cmd.Flags().Changed("builtin-tool")
-
-			parsed, err := resolveAgentSessionArgs(
-				agentType, rawCommand,
-				mode, modeOverridden,
-				workspace, workspaceOverridden,
-				builtinTools, builtinToolsOverridden,
-			)
-			if err != nil {
-				return err
-			}
-
-			return runAgentSession(cmd.Context(), parsed, cmd.OutOrStdout(), cmd.ErrOrStderr(), lookupEnvFromCmd(cmd))
-		},
+		RunE:      buildAgentSessionRunE("", &v),
 	}
+	registerAgentSessionFlags(cmd, &v)
+	return cmd
+}
 
-	cmd.Flags().StringVar(&rawCommand, "command", "", "Custom command to run (mutually exclusive with agent type)")
-	cmd.Flags().StringVar(&mode, "mode", "", "Session mode: interactive or long-running (default depends on agent type)")
-	cmd.Flags().StringVar(&workspace, "workspace", "", "Directory to copy into the sandbox as workspace")
-	cmd.Flags().StringArrayVar(&builtinTools, "builtin-tool", nil, "Builtin tool to install (repeatable, overrides defaults)")
-
+// newAgentTypeCommand creates a top-level command for a specific agent type
+// (e.g. "agbox claude"), equivalent to "agbox agent <type>".
+func newAgentTypeCommand(agentType string) *cobra.Command {
+	var v agentSessionFlagVars
+	cmd := &cobra.Command{
+		Use:   agentType,
+		Short: fmt.Sprintf("Launch %s agent session", agentType),
+		Long:  fmt.Sprintf("Launch %s agent session (equivalent to 'agbox agent %s').", agentType, agentType),
+		Args:  cobra.NoArgs,
+		RunE:  buildAgentSessionRunE(agentType, &v),
+	}
+	registerAgentSessionFlags(cmd, &v)
 	return cmd
 }
 
 // resolveAgentSessionArgs validates and resolves agent session arguments into
 // an agentSessionArgs struct. It is a pure function suitable for unit testing.
 func resolveAgentSessionArgs(
+	v *agentSessionFlagVars,
 	agentType string,
-	rawCommand string,
-	mode string,
-	modeOverridden bool,
-	workspace string,
-	workspaceOverridden bool,
-	builtinTools []string,
-	builtinToolsOverridden bool,
 ) (agentSessionArgs, error) {
 	var parsed agentSessionArgs
 
 	// Validate mutual exclusion: agent type vs --command.
-	if agentType != "" && rawCommand != "" {
+	if agentType != "" && v.rawCommand != "" {
 		return agentSessionArgs{}, usageErrorf("cannot use --command with agent type %q", agentType)
 	}
 
@@ -113,27 +141,27 @@ func resolveAgentSessionArgs(
 		isRegistered = true
 		parsed.agentType = agentType
 		parsed.command = typeDef.command
-		if builtinToolsOverridden {
-			parsed.builtinTools = builtinTools
+		if v.builtinToolsOverridden {
+			parsed.builtinTools = v.builtinTools
 		} else {
 			parsed.builtinTools = typeDef.builtinTools
 		}
-	} else if rawCommand != "" {
+	} else if v.rawCommand != "" {
 		// Custom command: split the string into argv.
-		parsed.command = strings.Fields(rawCommand)
+		parsed.command = strings.Fields(v.rawCommand)
 		if len(parsed.command) == 0 {
 			return agentSessionArgs{}, usageErrorf("--command must not be empty")
 		}
-		parsed.builtinTools = builtinTools
+		parsed.builtinTools = v.builtinTools
 	} else {
 		return agentSessionArgs{}, usageErrorf("agbox agent requires an agent type or --command")
 	}
 
 	// Mode resolution.
-	if modeOverridden {
-		switch agentMode(mode) {
+	if v.modeOverridden {
+		switch agentMode(v.mode) {
 		case agentModeInteractive, agentModeLongRunning:
-			parsed.mode = agentMode(mode)
+			parsed.mode = agentMode(v.mode)
 		default:
 			return agentSessionArgs{}, usageErrorf("--mode must be %q or %q", agentModeInteractive, agentModeLongRunning)
 		}
@@ -145,12 +173,12 @@ func resolveAgentSessionArgs(
 	}
 
 	// Workspace resolution.
-	if workspaceOverridden {
+	if v.workspaceOverridden {
 		// User explicitly provided --workspace; validate the path.
-		if workspace == "" {
+		if v.workspace == "" {
 			return agentSessionArgs{}, usageErrorf("--workspace must not be empty")
 		}
-		resolved, err := validateWorkspacePath(workspace)
+		resolved, err := validateWorkspacePath(v.workspace)
 		if err != nil {
 			return agentSessionArgs{}, err
 		}

--- a/cmd/agbox/cmd_agent.go
+++ b/cmd/agbox/cmd_agent.go
@@ -16,12 +16,11 @@ type agentSessionFlagVars struct {
 	mode         string
 	workspace    string
 	builtinTools []string
-	// Pre-reserved for ISSUE-188 (Commit 2 will consume these):
-	envs        []string
-	cpuLimit    string
-	memoryLimit string
-	diskLimit   string
-	sandboxID   string
+	envs         []string
+	cpuLimit     string
+	memoryLimit  string
+	diskLimit    string
+	sandboxID    string
 	// Track which flags were explicitly set by the user:
 	modeOverridden         bool
 	workspaceOverridden    bool
@@ -34,7 +33,6 @@ func registerAgentSessionFlags(cmd *cobra.Command, v *agentSessionFlagVars) {
 	cmd.Flags().StringVar(&v.mode, "mode", "", "Session mode: interactive or long-running (default depends on agent type)")
 	cmd.Flags().StringVar(&v.workspace, "workspace", "", "Directory to copy into the sandbox as workspace")
 	cmd.Flags().StringArrayVar(&v.builtinTools, "builtin-tool", nil, "Builtin tool to install (repeatable, overrides defaults)")
-	// ISSUE-188 flags (registered now, consumed in Commit 2):
 	cmd.Flags().StringArrayVar(&v.envs, "env", nil, "Environment variable in KEY=VAL form (repeatable)")
 	cmd.Flags().StringVar(&v.cpuLimit, "cpu-limit", "", "CPU limit (Docker --cpus format, e.g. 2, 0.5)")
 	cmd.Flags().StringVar(&v.memoryLimit, "memory-limit", "", "Memory limit (Docker --memory format, e.g. 4g, 512m)")
@@ -68,6 +66,10 @@ type agentSessionArgs struct {
 	mode         agentMode // resolved session mode
 	workspace    string    // host directory to copy; empty means "don't copy"
 	builtinTools []string
+	envs         map[string]string
+	cpuLimit     string
+	memoryLimit  string
+	diskLimit    string
 	sandboxID    string                                       // custom sandbox ID (empty = daemon generates)
 	configYaml   string                                       // embedded YAML config
 	phases       []execPhase                                  // multi-phase startup (non-empty replaces command)
@@ -197,8 +199,27 @@ func resolveAgentSessionArgs(
 	}
 	// else: custom --command without --workspace → parsed.workspace stays "".
 
-	// Sandbox ID resolution: use the type's generator if defined.
-	if isRegistered && typeDef.sandboxIDGen != nil {
+	// Parse --env flags into a map.
+	if len(v.envs) > 0 {
+		envMap := make(map[string]string, len(v.envs))
+		for _, raw := range v.envs {
+			key, value, err := parseKeyValueAssignment(raw, "--env")
+			if err != nil {
+				return agentSessionArgs{}, err
+			}
+			envMap[key] = value // last occurrence wins
+		}
+		parsed.envs = envMap
+	}
+
+	parsed.cpuLimit = v.cpuLimit
+	parsed.memoryLimit = v.memoryLimit
+	parsed.diskLimit = v.diskLimit
+
+	// Sandbox ID resolution: --sandbox-id overrides the type's generator.
+	if v.sandboxID != "" {
+		parsed.sandboxID = v.sandboxID
+	} else if isRegistered && typeDef.sandboxIDGen != nil {
 		parsed.sandboxID = typeDef.sandboxIDGen()
 	}
 	// else: parsed.sandboxID stays empty, daemon auto-generates.

--- a/cmd/agbox/cmd_agent_test.go
+++ b/cmd/agbox/cmd_agent_test.go
@@ -475,3 +475,210 @@ func TestTopLevelCommandRejectsCommandFlag(t *testing.T) {
 		t.Fatalf("unexpected error message: %v", err)
 	}
 }
+
+func TestResolveAgentSessionArgsFlags(t *testing.T) {
+	t.Run("single_env", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand: "sleep infinity",
+			envs:       []string{"KEY=VAL"},
+		}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(parsed.envs) != 1 || parsed.envs["KEY"] != "VAL" {
+			t.Fatalf("expected envs={KEY:VAL}, got %v", parsed.envs)
+		}
+	})
+
+	t.Run("env_last_wins", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand: "sleep infinity",
+			envs:       []string{"KEY=V1", "KEY=V2"},
+		}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if parsed.envs["KEY"] != "V2" {
+			t.Fatalf("expected last-wins KEY=V2, got %q", parsed.envs["KEY"])
+		}
+	})
+
+	t.Run("env_empty_value", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand: "sleep infinity",
+			envs:       []string{"KEY="},
+		}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v, ok := parsed.envs["KEY"]; !ok || v != "" {
+			t.Fatalf("expected envs[KEY]=\"\", got %q (ok=%v)", v, ok)
+		}
+	})
+
+	t.Run("env_empty_key", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand: "sleep infinity",
+			envs:       []string{"=VAL"},
+		}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v, ok := parsed.envs[""]; !ok || v != "VAL" {
+			t.Fatalf("expected envs[\"\"]=\"VAL\", got %q (ok=%v)", v, ok)
+		}
+	})
+
+	t.Run("env_no_equals", func(t *testing.T) {
+		_, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand: "sleep infinity",
+			envs:       []string{"BAD_NO_EQ"},
+		}, "")
+		if err == nil {
+			t.Fatal("expected error for env without =")
+		}
+		if !strings.Contains(err.Error(), "--env") {
+			t.Fatalf("expected error mentioning --env, got %v", err)
+		}
+	})
+
+	t.Run("cpu_limit", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand: "sleep infinity",
+			cpuLimit:   "2",
+		}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if parsed.cpuLimit != "2" {
+			t.Fatalf("expected cpuLimit=2, got %q", parsed.cpuLimit)
+		}
+	})
+
+	t.Run("memory_limit", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand:  "sleep infinity",
+			memoryLimit: "4g",
+		}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if parsed.memoryLimit != "4g" {
+			t.Fatalf("expected memoryLimit=4g, got %q", parsed.memoryLimit)
+		}
+	})
+
+	t.Run("disk_limit", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand: "sleep infinity",
+			diskLimit:  "10g",
+		}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if parsed.diskLimit != "10g" {
+			t.Fatalf("expected diskLimit=10g, got %q", parsed.diskLimit)
+		}
+	})
+
+	t.Run("sandbox_id_override", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand: "sleep infinity",
+			sandboxID:  "custom-abc",
+		}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if parsed.sandboxID != "custom-abc" {
+			t.Fatalf("expected sandboxID=custom-abc, got %q", parsed.sandboxID)
+		}
+	})
+
+	t.Run("sandbox_id_empty_uses_generator", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			sandboxID: "",
+		}, "openclaw")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		re := regexp.MustCompile(`^openclaw-[0-9a-f]{4}$`)
+		if !re.MatchString(parsed.sandboxID) {
+			t.Fatalf("expected sandboxID matching %s, got %q", re.String(), parsed.sandboxID)
+		}
+	})
+
+	t.Run("sandbox_id_overrides_generator", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			sandboxID: "custom-id",
+		}, "openclaw")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if parsed.sandboxID != "custom-id" {
+			t.Fatalf("expected sandboxID=custom-id, got %q", parsed.sandboxID)
+		}
+	})
+
+	t.Run("no_sandbox_id_openclaw_uses_generator", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, "openclaw")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		re := regexp.MustCompile(`^openclaw-[0-9a-f]{4}$`)
+		if !re.MatchString(parsed.sandboxID) {
+			t.Fatalf("expected sandboxID matching %s, got %q", re.String(), parsed.sandboxID)
+		}
+	})
+
+	t.Run("no_new_flags", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand: "sleep infinity",
+		}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if parsed.envs != nil {
+			t.Fatalf("expected nil envs, got %v", parsed.envs)
+		}
+		if parsed.cpuLimit != "" {
+			t.Fatalf("expected empty cpuLimit, got %q", parsed.cpuLimit)
+		}
+		if parsed.memoryLimit != "" {
+			t.Fatalf("expected empty memoryLimit, got %q", parsed.memoryLimit)
+		}
+		if parsed.diskLimit != "" {
+			t.Fatalf("expected empty diskLimit, got %q", parsed.diskLimit)
+		}
+		if parsed.sandboxID != "" {
+			t.Fatalf("expected empty sandboxID, got %q", parsed.sandboxID)
+		}
+	})
+}
+
+func TestTopLevelCommandsInheritNewFlags(t *testing.T) {
+	for _, agentType := range []string{"claude", "codex", "openclaw"} {
+		t.Run(agentType, func(t *testing.T) {
+			parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+				envs:        []string{"FOO=bar"},
+				cpuLimit:    "2",
+				memoryLimit: "4g",
+				diskLimit:   "10g",
+			}, agentType)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if parsed.envs["FOO"] != "bar" {
+				t.Fatalf("expected envs[FOO]=bar, got %v", parsed.envs)
+			}
+			if parsed.cpuLimit != "2" {
+				t.Fatalf("expected cpuLimit=2, got %q", parsed.cpuLimit)
+			}
+			if parsed.memoryLimit != "4g" {
+				t.Fatalf("expected memoryLimit=4g, got %q", parsed.memoryLimit)
+			}
+			if parsed.diskLimit != "10g" {
+				t.Fatalf("expected diskLimit=10g, got %q", parsed.diskLimit)
+			}
+		})
+	}
+}

--- a/cmd/agbox/cmd_agent_test.go
+++ b/cmd/agbox/cmd_agent_test.go
@@ -24,7 +24,7 @@ func realTempDir(t *testing.T) string {
 
 func TestResolveAgentSessionArgs_RegisteredType(t *testing.T) {
 	tmpDir := realTempDir(t)
-	parsed, err := resolveAgentSessionArgs("claude", "", "", false, tmpDir, true, nil, false)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{workspace: tmpDir, workspaceOverridden: true}, "claude")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestResolveAgentSessionArgs_RegisteredType(t *testing.T) {
 
 func TestResolveAgentSessionArgs_RegisteredTypeOverrideBuiltinTools(t *testing.T) {
 	tmpDir := realTempDir(t)
-	parsed, err := resolveAgentSessionArgs("claude", "", "", false, tmpDir, true, []string{"git"}, true)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{workspace: tmpDir, workspaceOverridden: true, builtinTools: []string{"git"}, builtinToolsOverridden: true}, "claude")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestResolveAgentSessionArgs_RegisteredTypeOverrideBuiltinTools(t *testing.T
 
 func TestResolveAgentSessionArgs_CustomCommand(t *testing.T) {
 	tmpDir := realTempDir(t)
-	parsed, err := resolveAgentSessionArgs("", "aider --yes", "", false, tmpDir, true, nil, false)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "aider --yes", workspace: tmpDir, workspaceOverridden: true}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestResolveAgentSessionArgs_CustomCommand(t *testing.T) {
 
 func TestResolveAgentSessionArgs_CustomCommandWithBuiltinTools(t *testing.T) {
 	tmpDir := realTempDir(t)
-	parsed, err := resolveAgentSessionArgs("", "aider", "", false, tmpDir, true, []string{"git", "uv"}, true)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "aider", workspace: tmpDir, workspaceOverridden: true, builtinTools: []string{"git", "uv"}, builtinToolsOverridden: true}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestResolveAgentSessionArgs_CustomCommandWithBuiltinTools(t *testing.T) {
 }
 
 func TestResolveAgentSessionArgs_MutualExclusion(t *testing.T) {
-	_, err := resolveAgentSessionArgs("claude", "aider", "", false, "/work", true, nil, false)
+	_, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "aider", workspace: "/work", workspaceOverridden: true}, "claude")
 	if err == nil {
 		t.Fatal("expected error for agent type + --command")
 	}
@@ -92,7 +92,7 @@ func TestResolveAgentSessionArgs_MutualExclusion(t *testing.T) {
 }
 
 func TestResolveAgentSessionArgs_NeitherTypeNorCommand(t *testing.T) {
-	_, err := resolveAgentSessionArgs("", "", "", false, "/work", true, nil, false)
+	_, err := resolveAgentSessionArgs(&agentSessionFlagVars{workspace: "/work", workspaceOverridden: true}, "")
 	if err == nil {
 		t.Fatal("expected error when neither agent type nor --command is given")
 	}
@@ -102,7 +102,7 @@ func TestResolveAgentSessionArgs_NeitherTypeNorCommand(t *testing.T) {
 }
 
 func TestResolveAgentSessionArgs_UnknownType(t *testing.T) {
-	_, err := resolveAgentSessionArgs("nonexistent", "", "", false, "/work", true, nil, false)
+	_, err := resolveAgentSessionArgs(&agentSessionFlagVars{workspace: "/work", workspaceOverridden: true}, "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for unknown type")
 	}
@@ -112,7 +112,7 @@ func TestResolveAgentSessionArgs_UnknownType(t *testing.T) {
 }
 
 func TestResolveAgentSessionArgs_EmptyCommand(t *testing.T) {
-	_, err := resolveAgentSessionArgs("", "  ", "", false, "/work", true, nil, false)
+	_, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "  ", workspace: "/work", workspaceOverridden: true}, "")
 	if err == nil {
 		t.Fatal("expected error for empty --command")
 	}
@@ -125,7 +125,7 @@ func TestResolveAgentSessionArgs_DuplicateAgentType(t *testing.T) {
 	tmpDir := realTempDir(t)
 	// With cobra, duplicate positional args are prevented by cobra.MaximumNArgs(1).
 	// Here we test resolveAgentSessionArgs directly with a registered agent type.
-	parsed, err := resolveAgentSessionArgs("claude", "", "", false, tmpDir, true, nil, false)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{workspace: tmpDir, workspaceOverridden: true}, "claude")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestResolveAgentSessionArgs_DuplicateAgentType(t *testing.T) {
 }
 
 func TestResolveAgentSessionArgs_RejectRoot(t *testing.T) {
-	_, err := resolveAgentSessionArgs("claude", "", "", false, "/", true, nil, false)
+	_, err := resolveAgentSessionArgs(&agentSessionFlagVars{workspace: "/", workspaceOverridden: true}, "claude")
 	if err == nil {
 		t.Fatal("expected error for root workspace")
 	}
@@ -149,7 +149,7 @@ func TestResolveAgentSessionArgs_RejectHome(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot get home dir: %v", err)
 	}
-	_, err = resolveAgentSessionArgs("claude", "", "", false, home, true, nil, false)
+	_, err = resolveAgentSessionArgs(&agentSessionFlagVars{workspace: home, workspaceOverridden: true}, "claude")
 	if err == nil {
 		t.Fatal("expected error for home directory workspace")
 	}
@@ -162,7 +162,7 @@ func TestResolveAgentSessionArgs_Mode(t *testing.T) {
 	tmpDir := realTempDir(t)
 
 	t.Run("claude_default_interactive", func(t *testing.T) {
-		parsed, err := resolveAgentSessionArgs("claude", "", "", false, tmpDir, true, nil, false)
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{workspace: tmpDir, workspaceOverridden: true}, "claude")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -172,7 +172,7 @@ func TestResolveAgentSessionArgs_Mode(t *testing.T) {
 	})
 
 	t.Run("claude_override_long_running", func(t *testing.T) {
-		parsed, err := resolveAgentSessionArgs("claude", "", "long-running", true, tmpDir, true, nil, false)
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{mode: "long-running", modeOverridden: true, workspace: tmpDir, workspaceOverridden: true}, "claude")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -182,7 +182,7 @@ func TestResolveAgentSessionArgs_Mode(t *testing.T) {
 	})
 
 	t.Run("command_default_interactive", func(t *testing.T) {
-		parsed, err := resolveAgentSessionArgs("", "sleep infinity", "", false, tmpDir, true, nil, false)
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "sleep infinity", workspace: tmpDir, workspaceOverridden: true}, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -192,7 +192,7 @@ func TestResolveAgentSessionArgs_Mode(t *testing.T) {
 	})
 
 	t.Run("command_override_long_running", func(t *testing.T) {
-		parsed, err := resolveAgentSessionArgs("", "sleep infinity", "long-running", true, tmpDir, true, nil, false)
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "sleep infinity", mode: "long-running", modeOverridden: true, workspace: tmpDir, workspaceOverridden: true}, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -202,7 +202,7 @@ func TestResolveAgentSessionArgs_Mode(t *testing.T) {
 	})
 
 	t.Run("invalid_mode", func(t *testing.T) {
-		_, err := resolveAgentSessionArgs("claude", "", "invalid", true, tmpDir, true, nil, false)
+		_, err := resolveAgentSessionArgs(&agentSessionFlagVars{mode: "invalid", modeOverridden: true, workspace: tmpDir, workspaceOverridden: true}, "claude")
 		if err == nil {
 			t.Fatal("expected error for invalid mode")
 		}
@@ -214,7 +214,7 @@ func TestResolveAgentSessionArgs_Mode(t *testing.T) {
 
 func TestResolveAgentSessionArgs_ModeOverride(t *testing.T) {
 	tmpDir := realTempDir(t)
-	parsed, err := resolveAgentSessionArgs("claude", "", "long-running", true, tmpDir, true, nil, false)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{mode: "long-running", modeOverridden: true, workspace: tmpDir, workspaceOverridden: true}, "claude")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -226,7 +226,7 @@ func TestResolveAgentSessionArgs_ModeOverride(t *testing.T) {
 func TestResolveAgentSessionArgs_WorkspaceCopy(t *testing.T) {
 	t.Run("claude_default_workspace_is_cwd", func(t *testing.T) {
 		// When no --workspace is given, registered type with copyWorkspace=true fills cwd.
-		parsed, err := resolveAgentSessionArgs("claude", "", "", false, "", false, nil, false)
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, "claude")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -237,7 +237,7 @@ func TestResolveAgentSessionArgs_WorkspaceCopy(t *testing.T) {
 
 	t.Run("command_no_workspace", func(t *testing.T) {
 		// Custom --command without --workspace: workspace stays empty.
-		parsed, err := resolveAgentSessionArgs("", "sleep infinity", "", false, "", false, nil, false)
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "sleep infinity"}, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -248,7 +248,7 @@ func TestResolveAgentSessionArgs_WorkspaceCopy(t *testing.T) {
 
 	t.Run("command_with_explicit_workspace", func(t *testing.T) {
 		tmpDir := realTempDir(t)
-		parsed, err := resolveAgentSessionArgs("", "sleep infinity", "", false, tmpDir, true, nil, false)
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "sleep infinity", workspace: tmpDir, workspaceOverridden: true}, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -260,7 +260,7 @@ func TestResolveAgentSessionArgs_WorkspaceCopy(t *testing.T) {
 
 func TestResolveAgentSessionArgs_WorkspaceExplicit(t *testing.T) {
 	tmpDir := realTempDir(t)
-	parsed, err := resolveAgentSessionArgs("", "sleep infinity", "", false, tmpDir, true, nil, false)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "sleep infinity", workspace: tmpDir, workspaceOverridden: true}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -325,7 +325,7 @@ func TestConfirmWorkspaceCopy(t *testing.T) {
 }
 
 func TestResolveAgentSessionArgs_Openclaw(t *testing.T) {
-	parsed, err := resolveAgentSessionArgs("openclaw", "", "", false, "", false, nil, false)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, "openclaw")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -368,7 +368,7 @@ func TestResolveAgentSessionArgs_Openclaw(t *testing.T) {
 
 func TestResolveAgentSessionArgs_SandboxID(t *testing.T) {
 	t.Run("auto_generated", func(t *testing.T) {
-		parsed, err := resolveAgentSessionArgs("openclaw", "", "", false, "", false, nil, false)
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, "openclaw")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -379,7 +379,7 @@ func TestResolveAgentSessionArgs_SandboxID(t *testing.T) {
 	})
 
 	t.Run("custom_command_no_generator", func(t *testing.T) {
-		parsed, err := resolveAgentSessionArgs("", "sleep infinity", "", false, "", false, nil, false)
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "sleep infinity"}, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -390,7 +390,7 @@ func TestResolveAgentSessionArgs_SandboxID(t *testing.T) {
 }
 
 func TestResolveAgentSessionArgs_ConfigYaml(t *testing.T) {
-	parsed, err := resolveAgentSessionArgs("openclaw", "", "", false, "", false, nil, false)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, "openclaw")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -401,5 +401,77 @@ func TestResolveAgentSessionArgs_ConfigYaml(t *testing.T) {
 		if !strings.Contains(parsed.configYaml, keyword) {
 			t.Fatalf("configYaml should contain %q, got:\n%s", keyword, parsed.configYaml)
 		}
+	}
+}
+
+func TestTopLevelAgentCommandsEquivalent(t *testing.T) {
+	for _, agentType := range []string{"claude", "codex", "openclaw"} {
+		t.Run(agentType, func(t *testing.T) {
+			v := &agentSessionFlagVars{}
+			topLevel, err := resolveAgentSessionArgs(v, agentType)
+			if err != nil {
+				t.Fatalf("top-level resolve error: %v", err)
+			}
+
+			vSub := &agentSessionFlagVars{}
+			subCmd, err := resolveAgentSessionArgs(vSub, agentType)
+			if err != nil {
+				t.Fatalf("sub-command resolve error: %v", err)
+			}
+
+			if topLevel.agentType != subCmd.agentType {
+				t.Fatalf("agentType mismatch: %q vs %q", topLevel.agentType, subCmd.agentType)
+			}
+			if topLevel.mode != subCmd.mode {
+				t.Fatalf("mode mismatch: %q vs %q", topLevel.mode, subCmd.mode)
+			}
+			if len(topLevel.command) != len(subCmd.command) {
+				t.Fatalf("command length mismatch: %v vs %v", topLevel.command, subCmd.command)
+			}
+			for i := range topLevel.command {
+				if topLevel.command[i] != subCmd.command[i] {
+					t.Fatalf("command[%d] mismatch: %q vs %q", i, topLevel.command[i], subCmd.command[i])
+				}
+			}
+			if len(topLevel.builtinTools) != len(subCmd.builtinTools) {
+				t.Fatalf("builtinTools length mismatch: %v vs %v", topLevel.builtinTools, subCmd.builtinTools)
+			}
+			for i := range topLevel.builtinTools {
+				if topLevel.builtinTools[i] != subCmd.builtinTools[i] {
+					t.Fatalf("builtinTools[%d] mismatch: %q vs %q", i, topLevel.builtinTools[i], subCmd.builtinTools[i])
+				}
+			}
+			if topLevel.configYaml != subCmd.configYaml {
+				t.Fatalf("configYaml mismatch")
+			}
+			if len(topLevel.phases) != len(subCmd.phases) {
+				t.Fatalf("phases length mismatch: %d vs %d", len(topLevel.phases), len(subCmd.phases))
+			}
+		})
+	}
+}
+
+func TestTopLevelCommandRejectsPositionalArgs(t *testing.T) {
+	cmd := newAgentTypeCommand("claude")
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"some-extra-arg"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for positional arg on top-level command")
+	}
+}
+
+func TestTopLevelCommandRejectsCommandFlag(t *testing.T) {
+	cmd := newAgentTypeCommand("claude")
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--command", "foo"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --command on top-level command")
+	}
+	if !strings.Contains(err.Error(), "cannot use --command with agent type") {
+		t.Fatalf("unexpected error message: %v", err)
 	}
 }

--- a/cmd/agbox/root.go
+++ b/cmd/agbox/root.go
@@ -48,6 +48,9 @@ func run(
 		newSandboxCommand(),
 		newExecCommand(),
 		newAgentCommand(),
+		newAgentTypeCommand("claude"),
+		newAgentTypeCommand("codex"),
+		newAgentTypeCommand("openclaw"),
 	)
 
 	err := rootCmd.ExecuteContext(ctx)

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -31,6 +31,10 @@ agbox exec cancel
 agbox exec list
 # Launch interactive agent session
 agbox agent
+# Launch agent session via top-level shortcut (equivalent to agbox agent <type>)
+agbox claude
+agbox codex
+agbox openclaw
 # Generate shell autocompletion script (bash, zsh, fish, powershell)
 agbox completion
 # Print usage for any command
@@ -77,6 +81,8 @@ Provides an out-of-the-box workflow: create a sandbox, optionally copy the proje
 ```bash
 # Use a registered agent type (resolves command + default builtin tools)
 agbox agent claude
+# Equivalent top-level shortcut
+agbox claude
 # Registered agent type with custom workspace
 agbox agent codex --workspace /path/to/project
 # Long-running mode
@@ -87,6 +93,10 @@ agbox agent --command "claude --dangerously-skip-permissions" --builtin-tool cla
 SB_ID=$(agbox agent --command "my-agent" --mode long-running --workspace /path/to/project 2>/dev/null)
 # Deploy OpenClaw gateway (long-running, persists after CLI exit)
 agbox agent openclaw
+# Set resource limits and environment variables
+agbox claude --cpu-limit 2 --memory-limit 4g --disk-limit 10g --env MY_API_KEY=secret
+# Override sandbox ID
+agbox codex --sandbox-id my-custom-sandbox
 ```
 
 ### Session Modes
@@ -113,7 +123,11 @@ Agent types declare their own capabilities, orthogonal to session mode. Each cap
 | builtinTools | Pre-installed tools | Fixed | Fixed | Fixed | User-specified | `--builtin-tool` |
 | workspace copy | Copy local directory to /workspace | Yes (default: cwd) | Yes (default: cwd) | No | No | `--workspace` (explicit to enable) |
 | .git check | Confirm when workspace lacks .git | Yes | Yes | No | No | None (automatic) |
-| sandboxIDGen | Custom ID generator | No | No | openclaw-XXXX | No | None |
+| envs | Environment variables for container | None | None | None | None | `--env` (repeatable, `KEY=VAL` form) |
+| cpuLimit | CPU limit | None | None | None | None | `--cpu-limit` (Docker `--cpus` format) |
+| memoryLimit | Memory limit | None | None | None | None | `--memory-limit` (Docker `--memory` format) |
+| diskLimit | Disk limit | None | None | None | None | `--disk-limit` (Docker `--storage-opt size=` format) |
+| sandboxIDGen | Custom ID generator | No | No | openclaw-XXXX | No | `--sandbox-id` |
 | configYaml | Embedded sandbox config | No | No | Yes (mounts, ports, envs) | No | None |
 | preFlight | Pre-flight validation | No | No | Auth + config check | No | None |
 | phases | Multi-phase startup | No | No | install + start | No | None |
@@ -125,7 +139,13 @@ Agent types declare their own capabilities, orthogonal to session mode. Each cap
   - Custom `--command` does not copy by default; passing `--workspace` explicitly enables it.
   - `/` and `$HOME` are rejected as workspace paths (symlinks are resolved before comparison).
 - `.git` check is declared per agent type (claude/codex enable it; openclaw and custom `--command` do not). When enabled, it triggers if the workspace directory lacks a `.git` entry.
-- openclaw auto-generates sandbox IDs matching `openclaw-XXXX` (4 hex chars); other types let the daemon generate IDs.
+- openclaw auto-generates sandbox IDs matching `openclaw-XXXX` (4 hex chars); other types let the daemon generate IDs. `--sandbox-id` overrides any generator; empty or omitted values fall through to the generator or daemon auto-generation.
+- `--env` passes environment variables to `CreateSpec.Envs`. Multiple `--env` flags are merged; duplicate keys use the last value. The daemon performs key-level merge with `configYaml` envs.
+- `--cpu-limit`, `--memory-limit`, and `--disk-limit` pass resource limits directly to `CreateSpec` fields. Values are not validated by the CLI; invalid formats are rejected by the daemon or Docker.
+
+### Top-Level Agent Shortcuts
+
+Each registered agent type is also available as a top-level command: `agbox claude`, `agbox codex`, `agbox openclaw`. These are exactly equivalent to `agbox agent <type>` — same flags, same behavior, same exit codes. The only difference is that top-level commands do not accept positional arguments (the agent type is implicit in the command name).
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

This PR delivers two merged issues as two clean commits:

### [ISSUE-187] Top-level agent commands

Promotes the three registered agent types (`claude`, `codex`, `openclaw`) to top-level CLI commands:
- `agbox claude` — equivalent to `agbox agent claude`
- `agbox codex` — equivalent to `agbox agent codex`
- `agbox openclaw` — equivalent to `agbox agent openclaw`

Core refactoring: extracted `agentSessionFlagVars` struct, `registerAgentSessionFlags()`, `buildAgentSessionRunE()`, and `newAgentTypeCommand()` as shared abstractions. All four entry points (agent + 3 top-level) share the same flag registration and resolution code path.

### [ISSUE-188] CreateSpec resource limits and env vars as CLI flags

Adds 5 new flags to all agent session commands:
- `--env KEY=VAL` (repeatable) — environment variables for the container
- `--cpu-limit` — CPU limit (Docker `--cpus` format)
- `--memory-limit` — memory limit (Docker `--memory` format)
- `--disk-limit` — disk limit (Docker `--storage-opt size=` format)
- `--sandbox-id` — custom sandbox ID (overrides agent type generator)

All flags propagate directly to `CreateSpec` / `CreateSandboxRequest`. No daemon or proto changes needed.

## Changes

- `cmd/agbox/cmd_agent.go` — shared flag abstraction, resolve logic, top-level command factory
- `cmd/agbox/root.go` — register 3 top-level commands
- `cmd/agbox/agent_session.go` — map new fields to `CreateSpec` in both session modes
- `cmd/agbox/cmd_agent_test.go` — 18 existing tests migrated + 5 new test functions
- `cmd/agbox/agent_session_test.go` — flag propagation test
- `docs/cli_reference.md` — document new commands and flags

## Test Coverage

- `TestTopLevelAgentCommandsEquivalent` — verifies behavioral equivalence across all 3 types
- `TestTopLevelCommandRejectsPositionalArgs` / `TestTopLevelCommandRejectsCommandFlag` — cobra constraint tests
- `TestResolveAgentSessionArgsFlags` — 13 table-driven subtests for all flag edge cases
- `TestRunAgentSessionPropagatesFlagsToCreateSpec` — end-to-end flag → CreateSpec verification
- `TestTopLevelCommandsInheritNewFlags` — top-level commands receive all new flags
- All existing tests pass without modification (signature migration only)

Closes #187
Closes #188
