### PR TITLE
[ISSUE-193] Remove `agbox agent <type>` duplicate CLI surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ curl -fsSL https://agents-sandbox.com/install.sh | bash
 
 # Run Claude Code in an isolated sandbox with full permissions
 # Equivalent to: claude --dangerously-skip-permissions
-agbox agent claude
+agbox claude
 
 # Run Codex in an isolated sandbox with full permissions
 # Equivalent to: codex --dangerously-bypass-approvals-and-sandbox
-agbox agent codex
+agbox codex
 ```
 
 Same single command — but now the agent is sandboxed, and your host is untouched.

--- a/cmd/agbox/agent_session.go
+++ b/cmd/agbox/agent_session.go
@@ -46,9 +46,10 @@ func primaryContainerName(sandboxID string) string {
 	return "agbox-primary-" + sanitizeContainerName(sandboxID)
 }
 
-// runAgentSession implements the shared flow for `agbox agent <tool>` and
-// `agbox agent --command "..."`. It validates inputs, connects to the daemon,
-// and dispatches to the appropriate mode handler.
+// runAgentSession implements the shared flow for top-level per-type agent
+// commands (`agbox claude`, `agbox codex`, `agbox openclaw`) and for
+// `agbox agent --command "..."`. It validates inputs, connects to the
+// daemon, and dispatches to the appropriate mode handler.
 func runAgentSession(
 	ctx context.Context,
 	parsed agentSessionArgs,

--- a/cmd/agbox/cmd_agent.go
+++ b/cmd/agbox/cmd_agent.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -41,17 +40,14 @@ func registerAgentSessionFlags(cmd *cobra.Command, v *agentSessionFlagVars) {
 }
 
 // buildAgentSessionRunE creates the RunE function for agent session commands.
-// When agentType is non-empty (top-level commands), it skips positional arg parsing.
+// agentType is non-empty for top-level per-type commands (agbox claude, etc.)
+// and empty for the `agbox agent --command` custom-command command.
 func buildAgentSessionRunE(agentType string, v *agentSessionFlagVars) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		resolvedType := agentType
-		if resolvedType == "" && len(args) > 0 {
-			resolvedType = args[0]
-		}
+	return func(cmd *cobra.Command, _ []string) error {
 		v.modeOverridden = cmd.Flags().Changed("mode")
 		v.workspaceOverridden = cmd.Flags().Changed("workspace")
 		v.builtinToolsOverridden = cmd.Flags().Changed("builtin-tool")
-		parsed, err := resolveAgentSessionArgs(v, resolvedType)
+		parsed, err := resolveAgentSessionArgs(v, agentType)
 		if err != nil {
 			return err
 		}
@@ -76,40 +72,31 @@ type agentSessionArgs struct {
 	readyMessage func(sandboxID, containerName string) string // custom ready message
 }
 
-// registeredAgentNames returns the sorted list of pre-registered agent type names.
-func registeredAgentNames() []string {
-	names := make([]string, 0, len(agentTypeDefs))
-	for name := range agentTypeDefs {
-		names = append(names, name)
-	}
-	// Sort for deterministic output.
-	sort.Strings(names)
-	return names
-}
-
+// newAgentCommand builds `agbox agent --command "..."` for running a custom
+// agent binary inside a sandbox. Registered agent types (claude, codex,
+// openclaw) are exposed as top-level commands instead — they are not
+// accepted here as positional arguments.
 func newAgentCommand() *cobra.Command {
 	var v agentSessionFlagVars
-	agentNames := registeredAgentNames()
 	cmd := &cobra.Command{
-		Use:       "agent [agent_type]",
-		Short:     "Launch agent session",
-		Long:      "Launch agent session.\n\nAvailable agent types: " + strings.Join(agentNames, ", ") + "\nOr use --command for a custom agent.",
-		Args:      cobra.MaximumNArgs(1),
-		ValidArgs: agentNames,
-		RunE:      buildAgentSessionRunE("", &v),
+		Use:   "agent",
+		Short: "Launch a custom agent session via --command",
+		Long:  "Launch a sandbox and run a custom agent command specified via --command.\n\nFor pre-registered agents, use the dedicated top-level commands: agbox claude, agbox codex, agbox openclaw.",
+		Args:  cobra.NoArgs,
+		RunE:  buildAgentSessionRunE("", &v),
 	}
 	registerAgentSessionFlags(cmd, &v)
 	return cmd
 }
 
-// newAgentTypeCommand creates a top-level command for a specific agent type
-// (e.g. "agbox claude"), equivalent to "agbox agent <type>".
+// newAgentTypeCommand creates a top-level command for a specific registered
+// agent type (e.g. "agbox claude").
 func newAgentTypeCommand(agentType string) *cobra.Command {
 	var v agentSessionFlagVars
 	cmd := &cobra.Command{
 		Use:   agentType,
 		Short: fmt.Sprintf("Launch %s agent session", agentType),
-		Long:  fmt.Sprintf("Launch %s agent session (equivalent to 'agbox agent %s').", agentType, agentType),
+		Long:  fmt.Sprintf("Launch %s agent session.", agentType),
 		Args:  cobra.NoArgs,
 		RunE:  buildAgentSessionRunE(agentType, &v),
 	}
@@ -138,7 +125,9 @@ func resolveAgentSessionArgs(
 		var ok bool
 		typeDef, ok = agentTypeDefs[agentType]
 		if !ok {
-			return agentSessionArgs{}, usageErrorf("unknown agent type %q; use --command for custom agents", agentType)
+			// Should not happen: agentType is injected by top-level per-type commands
+			// which are registered only for known types.
+			return agentSessionArgs{}, usageErrorf("unknown agent type %q", agentType)
 		}
 		isRegistered = true
 		parsed.agentType = agentType
@@ -156,7 +145,7 @@ func resolveAgentSessionArgs(
 		}
 		parsed.builtinTools = v.builtinTools
 	} else {
-		return agentSessionArgs{}, usageErrorf("agbox agent requires an agent type or --command")
+		return agentSessionArgs{}, usageErrorf("agbox agent requires --command; for pre-registered agents use agbox claude / agbox codex / agbox openclaw")
 	}
 
 	// Mode resolution.

--- a/cmd/agbox/cmd_agent_test.go
+++ b/cmd/agbox/cmd_agent_test.go
@@ -94,9 +94,9 @@ func TestResolveAgentSessionArgs_MutualExclusion(t *testing.T) {
 func TestResolveAgentSessionArgs_NeitherTypeNorCommand(t *testing.T) {
 	_, err := resolveAgentSessionArgs(&agentSessionFlagVars{workspace: "/work", workspaceOverridden: true}, "")
 	if err == nil {
-		t.Fatal("expected error when neither agent type nor --command is given")
+		t.Fatal("expected error when --command is missing on agbox agent")
 	}
-	if !strings.Contains(err.Error(), "requires an agent type or --command") {
+	if !strings.Contains(err.Error(), "requires --command") {
 		t.Fatalf("unexpected error message: %v", err)
 	}
 }
@@ -118,19 +118,6 @@ func TestResolveAgentSessionArgs_EmptyCommand(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "must not be empty") {
 		t.Fatalf("unexpected error message: %v", err)
-	}
-}
-
-func TestResolveAgentSessionArgs_DuplicateAgentType(t *testing.T) {
-	tmpDir := realTempDir(t)
-	// With cobra, duplicate positional args are prevented by cobra.MaximumNArgs(1).
-	// Here we test resolveAgentSessionArgs directly with a registered agent type.
-	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{workspace: tmpDir, workspaceOverridden: true}, "claude")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if parsed.agentType != "claude" {
-		t.Fatalf("expected agentType=claude, got %q", parsed.agentType)
 	}
 }
 
@@ -404,53 +391,6 @@ func TestResolveAgentSessionArgs_ConfigYaml(t *testing.T) {
 	}
 }
 
-func TestTopLevelAgentCommandsEquivalent(t *testing.T) {
-	for _, agentType := range []string{"claude", "codex", "openclaw"} {
-		t.Run(agentType, func(t *testing.T) {
-			v := &agentSessionFlagVars{}
-			topLevel, err := resolveAgentSessionArgs(v, agentType)
-			if err != nil {
-				t.Fatalf("top-level resolve error: %v", err)
-			}
-
-			vSub := &agentSessionFlagVars{}
-			subCmd, err := resolveAgentSessionArgs(vSub, agentType)
-			if err != nil {
-				t.Fatalf("sub-command resolve error: %v", err)
-			}
-
-			if topLevel.agentType != subCmd.agentType {
-				t.Fatalf("agentType mismatch: %q vs %q", topLevel.agentType, subCmd.agentType)
-			}
-			if topLevel.mode != subCmd.mode {
-				t.Fatalf("mode mismatch: %q vs %q", topLevel.mode, subCmd.mode)
-			}
-			if len(topLevel.command) != len(subCmd.command) {
-				t.Fatalf("command length mismatch: %v vs %v", topLevel.command, subCmd.command)
-			}
-			for i := range topLevel.command {
-				if topLevel.command[i] != subCmd.command[i] {
-					t.Fatalf("command[%d] mismatch: %q vs %q", i, topLevel.command[i], subCmd.command[i])
-				}
-			}
-			if len(topLevel.builtinTools) != len(subCmd.builtinTools) {
-				t.Fatalf("builtinTools length mismatch: %v vs %v", topLevel.builtinTools, subCmd.builtinTools)
-			}
-			for i := range topLevel.builtinTools {
-				if topLevel.builtinTools[i] != subCmd.builtinTools[i] {
-					t.Fatalf("builtinTools[%d] mismatch: %q vs %q", i, topLevel.builtinTools[i], subCmd.builtinTools[i])
-				}
-			}
-			if topLevel.configYaml != subCmd.configYaml {
-				t.Fatalf("configYaml mismatch")
-			}
-			if len(topLevel.phases) != len(subCmd.phases) {
-				t.Fatalf("phases length mismatch: %d vs %d", len(topLevel.phases), len(subCmd.phases))
-			}
-		})
-	}
-}
-
 func TestTopLevelCommandRejectsPositionalArgs(t *testing.T) {
 	cmd := newAgentTypeCommand("claude")
 	cmd.SilenceErrors = true
@@ -459,6 +399,19 @@ func TestTopLevelCommandRejectsPositionalArgs(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for positional arg on top-level command")
+	}
+}
+
+// TestAgentCommandRejectsPositionalAgentType ensures `agbox agent <type>`
+// is no longer supported — callers must use the top-level per-type command.
+func TestAgentCommandRejectsPositionalAgentType(t *testing.T) {
+	cmd := newAgentCommand()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"claude"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when positional agent type is passed to `agbox agent`")
 	}
 }
 

--- a/cmd/agbox/openclaw.go
+++ b/cmd/agbox/openclaw.go
@@ -122,7 +122,7 @@ Manage:
   agbox sandbox stop %s      # stop gateway
   agbox sandbox resume %s    # restart container only (gateway process lost)
   # To redeploy after resume: delete and recreate
-  agbox sandbox delete %s && agbox agent openclaw
+  agbox sandbox delete %s && agbox openclaw
   agbox sandbox delete %s    # delete sandbox
   agbox exec list %s         # list running execs
 `, gatewayURL, sandboxID, sandboxID, sandboxID, sandboxID, sandboxID, sandboxID)

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -1,7 +1,9 @@
 # Agent Guide
 
-The `agbox agent` command creates a sandbox, installs tools, and runs an AI agent
-in a single step.
+The agent commands (`agbox claude`, `agbox codex`, `agbox openclaw`, and
+`agbox agent --command "..."`) create a sandbox, install tools, and run an AI
+agent in a single step. Each registered agent type has its own top-level command;
+`agbox agent` itself is reserved exclusively for the `--command` custom-agent mode.
 
 **Workspace**: the current directory (or `--workspace` path) is copied into
 `/workspace` inside the container. Changes inside the sandbox do **not** affect
@@ -23,14 +25,14 @@ Claude and Codex share identical workflow — only the CLI binary differs.
 
 ```bash
 # Basic usage
-agbox agent claude
-agbox agent codex
+agbox claude
+agbox codex
 
 # Use a specific project directory
-agbox agent claude --workspace /path/to/project
+agbox claude --workspace /path/to/project
 
 # Override builtin tools (each sandbox image defines a default set)
-agbox agent codex --builtin-tool claude --builtin-tool git
+agbox codex --builtin-tool claude --builtin-tool git
 ```
 
 ## OpenClaw
@@ -54,7 +56,7 @@ OPENCLAW_STATE_DIR=~/.openclaw openclaw models auth add --provider openai --api-
 ### Deploy
 
 ```bash
-agbox agent openclaw
+agbox openclaw
 ```
 
 The CLI creates a sandbox, installs `openclaw@latest`, and starts the gateway.
@@ -93,9 +95,13 @@ graph TD
 
 Use [sandbox commands](cli_reference.md) to stop/delete/list sandboxes.
 `agbox sandbox resume` does not restart the gateway — to redeploy, delete and recreate:
-`agbox sandbox delete <sandbox-id> && agbox agent openclaw`.
+`agbox sandbox delete <sandbox-id> && agbox openclaw`.
 
 ## Custom Command
+
+`agbox agent` is the only entry point for the custom-command mode; it requires
+`--command` and does not accept a positional agent type (use `agbox claude` /
+`agbox codex` / `agbox openclaw` for those).
 
 Run any command inside a sandbox:
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -29,12 +29,12 @@ agbox exec get
 agbox exec cancel
 # List active execs
 agbox exec list
-# Launch interactive agent session
-agbox agent
-# Launch agent session via top-level shortcut (equivalent to agbox agent <type>)
+# Launch a pre-registered agent session (top-level command per type)
 agbox claude
 agbox codex
 agbox openclaw
+# Launch a custom agent via --command (only use-case for `agbox agent`)
+agbox agent --command "<binary> [args...]"
 # Generate shell autocompletion script (bash, zsh, fish, powershell)
 agbox completion
 # Print usage for any command
@@ -74,29 +74,31 @@ agbox exec list [sandbox_id] [--json]
 - `cancel`: cancels a running exec. Waits until the exec reaches a terminal state.
 - `list`: lists active execs. Optionally filter by sandbox ID.
 
-## Agent Command
+## Agent Commands
 
-Provides an out-of-the-box workflow: create a sandbox, optionally copy the project directory, run an agent, and manage the sandbox lifecycle.
+Provide an out-of-the-box workflow: create a sandbox, optionally copy the project directory, run an agent, and manage the sandbox lifecycle.
+
+The CLI exposes one top-level command per registered agent type. Use them directly — there is no `agbox agent <type>` form. The generic `agbox agent` entry point is reserved for the custom-command mode (`--command`).
 
 ```bash
-# Use a registered agent type (resolves command + default builtin tools)
-agbox agent claude
-# Equivalent top-level shortcut
+# Pre-registered agents (top-level commands)
 agbox claude
-# Registered agent type with custom workspace
-agbox agent codex --workspace /path/to/project
+agbox codex
+agbox openclaw                                         # deploy OpenClaw gateway (long-running)
+
+# Custom workspace
+agbox codex --workspace /path/to/project
 # Long-running mode
-agbox agent claude --mode long-running
-# Custom command with explicit builtin tools
-agbox agent --command "claude --dangerously-skip-permissions" --builtin-tool claude --builtin-tool git --builtin-tool uv --builtin-tool npm
-# Long-running custom command (stdout emits sandbox_id for scripting)
-SB_ID=$(agbox agent --command "my-agent" --mode long-running --workspace /path/to/project 2>/dev/null)
-# Deploy OpenClaw gateway (long-running, persists after CLI exit)
-agbox agent openclaw
-# Set resource limits and environment variables
+agbox claude --mode long-running
+# Resource limits and environment variables
 agbox claude --cpu-limit 2 --memory-limit 4g --disk-limit 10g --env MY_API_KEY=secret
 # Override sandbox ID
 agbox codex --sandbox-id my-custom-sandbox
+
+# Custom agent via `agbox agent --command` (the ONLY supported form of `agbox agent`)
+agbox agent --command "claude --dangerously-skip-permissions" --builtin-tool claude --builtin-tool git --builtin-tool uv --builtin-tool npm
+# Long-running custom command (stdout emits sandbox_id for scripting)
+SB_ID=$(agbox agent --command "my-agent" --mode long-running --workspace /path/to/project 2>/dev/null)
 ```
 
 ### Session Modes
@@ -143,9 +145,11 @@ Agent types declare their own capabilities, orthogonal to session mode. Each cap
 - `--env` passes environment variables to `CreateSpec.Envs`. Multiple `--env` flags are merged; duplicate keys use the last value. The daemon performs key-level merge with `configYaml` envs.
 - `--cpu-limit`, `--memory-limit`, and `--disk-limit` pass resource limits directly to `CreateSpec` fields. Values are not validated by the CLI; invalid formats are rejected by the daemon or Docker.
 
-### Top-Level Agent Shortcuts
+### Command Surface
 
-Each registered agent type is also available as a top-level command: `agbox claude`, `agbox codex`, `agbox openclaw`. These are exactly equivalent to `agbox agent <type>` — same flags, same behavior, same exit codes. The only difference is that top-level commands do not accept positional arguments (the agent type is implicit in the command name).
+Each registered agent type has its own dedicated top-level command: `agbox claude`, `agbox codex`, `agbox openclaw`. They do not accept positional arguments — the agent type is implicit in the command name. All of them reuse the same underlying session flags (`--mode`, `--workspace`, `--builtin-tool`, `--env`, `--cpu-limit`, `--memory-limit`, `--disk-limit`, `--sandbox-id`).
+
+`agbox agent` is reserved exclusively for the custom-command mode: you must pass `--command` and it does not accept a positional agent type. The old `agbox agent <type>` form has been removed — use the per-type top-level command instead.
 
 ## Exit Codes
 

--- a/docs/container_dependency_strategy.md
+++ b/docs/container_dependency_strategy.md
@@ -100,23 +100,23 @@ The runtime must execute under a non-root user inside the sandbox. Bind-mounted 
 
 Docker objects without these labels are never inspected, stopped, or removed by the daemon. Ownership must be derivable from runtime state plus namespaced labels without requiring an external product database snapshot. Cleanup continues on daemon-owned contexts rather than request-scoped cancellation.
 
-## Architectural Exception: `agbox agent`
+## Architectural Exception: agent commands
 
-The rule that all Docker access goes through the daemon's structured runtime client has one deliberate exception: `agbox agent` in interactive mode.
+The rule that all Docker access goes through the daemon's structured runtime client has one deliberate exception: the CLI agent commands in interactive mode.
 
-This subcommand creates a sandbox via gRPC, waits for it to become READY, then — depending on the session mode — either attaches directly or delegates to the daemon's exec model:
+These commands — the per-type top-level entries (`agbox claude`, `agbox codex`, `agbox openclaw`) and the custom-command entry (`agbox agent --command "..."`) — create a sandbox via gRPC, wait for it to become READY, then — depending on the session mode — either attach directly or delegate to the daemon's exec model:
 
 - **Interactive mode** (default): Calls `docker exec -it` directly from the CLI process to attach an interactive TTY session into the primary container. On exit, the sandbox is deleted via gRPC.
 - **Long-running mode** (`--mode long-running`): Submits the agent command via `CreateExec` RPC and waits for exec completion via event subscription. Does not call `docker exec` directly. On exit, the sandbox is not deleted and must be managed manually.
 
-Two agent definition modes are supported:
-- **Pre-registered tool:** `agbox agent claude`, `agbox agent codex` — uses built-in command and builtin-tool defaults from the agent tool registry.
-- **Custom command:** `agbox agent --command "aider --yes" --workspace /path/to/project` — user provides the full command and specifies the workspace directory.
+Two agent definition surfaces are supported:
+- **Pre-registered tool:** `agbox claude`, `agbox codex`, `agbox openclaw` — each is its own top-level command that uses the built-in command and builtin-tool defaults from the agent tool registry. The old `agbox agent <type>` form has been removed.
+- **Custom command:** `agbox agent --command "aider --yes" --workspace /path/to/project` — the only remaining use of `agbox agent`; the user provides the full command and specifies the workspace directory.
 
 **Why the interactive-mode exception is necessary:**
 
-The daemon's exec model is designed for non-interactive batch execution. Adding interactive TTY support at the daemon protocol layer would require gRPC bidirectional streaming plus in-daemon PTY management — significant complexity with little benefit beyond this subcommand. Calling `docker exec -it` directly from the CLI is simpler, keeps the daemon out of the TTY path, and is equivalent to what a user would do manually.
+The daemon's exec model is designed for non-interactive batch execution. Adding interactive TTY support at the daemon protocol layer would require gRPC bidirectional streaming plus in-daemon PTY management — significant complexity with little benefit beyond these commands. Calling `docker exec -it` directly from the CLI is simpler, keeps the daemon out of the TTY path, and is equivalent to what a user would do manually.
 
-**Known constraint:** The CLI's `docker exec` call (interactive mode only) and the daemon's Docker Engine API calls must target the same Docker daemon. If `DOCKER_HOST` or `DOCKER_CONTEXT` differs between the environment where `agboxd` was started and the shell running `agbox agent`, the exec may land on the wrong target. This is rarely a problem when `agboxd` runs as a user process sharing the shell environment.
+**Known constraint:** The CLI's `docker exec` call (interactive mode only) and the daemon's Docker Engine API calls must target the same Docker daemon. If `DOCKER_HOST` or `DOCKER_CONTEXT` differs between the environment where `agboxd` was started and the shell running the agent command, the exec may land on the wrong target. This is rarely a problem when `agboxd` runs as a user process sharing the shell environment.
 
-**Scope:** The direct Docker access exception is strictly limited to `agbox agent` in interactive mode. Long-running mode and all other CLI commands use the daemon's gRPC API exclusively.
+**Scope:** The direct Docker access exception is strictly limited to the agent commands in interactive mode. Long-running mode and all other CLI commands use the daemon's gRPC API exclusively.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -14,12 +14,12 @@ This installs `agboxd` (daemon) and `agbox` (CLI), then starts the daemon as a u
 
 ```bash
 # Claude Code — full permissions, fully isolated
-agbox agent claude
+agbox claude
 
 # Codex
-agbox agent codex
+agbox codex
 
-# Any custom command
+# Any custom command (agbox agent is only used for the --command form)
 agbox agent --command "aider --yes" --builtin-tool git --builtin-tool uv
 ```
 

--- a/docs/sandbox_container_lifecycle.md
+++ b/docs/sandbox_container_lifecycle.md
@@ -17,7 +17,8 @@ Docker object labels use the reverse-DNS namespace `io.github.1996fanrui.agents-
 
 ## CLI Agent Modes
 
-The `agbox agent` command supports two modes:
+The agent commands (`agbox claude`, `agbox codex`, `agbox openclaw`, and
+`agbox agent --command "..."`) support two modes:
 
 - **Interactive** (`--mode interactive`, default): Attaches a TTY to the agent process. The CLI deletes the sandbox on exit. Uses `idle_ttl=10d` as a safety net.
 - **Long-running** (`--mode long-running`): Submits the agent command via `CreateExec` and waits for completion. The CLI can detach (Ctrl+C) without affecting the sandbox. Uses `idle_ttl=0` (disable idle stop). The sandbox must be managed manually via `agbox sandbox stop/delete`.

--- a/website/index.html
+++ b/website/index.html
@@ -351,11 +351,11 @@
 
 <span class="cmd-comment"># Run interactive Claude Code in an isolated sandbox with full permissions.</span>
 <span class="cmd-comment"># Equivalent to running: claude --dangerously-skip-permissions</span>
-<span class="cmd-prefix">$ </span>agbox agent claude
+<span class="cmd-prefix">$ </span>agbox claude
 
 <span class="cmd-comment"># Run interactive Codex in an isolated sandbox with full permissions.</span>
 <span class="cmd-comment"># Equivalent to running: codex --dangerously-bypass-approvals-and-sandbox</span>
-<span class="cmd-prefix">$ </span>agbox agent codex</div>
+<span class="cmd-prefix">$ </span>agbox codex</div>
     </div>
     <a href="https://docs.agents-sandbox.com" class="link-arrow">View full documentation &rarr;</a>
   </div>

--- a/website/script.js
+++ b/website/script.js
@@ -126,7 +126,7 @@
 function closeMobileMenu() { document.getElementById('mobileMenu').classList.remove('open'); }
 function copyCommands() {
   navigator.clipboard.writeText(
-    'curl -fsSL https://agents-sandbox.com/install.sh | bash\nagbox agent claude\nagbox agent codex'
+    'curl -fsSL https://agents-sandbox.com/install.sh | bash\nagbox claude\nagbox codex'
   ).then(function() {
     var btn = document.querySelector('.copy-btn');
     btn.textContent = 'Copied!';


### PR DESCRIPTION
## Summary

- Drop the `agbox agent <type>` form; registered agents must be invoked via the per-type top-level command (`agbox claude`, `agbox codex`, `agbox openclaw`).
- `agbox agent` is now reserved exclusively for the custom-command mode (`--command`) and no longer accepts a positional agent type.
- Underlying session resolution and flag registration stay fully shared across both surfaces — only the user-facing surface is simplified.
- All docs, the README, and the marketing site updated to drop old examples and explicitly state the new rule.

Close #193

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `agbox agent claude` now fails with "unknown command"
- [x] `agbox agent --help` documents `--command`-only usage and points to top-level per-type commands
- [x] `agbox claude --help` / `agbox codex --help` / `agbox openclaw --help` still work
