### PR TITLE
[ISSUE-189] Refactor openclaw to primary-command model and add paseo agent type

### DIFF
--- a/.github/workflows/publish-openclaw-runtime.yml
+++ b/.github/workflows/publish-openclaw-runtime.yml
@@ -1,0 +1,72 @@
+name: Publish OpenClaw Runtime
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version to publish, for example 1.2.3 or v1.2.3
+        required: true
+        type: string
+  push:
+    tags:
+      - "image-openclaw-v*"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/agents-sandbox/openclaw-runtime
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          set -e
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            raw_version="${GITHUB_REF_NAME}"
+          else
+            raw_version="${{ inputs.version }}"
+          fi
+
+          version="${raw_version#image-openclaw-v}"
+          version="${version#v}"
+          if [ -z "${version}" ]; then
+            echo "Release version cannot be empty." >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push openclaw runtime
+        uses: docker/build-push-action@v6
+        with:
+          context: images/openclaw-runtime
+          file: images/openclaw-runtime/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: OPENCLAW_VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.IMAGE_NAME }}:latest

--- a/cmd/agbox/agent_session.go
+++ b/cmd/agbox/agent_session.go
@@ -59,9 +59,14 @@ func runAgentSession(
 ) error {
 	// Run pre-flight checks if the agent type defines them.
 	if typeDef, ok := agentTypeDefs[parsed.agentType]; ok && typeDef.preFlight != nil {
-		if err := typeDef.preFlight(stderr); err != nil {
+		if err := typeDef.preFlight(stderr, &parsed); err != nil {
 			return err
 		}
+	}
+
+	// Inject paseo readyMessage factory after preFlight has filtered builtinTools.
+	if parsed.agentType == "paseo" {
+		parsed.readyMessage = paseoReadyMessageFactory(parsed.builtinTools)
 	}
 
 	// Workspace existence check (only when workspace is non-empty).
@@ -150,7 +155,7 @@ func runInteractiveSession(
 		SandboxId:  parsed.sandboxID,
 		ConfigYaml: configYamlBytes(parsed.configYaml),
 		CreateSpec: &agboxv1.CreateSpec{
-			Image:        defaultImage,
+			Image:        parsed.image,
 			BuiltinTools: parsed.builtinTools,
 			Copies:       copies,
 			Envs:         parsed.envs,
@@ -245,9 +250,9 @@ func runInteractiveSession(
 	}
 }
 
-// runLongRunningSession submits the agent command via CreateExec and waits for
-// completion. The CLI can detach (Ctrl+C) without affecting the sandbox. The
-// sandbox must be managed manually via `agbox sandbox stop/delete`.
+// runLongRunningSession creates the sandbox, waits for it to become READY,
+// then detaches. The sandbox must be managed manually via
+// `agbox sandbox stop/delete`.
 func runLongRunningSession(
 	ctx context.Context,
 	client sandboxExecClient,
@@ -275,7 +280,8 @@ func runLongRunningSession(
 		SandboxId:  parsed.sandboxID,
 		ConfigYaml: configYamlBytes(parsed.configYaml),
 		CreateSpec: &agboxv1.CreateSpec{
-			Image:        defaultImage,
+			Image:        parsed.image,
+			Command:      parsed.command,
 			BuiltinTools: parsed.builtinTools,
 			Copies:       copies,
 			Envs:         parsed.envs,
@@ -326,124 +332,11 @@ func runLongRunningSession(
 	_, _ = fmt.Fprintf(stderr, "     [%.1fs]\n", time.Since(waitStart).Seconds())
 	_, _ = fmt.Fprintf(stderr, "  Shell: docker exec -it --user agbox %s bash\n", containerName)
 
-	if len(parsed.phases) > 0 {
-		// Multi-phase execution.
-		for i, phase := range parsed.phases {
-			_, _ = fmt.Fprintf(stderr, "%s", phase.label)
-			phaseStart := time.Now()
+	// After READY, container is running. Set detachSuccess so deferred cleanup
+	// does not delete the sandbox.
+	detachSuccess = true
 
-			createExecResp, err := client.CreateExec(ctx, &agboxv1.CreateExecRequest{
-				SandboxId: sandboxID,
-				Command:   phase.command,
-			})
-			if err != nil {
-				return runtimeErrorf("create exec (phase %d): %v", i+1, err)
-			}
-
-			if i == 0 {
-				detachSuccess = true
-			}
-
-			execID := createExecResp.GetExecId()
-			if err := waitForExecDone(ctx, client, execID, sandboxID); err != nil {
-				_, _ = fmt.Fprintf(stderr, "\n\nPhase %q failed.\n", phase.label)
-				_, _ = fmt.Fprintf(stderr, "  Stderr log: docker exec --user agbox %s cat %s\n", containerName, createExecResp.GetStderrLogPath())
-				_, _ = fmt.Fprintf(stderr, "  Clean up:   agbox sandbox delete %s\n", sandboxID)
-				return err
-			}
-
-			_, _ = fmt.Fprintf(stderr, "     [%.1fs]\n", time.Since(phaseStart).Seconds())
-		}
-	} else {
-		// Single exec (existing behavior for claude/codex).
-		createExecResp, err := client.CreateExec(ctx, &agboxv1.CreateExecRequest{
-			SandboxId: sandboxID,
-			Command:   parsed.command,
-		})
-		if err != nil {
-			return runtimeErrorf("create exec: %v", err)
-		}
-
-		execID := createExecResp.GetExecId()
-
-		// Exec is now running on the daemon side. From this point on, do not
-		// clean up the sandbox — the exec must be allowed to complete even if
-		// subsequent RPC calls (GetExec, Subscribe) fail from the CLI.
-		detachSuccess = true
-
-		// Get baseline exec status to determine the subscription cursor.
-		getExecResp, err := client.GetExec(ctx, execID)
-		if err != nil {
-			return runtimeErrorf("get exec baseline: %v", err)
-		}
-		baseline, err := requireExecStatus(getExecResp, execID)
-		if err != nil {
-			return runtimeErrorf("get exec baseline: %v", err)
-		}
-
-		// Print access info before checking terminal state so the user always
-		// sees sandbox/exec identifiers even if the exec finished immediately.
-		_, _ = fmt.Fprintf(stderr, "\nSandbox ready. Exec submitted.\n")
-		_, _ = fmt.Fprintf(stderr, "  Command:    %s\n", strings.Join(parsed.command, " "))
-		_, _ = fmt.Fprintf(stderr, "  Sandbox ID: %s\n", sandboxID)
-		_, _ = fmt.Fprintf(stderr, "  Exec ID:    %s\n", execID)
-		_, _ = fmt.Fprintf(stderr, "  Container:  %s\n", containerName)
-		_, _ = fmt.Fprintf(stderr, "  Attach:     docker exec -it --user agbox %s bash\n", containerName)
-		_, _ = fmt.Fprintf(stderr, "  Stdout log: %s\n", createExecResp.GetStdoutLogPath())
-		_, _ = fmt.Fprintf(stderr, "  Stderr log: %s\n", createExecResp.GetStderrLogPath())
-
-		// stdout: only sandbox_id for programmatic consumption.
-		_, _ = fmt.Fprintln(stdout, sandboxID)
-
-		// If already terminal (e.g., instant failure), report and exit.
-		if isTerminalExecState(baseline.GetState()) {
-			return longRunningExecResult(stderr, baseline)
-		}
-
-		_, _ = fmt.Fprintf(stderr, "\nWaiting for exec to complete...\n")
-
-		// Subscribe to sandbox events to watch for exec completion.
-		stream, err := client.SubscribeSandboxEvents(ctx, baseline.GetSandboxId(), baseline.GetLastEventSequence(), false)
-		if err != nil {
-			return runtimeErrorf("subscribe sandbox events: %v", err)
-		}
-		defer stream.Close()
-
-		eventCh := make(chan execEventResult, 1)
-		go pumpExecEvents(stream, eventCh)
-
-		for {
-			select {
-			case <-sigintCh:
-				// Detach: leave sandbox and exec running, exit with signal code.
-				return exitCodeError(130)
-			case <-sigtermCh:
-				return exitCodeError(143)
-			case result, ok := <-eventCh:
-				if !ok {
-					return runtimeErrorf("exec event stream closed; check result with: agbox exec get %s", execID)
-				}
-				if result.err != nil {
-					return runtimeErrorf("wait exec events: %v", result.err)
-				}
-				currentResp, err := client.GetExec(ctx, execID)
-				if err != nil {
-					return runtimeErrorf("get exec: %v", err)
-				}
-				current, err := requireExecStatus(currentResp, execID)
-				if err != nil {
-					return runtimeErrorf("get exec: %v", err)
-				}
-				if isTerminalExecState(current.GetState()) {
-					return longRunningExecResult(stderr, current)
-				}
-			case <-ctx.Done():
-				return runtimeErrorf("wait exec: %v", ctx.Err())
-			}
-		}
-	}
-
-	// Print readyMessage if defined (long-running mode only).
+	// Print readyMessage if defined.
 	if parsed.readyMessage != nil {
 		_, _ = fmt.Fprint(stderr, parsed.readyMessage(sandboxID, containerName))
 	}
@@ -451,28 +344,6 @@ func runLongRunningSession(
 	// stdout: sandbox_id for programmatic consumption.
 	_, _ = fmt.Fprintln(stdout, sandboxID)
 	return nil
-}
-
-// longRunningExecResult prints the terminal exec result to stderr and returns
-// an appropriate exit code error.
-func longRunningExecResult(stderr io.Writer, status *agboxv1.ExecStatus) error {
-	code := execExitCode(status.GetState(), status.GetExitCode(), 0)
-	switch status.GetState() {
-	case agboxv1.ExecState_EXEC_STATE_FINISHED:
-		_, _ = fmt.Fprintf(stderr, "Exec finished (exit_code=%d).\n", status.GetExitCode())
-	case agboxv1.ExecState_EXEC_STATE_FAILED:
-		_, _ = fmt.Fprintf(stderr, "Exec failed (exit_code=%d).", status.GetExitCode())
-		if status.GetError() != "" {
-			_, _ = fmt.Fprintf(stderr, " Error: %s", status.GetError())
-		}
-		_, _ = fmt.Fprintln(stderr)
-	case agboxv1.ExecState_EXEC_STATE_CANCELLED:
-		_, _ = fmt.Fprintf(stderr, "Exec cancelled.\n")
-	}
-	if code == 0 {
-		return nil
-	}
-	return exitCodeError(code)
 }
 
 // waitForExecDone blocks until the exec reaches a terminal state.

--- a/cmd/agbox/agent_session_test.go
+++ b/cmd/agbox/agent_session_test.go
@@ -171,57 +171,77 @@ func TestRunAgentSession_InteractiveTTYCheck(t *testing.T) {
 	}
 }
 
-func TestRunAgentSession_LongRunningNoTTY(t *testing.T) {
-	// Long-running mode should NOT fail with TTY error; it proceeds to CreateSandbox.
+// newReadyOnlyMock creates a mockAgentClient where subscribe delivers a READY
+// event immediately. No CreateExec/GetExec needed.
+func newReadyOnlyMock() *mockAgentClient {
 	eventCh := make(chan *agboxv1.SandboxEvent, 1)
-	mock := newReadyMock(eventCh)
-
-	getExecCalls := 0
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return &agboxv1.CreateExecResponse{ExecId: "exec-1", StdoutLogPath: "/logs/stdout", StderrLogPath: "/logs/stderr"}, nil
-	}
-	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
-		getExecCalls++
-		if getExecCalls == 1 {
-			// Baseline: running.
-			return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_RUNNING, 3, 0), nil
-		}
-		// Terminal: finished.
-		return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_FINISHED, 4, 0), nil
-	}
-
-	// Send an event to unblock the wait loop.
 	eventCh <- &agboxv1.SandboxEvent{
-		EventId: "ev-1", Sequence: 4, SandboxId: "sb-001",
-		Details: &agboxv1.SandboxEvent_Exec{Exec: &agboxv1.ExecEventDetails{ExecId: "exec-1"}},
+		EventId: "ev-ready", Sequence: 2, SandboxId: "sb-001",
+		SandboxState: agboxv1.SandboxState_SANDBOX_STATE_READY,
+		Details: &agboxv1.SandboxEvent_SandboxPhase{SandboxPhase: &agboxv1.SandboxPhaseDetails{
+			Phase: "ready",
+		}},
+	}
+	return &mockAgentClient{
+		createSandboxFn: func(_ context.Context, _ *agboxv1.CreateSandboxRequest) (*agboxv1.CreateSandboxResponse, error) {
+			return &agboxv1.CreateSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:         "sb-001",
+					State:             agboxv1.SandboxState_SANDBOX_STATE_PENDING,
+					LastEventSequence: 1,
+				},
+			}, nil
+		},
+		getSandboxFn: func(_ context.Context, id string) (*agboxv1.GetSandboxResponse, error) {
+			return &agboxv1.GetSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:         id,
+					State:             agboxv1.SandboxState_SANDBOX_STATE_READY,
+					LastEventSequence: 2,
+				},
+			}, nil
+		},
+		deleteSandboxFn: func(_ context.Context, _ string) (*agboxv1.AcceptedResponse, error) {
+			return &agboxv1.AcceptedResponse{Accepted: true}, nil
+		},
+		subscribeFn: func(_ context.Context, _ string, _ uint64, _ bool) (rawclient.SandboxEventStream, error) {
+			return &mockEventStream{events: eventCh}, nil
+		},
+	}
+}
+
+func TestRunLongRunningSession_SingleHappyPath(t *testing.T) {
+	// AT-L1: sandbox READY → detach, stdout = sandbox_id, no delete.
+	mock := newReadyOnlyMock()
+
+	readyMsg := func(sandboxID, containerName string) string {
+		return fmt.Sprintf("ready: %s %s\n", sandboxID, containerName)
 	}
 
 	var stdout, stderr bytes.Buffer
 	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
-		mode:    agentModeLongRunning,
-		command: []string{"sleep", "infinity"},
+		mode:         agentModeLongRunning,
+		command:      []string{"my-service", "start"},
+		readyMessage: readyMsg,
 	}, "test", &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Verify no TTY error occurred (we reached sandbox creation).
-	if mock.createSandboxReq == nil {
-		t.Fatal("expected CreateSandbox to be called")
+
+	if got := strings.TrimSpace(stdout.String()); got != "sb-001" {
+		t.Fatalf("expected stdout=%q, got %q", "sb-001", got)
+	}
+	if !strings.Contains(stderr.String(), "ready: sb-001") {
+		t.Fatalf("expected readyMessage in stderr, got:\n%s", stderr.String())
+	}
+	if mock.deleteCalled {
+		t.Fatal("expected DeleteSandbox NOT to be called on success")
 	}
 }
 
 func TestRunAgentSession_LongRunningIdleTTL(t *testing.T) {
 	// Verify idle_ttl=0 in CreateSandbox request.
-	eventCh := make(chan *agboxv1.SandboxEvent, 1)
-	mock := newReadyMock(eventCh)
-
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return &agboxv1.CreateExecResponse{ExecId: "exec-1"}, nil
-	}
-	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
-		// Return terminal immediately so the test finishes.
-		return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_FINISHED, 3, 0), nil
-	}
+	mock := newReadyOnlyMock()
 
 	var stdout, stderr bytes.Buffer
 	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
@@ -232,7 +252,6 @@ func TestRunAgentSession_LongRunningIdleTTL(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify idle_ttl was set to 0.
 	req := mock.createSandboxReq
 	if req == nil {
 		t.Fatal("expected CreateSandbox to be called")
@@ -248,58 +267,36 @@ func TestRunAgentSession_LongRunningIdleTTL(t *testing.T) {
 }
 
 func TestRunAgentSession_LongRunningOutput(t *testing.T) {
-	// Verify stdout=sandbox_id, stderr has status info.
-	eventCh := make(chan *agboxv1.SandboxEvent, 1)
-	mock := newReadyMock(eventCh)
+	// Verify stdout=sandbox_id, stderr has readyMessage.
+	mock := newReadyOnlyMock()
 
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return &agboxv1.CreateExecResponse{ExecId: "exec-1", StdoutLogPath: "/logs/exec-1.stdout.log", StderrLogPath: "/logs/exec-1.stderr.log"}, nil
-	}
-	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
-		return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_FINISHED, 3, 0), nil
+	readyMsg := func(sandboxID, containerName string) string {
+		return fmt.Sprintf("Service running on %s (container: %s)\n", sandboxID, containerName)
 	}
 
 	var stdout, stderr bytes.Buffer
 	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
-		mode:    agentModeLongRunning,
-		command: []string{"echo", "hello"},
+		mode:         agentModeLongRunning,
+		command:      []string{"echo", "hello"},
+		readyMessage: readyMsg,
 	}, "test", &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// stdout should contain only the sandbox_id.
 	if got := strings.TrimSpace(stdout.String()); got != "sb-001" {
 		t.Fatalf("expected stdout=%q, got %q", "sb-001", got)
 	}
 
-	// stderr should contain key access info.
 	stderrStr := stderr.String()
-	for _, want := range []string{
-		"Sandbox ID: sb-001",
-		"Exec ID:    exec-1",
-		"echo hello",
-		"/logs/exec-1.stdout.log",
-		"/logs/exec-1.stderr.log",
-		"Exec finished (exit_code=0)",
-	} {
-		if !strings.Contains(stderrStr, want) {
-			t.Fatalf("stderr missing %q, got:\n%s", want, stderrStr)
-		}
+	if !strings.Contains(stderrStr, "Service running on sb-001") {
+		t.Fatalf("stderr missing readyMessage, got:\n%s", stderrStr)
 	}
 }
 
 func TestRunAgentSession_LongRunningNoDelete(t *testing.T) {
-	// Verify DeleteSandbox is NOT called on successful exec delivery + completion.
-	eventCh := make(chan *agboxv1.SandboxEvent, 1)
-	mock := newReadyMock(eventCh)
-
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return &agboxv1.CreateExecResponse{ExecId: "exec-1"}, nil
-	}
-	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
-		return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_FINISHED, 3, 0), nil
-	}
+	// Verify DeleteSandbox is NOT called after READY (detachSuccess=true).
+	mock := newReadyOnlyMock()
 
 	var stdout, stderr bytes.Buffer
 	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
@@ -315,31 +312,43 @@ func TestRunAgentSession_LongRunningNoDelete(t *testing.T) {
 	}
 }
 
-func TestRunAgentSession_LongRunningExecFailCleanup(t *testing.T) {
-	// Verify DeleteSandbox IS called when CreateExec fails.
-	eventCh := make(chan *agboxv1.SandboxEvent, 1)
-	mock := newReadyMock(eventCh)
+func TestRunLongRunningSession_SandboxFailed_ReturnsError(t *testing.T) {
+	// AT-L3: sandbox enters FAILED → error returned, sandbox cleaned up.
+	failedEventCh := make(chan *agboxv1.SandboxEvent, 1)
+	failedEventCh <- &agboxv1.SandboxEvent{
+		EventId: "ev-fail", Sequence: 2, SandboxId: "sb-001",
+		SandboxState: agboxv1.SandboxState_SANDBOX_STATE_FAILED,
+		Details: &agboxv1.SandboxEvent_SandboxPhase{SandboxPhase: &agboxv1.SandboxPhaseDetails{
+			Phase: "materialization",
+		}},
+	}
 
-	// Make GetSandbox return DELETED to satisfy deleteAndWait.
-	origGetSandbox := mock.getSandboxFn
-	deletePhase := false
-	mock.getSandboxFn = func(ctx context.Context, id string) (*agboxv1.GetSandboxResponse, error) {
-		if deletePhase {
-			return &agboxv1.GetSandboxResponse{
+	mock := &mockAgentClient{
+		createSandboxFn: func(_ context.Context, _ *agboxv1.CreateSandboxRequest) (*agboxv1.CreateSandboxResponse, error) {
+			return &agboxv1.CreateSandboxResponse{
 				Sandbox: &agboxv1.SandboxHandle{
-					SandboxId: id,
-					State:     agboxv1.SandboxState_SANDBOX_STATE_DELETED,
+					SandboxId:         "sb-001",
+					State:             agboxv1.SandboxState_SANDBOX_STATE_PENDING,
+					LastEventSequence: 1,
 				},
 			}, nil
-		}
-		return origGetSandbox(ctx, id)
-	}
-	mock.deleteSandboxFn = func(_ context.Context, _ string) (*agboxv1.AcceptedResponse, error) {
-		deletePhase = true
-		return &agboxv1.AcceptedResponse{Accepted: true}, nil
-	}
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return nil, fmt.Errorf("exec creation failed")
+		},
+		getSandboxFn: func(_ context.Context, id string) (*agboxv1.GetSandboxResponse, error) {
+			return &agboxv1.GetSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:         id,
+					State:             agboxv1.SandboxState_SANDBOX_STATE_FAILED,
+					LastEventSequence: 2,
+					ErrorMessage:      "image pull failed",
+				},
+			}, nil
+		},
+		deleteSandboxFn: func(_ context.Context, _ string) (*agboxv1.AcceptedResponse, error) {
+			return &agboxv1.AcceptedResponse{Accepted: true}, nil
+		},
+		subscribeFn: func(_ context.Context, _ string, _ uint64, _ bool) (rawclient.SandboxEventStream, error) {
+			return &mockEventStream{events: failedEventCh}, nil
+		},
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -348,180 +357,67 @@ func TestRunAgentSession_LongRunningExecFailCleanup(t *testing.T) {
 		command: []string{"echo"},
 	}, "test", &stdout, &stderr)
 	if err == nil {
-		t.Fatal("expected error from CreateExec failure")
+		t.Fatal("expected error when sandbox fails")
 	}
 
 	if !mock.deleteCalled {
-		t.Fatal("expected DeleteSandbox to be called on CreateExec failure")
+		t.Fatal("expected DeleteSandbox to be called when sandbox fails before READY")
 	}
 }
 
-func TestRunLongRunningSession_ExecSuccess(t *testing.T) {
-	// Exec FINISHED with exit_code=0.
-	eventCh := make(chan *agboxv1.SandboxEvent, 1)
-	mock := newReadyMock(eventCh)
-
-	getExecCalls := 0
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return &agboxv1.CreateExecResponse{ExecId: "exec-1"}, nil
-	}
-	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
-		getExecCalls++
-		if getExecCalls == 1 {
-			return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_RUNNING, 3, 0), nil
-		}
-		return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_FINISHED, 4, 0), nil
-	}
-
-	eventCh <- &agboxv1.SandboxEvent{
-		EventId: "ev-1", Sequence: 4, SandboxId: "sb-001",
-		Details: &agboxv1.SandboxEvent_Exec{Exec: &agboxv1.ExecEventDetails{ExecId: "exec-1"}},
-	}
+func TestRunLongRunningSession_CommandFromParsedOverridesYaml(t *testing.T) {
+	// AT-L5: command from parsed args is passed to CreateSpec.
+	mock := newReadyOnlyMock()
 
 	var stdout, stderr bytes.Buffer
 	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
 		mode:    agentModeLongRunning,
-		command: []string{"echo"},
+		command: []string{"custom-cmd", "--flag"},
 	}, "test", &stdout, &stderr)
 	if err != nil {
-		t.Fatalf("expected exit code 0, got error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(stderr.String(), "Exec finished (exit_code=0)") {
-		t.Fatalf("expected success message in stderr, got:\n%s", stderr.String())
+
+	req := mock.createSandboxReq
+	if req == nil {
+		t.Fatal("expected CreateSandbox to be called")
+	}
+	cmd := req.GetCreateSpec().GetCommand()
+	if len(cmd) != 2 || cmd[0] != "custom-cmd" || cmd[1] != "--flag" {
+		t.Fatalf("expected command=[custom-cmd --flag], got %v", cmd)
 	}
 }
 
-func TestRunLongRunningSession_ExecFailed(t *testing.T) {
-	// Exec FAILED with exit_code=0 and an error message → exit 125.
-	eventCh := make(chan *agboxv1.SandboxEvent, 1)
-	mock := newReadyMock(eventCh)
-
-	getExecCalls := 0
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return &agboxv1.CreateExecResponse{ExecId: "exec-1"}, nil
-	}
-	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
-		getExecCalls++
-		if getExecCalls == 1 {
-			return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_RUNNING, 3, 0), nil
-		}
-		return &agboxv1.GetExecResponse{
-			Exec: &agboxv1.ExecStatus{
-				ExecId:            "exec-1",
-				SandboxId:         "sb-001",
-				State:             agboxv1.ExecState_EXEC_STATE_FAILED,
-				ExitCode:          0,
-				Error:             "container OOM",
-				LastEventSequence: 4,
-			},
-		}, nil
-	}
-
-	eventCh <- &agboxv1.SandboxEvent{
-		EventId: "ev-1", Sequence: 4, SandboxId: "sb-001",
-		Details: &agboxv1.SandboxEvent_Exec{Exec: &agboxv1.ExecEventDetails{ExecId: "exec-1"}},
-	}
-
-	var stdout, stderr bytes.Buffer
-	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
-		mode:    agentModeLongRunning,
-		command: []string{"echo"},
-	}, "test", &stdout, &stderr)
-	if exitCodeForError(err) != 125 {
-		t.Fatalf("expected exit code 125, got %d (err=%v)", exitCodeForError(err), err)
-	}
-	stderrStr := stderr.String()
-	if !strings.Contains(stderrStr, "Exec failed (exit_code=0)") {
-		t.Fatalf("expected failure message, got:\n%s", stderrStr)
-	}
-	if !strings.Contains(stderrStr, "Error: container OOM") {
-		t.Fatalf("expected error detail, got:\n%s", stderrStr)
-	}
-}
-
-func TestRunLongRunningSession_ExecNonZeroExit(t *testing.T) {
-	// Exec FINISHED with exit_code=42 → exit 42.
-	eventCh := make(chan *agboxv1.SandboxEvent, 1)
-	mock := newReadyMock(eventCh)
-
-	getExecCalls := 0
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return &agboxv1.CreateExecResponse{ExecId: "exec-1"}, nil
-	}
-	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
-		getExecCalls++
-		if getExecCalls == 1 {
-			return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_RUNNING, 3, 0), nil
-		}
-		return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_FINISHED, 4, 42), nil
+func TestRunLongRunningSession_CtrlCBeforeReady(t *testing.T) {
+	// Signal before READY → cleanup (detachSuccess=false).
+	blockingCh := make(chan *agboxv1.SandboxEvent) // unbuffered, blocks forever
+	mock := &mockAgentClient{
+		createSandboxFn: func(_ context.Context, _ *agboxv1.CreateSandboxRequest) (*agboxv1.CreateSandboxResponse, error) {
+			return &agboxv1.CreateSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:         "sb-001",
+					State:             agboxv1.SandboxState_SANDBOX_STATE_PENDING,
+					LastEventSequence: 1,
+				},
+			}, nil
+		},
+		getSandboxFn: func(_ context.Context, id string) (*agboxv1.GetSandboxResponse, error) {
+			return &agboxv1.GetSandboxResponse{
+				Sandbox: &agboxv1.SandboxHandle{
+					SandboxId:         id,
+					State:             agboxv1.SandboxState_SANDBOX_STATE_DELETED,
+					LastEventSequence: 5,
+				},
+			}, nil
+		},
+		deleteSandboxFn: func(_ context.Context, _ string) (*agboxv1.AcceptedResponse, error) {
+			return &agboxv1.AcceptedResponse{Accepted: true}, nil
+		},
+		subscribeFn: func(_ context.Context, _ string, _ uint64, _ bool) (rawclient.SandboxEventStream, error) {
+			return &mockEventStream{events: blockingCh}, nil
+		},
 	}
 
-	eventCh <- &agboxv1.SandboxEvent{
-		EventId: "ev-1", Sequence: 4, SandboxId: "sb-001",
-		Details: &agboxv1.SandboxEvent_Exec{Exec: &agboxv1.ExecEventDetails{ExecId: "exec-1"}},
-	}
-
-	var stdout, stderr bytes.Buffer
-	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
-		mode:    agentModeLongRunning,
-		command: []string{"false"},
-	}, "test", &stdout, &stderr)
-	if exitCodeForError(err) != 42 {
-		t.Fatalf("expected exit code 42, got %d (err=%v)", exitCodeForError(err), err)
-	}
-	if !strings.Contains(stderr.String(), "Exec finished (exit_code=42)") {
-		t.Fatalf("expected exit code message, got:\n%s", stderr.String())
-	}
-}
-
-func TestRunLongRunningSession_ExecCancelled(t *testing.T) {
-	// Exec CANCELLED → exit 125.
-	eventCh := make(chan *agboxv1.SandboxEvent, 1)
-	mock := newReadyMock(eventCh)
-
-	getExecCalls := 0
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return &agboxv1.CreateExecResponse{ExecId: "exec-1"}, nil
-	}
-	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
-		getExecCalls++
-		if getExecCalls == 1 {
-			return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_RUNNING, 3, 0), nil
-		}
-		return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_CANCELLED, 4, 0), nil
-	}
-
-	eventCh <- &agboxv1.SandboxEvent{
-		EventId: "ev-1", Sequence: 4, SandboxId: "sb-001",
-		Details: &agboxv1.SandboxEvent_Exec{Exec: &agboxv1.ExecEventDetails{ExecId: "exec-1"}},
-	}
-
-	var stdout, stderr bytes.Buffer
-	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
-		mode:    agentModeLongRunning,
-		command: []string{"echo"},
-	}, "test", &stdout, &stderr)
-	if exitCodeForError(err) != 125 {
-		t.Fatalf("expected exit code 125, got %d (err=%v)", exitCodeForError(err), err)
-	}
-	if !strings.Contains(stderr.String(), "Exec cancelled") {
-		t.Fatalf("expected cancel message, got:\n%s", stderr.String())
-	}
-}
-
-func TestRunLongRunningSession_CtrlCDetach(t *testing.T) {
-	// Signal after exec delivery → detach, no delete, no cancel.
-	eventCh := make(chan *agboxv1.SandboxEvent) // unbuffered; blocks until signal
-	mock := newReadyMock(eventCh)
-
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return &agboxv1.CreateExecResponse{ExecId: "exec-1"}, nil
-	}
-	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
-		return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_RUNNING, 3, 0), nil
-	}
-
-	// Run in goroutine so we can inject a signal.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -534,25 +430,20 @@ func TestRunLongRunningSession_CtrlCDetach(t *testing.T) {
 		}, "test", &stdout, &stderr)
 	}()
 
-	// Wait for "Waiting for exec" to appear, then cancel via context to simulate detach.
 	cancel()
-
 	err := <-resultCh
 	if err == nil {
 		t.Fatal("expected error from context cancellation")
 	}
 
-	// DeleteSandbox should NOT be called (detachSuccess=true after exec delivery).
-	if mock.deleteCalled {
-		t.Fatal("expected DeleteSandbox NOT to be called on detach")
-	}
-	if mock.cancelCalled {
-		t.Fatal("expected CancelExec NOT to be called on detach")
+	if !mock.deleteCalled {
+		t.Fatal("expected DeleteSandbox to be called when cancelled before READY")
 	}
 }
 
 func TestRunLongRunningSession_SignalBeforeDelivery(t *testing.T) {
-	// CreateSandbox succeeds, but signal arrives before CreateExec → cleanup.
+	// CreateSandbox succeeds, context cancelled before READY → cleanup.
+	blockingCh := make(chan *agboxv1.SandboxEvent) // unbuffered, blocks forever
 	mock := &mockAgentClient{
 		createSandboxFn: func(_ context.Context, _ *agboxv1.CreateSandboxRequest) (*agboxv1.CreateSandboxResponse, error) {
 			return &agboxv1.CreateSandboxResponse{
@@ -572,44 +463,40 @@ func TestRunLongRunningSession_SignalBeforeDelivery(t *testing.T) {
 				},
 			}, nil
 		},
-		// CreateExec: make it fail as if the signal interrupts before exec.
-		createExecFn: func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-			return nil, fmt.Errorf("context cancelled")
+		subscribeFn: func(_ context.Context, _ string, _ uint64, _ bool) (rawclient.SandboxEventStream, error) {
+			return &mockEventStream{events: blockingCh}, nil
 		},
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resultCh := make(chan error, 1)
 	var stdout, stderr bytes.Buffer
-	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
-		mode:    agentModeLongRunning,
-		command: []string{"echo"},
-	}, "test", &stdout, &stderr)
+	go func() {
+		resultCh <- runLongRunningSession(ctx, mock, agentSessionArgs{
+			mode:    agentModeLongRunning,
+			command: []string{"echo"},
+		}, "test", &stdout, &stderr)
+	}()
+
+	cancel()
+	err := <-resultCh
 	if err == nil {
 		t.Fatal("expected error")
 	}
 
-	// Sandbox should be cleaned up since exec was never delivered.
 	if !mock.deleteCalled {
-		t.Fatal("expected DeleteSandbox to be called when exec delivery fails")
+		t.Fatal("expected DeleteSandbox to be called when signal arrives before READY")
 	}
 }
 
 func TestRunAgentSession_LongRunningNoGitConfirm(t *testing.T) {
 	// Workspace without .git, long-running mode → no confirmation prompt.
-	// If confirmation were triggered, it would fail (no stdin TTY in tests).
 	tmpDir := realTempDir(t)
-
-	eventCh := make(chan *agboxv1.SandboxEvent, 1)
-	mock := newReadyMock(eventCh)
-
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return &agboxv1.CreateExecResponse{ExecId: "exec-1"}, nil
-	}
-	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
-		return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_FINISHED, 3, 0), nil
-	}
+	mock := newReadyOnlyMock()
 
 	var stdout, stderr bytes.Buffer
-	// Call runLongRunningSession directly; no .git in tmpDir, yet no prompt.
 	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
 		mode:      agentModeLongRunning,
 		agentType: "claude",
@@ -620,7 +507,6 @@ func TestRunAgentSession_LongRunningNoGitConfirm(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify workspace was included in copies.
 	req := mock.createSandboxReq
 	if req == nil {
 		t.Fatal("expected CreateSandbox to be called")
@@ -632,15 +518,7 @@ func TestRunAgentSession_LongRunningNoGitConfirm(t *testing.T) {
 }
 
 func TestRunAgentSessionPropagatesFlagsToCreateSpec(t *testing.T) {
-	eventCh := make(chan *agboxv1.SandboxEvent, 1)
-	mock := newReadyMock(eventCh)
-
-	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
-		return &agboxv1.CreateExecResponse{ExecId: "exec-1"}, nil
-	}
-	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
-		return execResponse("exec-1", "sb-001", agboxv1.ExecState_EXEC_STATE_FINISHED, 3, 0), nil
-	}
+	mock := newReadyOnlyMock()
 
 	var stdout, stderr bytes.Buffer
 	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
@@ -673,5 +551,24 @@ func TestRunAgentSessionPropagatesFlagsToCreateSpec(t *testing.T) {
 	envs := spec.GetEnvs()
 	if envs["FOO"] != "bar" || envs["BAZ"] != "qux" {
 		t.Fatalf("expected envs={FOO:bar, BAZ:qux}, got %v", envs)
+	}
+}
+
+func TestNoLegacyHelpers(t *testing.T) {
+	// AT-O4: verify longRunningExecResult no longer exists in the codebase.
+	// Since we removed the function, attempting to reference it would be a
+	// compile error. This test just confirms we're in the new model by
+	// verifying the happy path runs without CreateExec.
+	mock := newReadyOnlyMock()
+	var stdout, stderr bytes.Buffer
+	err := runLongRunningSession(context.Background(), mock, agentSessionArgs{
+		mode:    agentModeLongRunning,
+		command: []string{"echo"},
+	}, "test", &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "sb-001" {
+		t.Fatalf("expected stdout=%q, got %q", "sb-001", got)
 	}
 }

--- a/cmd/agbox/agent_types.go
+++ b/cmd/agbox/agent_types.go
@@ -12,12 +12,6 @@ const (
 	agentModeLongRunning agentMode = "long-running"
 )
 
-// execPhase defines a single phase in a multi-phase startup sequence.
-type execPhase struct {
-	label   string   // display label (e.g., "Installing openclaw...")
-	command []string // exec command for this phase
-}
-
 // agentTypeDef defines the container-internal command and the builtin tools for an agent type.
 type agentTypeDef struct {
 	mode          agentMode
@@ -25,11 +19,10 @@ type agentTypeDef struct {
 	builtinTools  []string
 	copyWorkspace bool
 	confirmGit    bool
-	configYaml    string                                       // embedded YAML config string, passed to CreateSandboxRequest.ConfigYaml
-	sandboxIDGen  func() string                                // custom sandbox ID generator; nil means daemon auto-generates
-	preFlight     func(stderr io.Writer) error                 // pre-flight check; nil means no check
-	phases        []execPhase                                  // multi-phase startup sequence; non-empty replaces command
-	readyMessage  func(sandboxID, containerName string) string // custom ready message; nil uses default output
+	configYaml    string                                                 // embedded YAML config string, passed to CreateSandboxRequest.ConfigYaml
+	sandboxIDGen  func() string                                          // custom sandbox ID generator; nil means daemon auto-generates
+	preFlight     func(stderr io.Writer, parsed *agentSessionArgs) error // pre-flight check; nil means no check
+	readyMessage  func(sandboxID, containerName string) string           // custom ready message; nil uses default output
 }
 
 // agentTypeDefs maps agent type names to their full definitions.
@@ -54,53 +47,14 @@ var agentTypeDefs = map[string]agentTypeDef{
 		configYaml:   openclawConfigYaml,
 		sandboxIDGen: openclawSandboxIDGen,
 		preFlight:    openclawPreFlight,
-		phases: []execPhase{
-			{
-				label: "Installing openclaw...",
-				command: []string{
-					"bash", "-c",
-					// Install to user-local prefix because the agbox user lacks root/sudo.
-					// PATH is set via configYaml envs so openclaw is available in all execs.
-					"npm config set prefix ~/.npm-global && " +
-						"npm install -g openclaw@latest",
-				},
-			},
-			{
-				label: "Initializing config...",
-				command: []string{
-					"bash", "-c",
-					// Use openclaw's own CLI to generate config rather than hand-writing JSON.
-					// This avoids coupling with OpenClaw's config schema and survives upstream upgrades.
-					// Only runs when config does not exist yet (onboard is idempotent for existing configs).
-					"if [ ! -f ~/.openclaw/config/openclaw.json ]; then " +
-						"openclaw onboard --mode local --non-interactive --accept-risk " +
-						"--gateway-auth token --gateway-bind lan --gateway-port 18789 " +
-						"--no-install-daemon --skip-channels --skip-skills --skip-health --skip-search --skip-ui " +
-						"--auth-choice skip && " +
-						// dangerouslyDisableDeviceAuth skips per-browser device pairing while keeping
-						// token auth. Safe because daemon hardcodes HostIP=127.0.0.1 for port bindings,
-						// so the gateway is only reachable from localhost.
-						"openclaw config set gateway.controlUi.dangerouslyDisableDeviceAuth true --strict-json; " +
-						"fi && " +
-						// The sandbox is fully isolated, so elevated (sudo) commands carry no
-						// additional risk. Setting elevatedDefault=full makes the agent auto-approve
-						// elevated exec without routing through gateway device-pairing approval.
-						"openclaw config set agents.defaults.elevatedDefault full",
-				},
-			},
-			{
-				label: "Starting gateway...",
-				command: []string{
-					"bash", "-c",
-					"openclaw gateway run --port 18789 --bind lan &\n" +
-						"timeout=60; elapsed=0; " +
-						"until curl -sf http://localhost:18789/ > /dev/null 2>&1; do " +
-						"sleep 1; elapsed=$((elapsed+1)); " +
-						"if [ $elapsed -ge $timeout ]; then echo 'Gateway health check timed out' >&2; exit 1; fi; " +
-						"done",
-				},
-			},
-		},
 		readyMessage: openclawReadyMessage,
+	},
+	"paseo": {
+		mode:         agentModeLongRunning,
+		builtinTools: []string{"claude", "codex", "npm", "uv", "apt", "opencode"},
+		configYaml:   paseoConfigYaml,
+		sandboxIDGen: paseoSandboxIDGen,
+		preFlight:    paseoPreFlight,
+		// readyMessage injected by runAgentSession after preFlight filters builtinTools.
 	},
 }

--- a/cmd/agbox/agent_types_test.go
+++ b/cmd/agbox/agent_types_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAgentTypeDef_NoPhasesField(t *testing.T) {
+	// AT-O3: verify agentTypeDef struct has no "phases" field.
+	rt := reflect.TypeOf(agentTypeDef{})
+	for i := 0; i < rt.NumField(); i++ {
+		if rt.Field(i).Name == "phases" {
+			t.Fatal("agentTypeDef must not have a 'phases' field")
+		}
+	}
+}
+
+func TestAgentTypeDef_NoExecPhaseType(t *testing.T) {
+	// Verify no "execPhase" type exists in agent_types.go source.
+	data, err := os.ReadFile("agent_types.go")
+	if err != nil {
+		t.Fatalf("read agent_types.go: %v", err)
+	}
+	if strings.Contains(string(data), "execPhase") {
+		t.Fatal("agent_types.go must not contain 'execPhase' type")
+	}
+}

--- a/cmd/agbox/cmd_agent.go
+++ b/cmd/agbox/cmd_agent.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 // agentSessionFlagVars holds the raw flag values for an agent session command.
@@ -28,7 +29,7 @@ type agentSessionFlagVars struct {
 
 // registerAgentSessionFlags registers all agent session flags on a cobra command.
 func registerAgentSessionFlags(cmd *cobra.Command, v *agentSessionFlagVars) {
-	cmd.Flags().StringVar(&v.rawCommand, "command", "", "Custom command to run (mutually exclusive with agent type)")
+	cmd.Flags().StringVar(&v.rawCommand, "command", "", "Override the agent's default command.\n  interactive mode: replaces the TTY command launched via docker exec.\n  long-running mode: replaces the container primary command (under tini).\nValue is split by whitespace via strings.Fields (no shell quoting).")
 	cmd.Flags().StringVar(&v.mode, "mode", "", "Session mode: interactive or long-running (default depends on agent type)")
 	cmd.Flags().StringVar(&v.workspace, "workspace", "", "Directory to copy into the sandbox as workspace")
 	cmd.Flags().StringArrayVar(&v.builtinTools, "builtin-tool", nil, "Builtin tool to install (repeatable, overrides defaults)")
@@ -37,6 +38,14 @@ func registerAgentSessionFlags(cmd *cobra.Command, v *agentSessionFlagVars) {
 	cmd.Flags().StringVar(&v.memoryLimit, "memory-limit", "", "Memory limit (Docker --memory format, e.g. 4g, 512m)")
 	cmd.Flags().StringVar(&v.diskLimit, "disk-limit", "", "Disk limit (Docker --storage-opt size= format, e.g. 10g)")
 	cmd.Flags().StringVar(&v.sandboxID, "sandbox-id", "", "Custom sandbox ID (overrides agent type default)")
+}
+
+// newPaseoTopLevelCommand builds the top-level `agbox paseo` command with the
+// `url` subcommand. Unlike other agent types, paseo has a subcommand tree.
+func newPaseoTopLevelCommand() *cobra.Command {
+	cmd := newAgentTypeCommand("paseo")
+	cmd.AddCommand(newPaseoURLCommand())
+	return cmd
 }
 
 // buildAgentSessionRunE creates the RunE function for agent session commands.
@@ -68,7 +77,7 @@ type agentSessionArgs struct {
 	diskLimit    string
 	sandboxID    string                                       // custom sandbox ID (empty = daemon generates)
 	configYaml   string                                       // embedded YAML config
-	phases       []execPhase                                  // multi-phase startup (non-empty replaces command)
+	image        string                                       // container image (empty = daemon uses configYaml image)
 	readyMessage func(sandboxID, containerName string) string // custom ready message
 }
 
@@ -81,7 +90,7 @@ func newAgentCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "agent",
 		Short: "Launch a custom agent session via --command",
-		Long:  "Launch a sandbox and run a custom agent command specified via --command.\n\nFor pre-registered agents, use the dedicated top-level commands: agbox claude, agbox codex, agbox openclaw.",
+		Long:  "Launch a sandbox and run a custom agent command specified via --command.\n\nFor pre-registered agents, use the dedicated top-level commands: agbox claude, agbox codex, agbox openclaw, agbox paseo.",
 		Args:  cobra.NoArgs,
 		RunE:  buildAgentSessionRunE("", &v),
 	}
@@ -112,11 +121,6 @@ func resolveAgentSessionArgs(
 ) (agentSessionArgs, error) {
 	var parsed agentSessionArgs
 
-	// Validate mutual exclusion: agent type vs --command.
-	if agentType != "" && v.rawCommand != "" {
-		return agentSessionArgs{}, usageErrorf("cannot use --command with agent type %q", agentType)
-	}
-
 	// Resolve the agent type definition when a registered type is used.
 	var typeDef agentTypeDef
 	var isRegistered bool
@@ -135,7 +139,7 @@ func resolveAgentSessionArgs(
 		if v.builtinToolsOverridden {
 			parsed.builtinTools = v.builtinTools
 		} else {
-			parsed.builtinTools = typeDef.builtinTools
+			parsed.builtinTools = append([]string(nil), typeDef.builtinTools...)
 		}
 	} else if v.rawCommand != "" {
 		// Custom command: split the string into argv.
@@ -145,7 +149,7 @@ func resolveAgentSessionArgs(
 		}
 		parsed.builtinTools = v.builtinTools
 	} else {
-		return agentSessionArgs{}, usageErrorf("agbox agent requires --command; for pre-registered agents use agbox claude / agbox codex / agbox openclaw")
+		return agentSessionArgs{}, usageErrorf("agbox agent requires --command; for pre-registered agents use agbox claude / agbox codex / agbox openclaw / agbox paseo")
 	}
 
 	// Mode resolution.
@@ -161,6 +165,14 @@ func resolveAgentSessionArgs(
 	} else {
 		// Custom --command defaults to interactive.
 		parsed.mode = agentModeInteractive
+	}
+
+	// --command override: for registered types with rawCommand, the rawCommand overrides typeDef.command.
+	if isRegistered && v.rawCommand != "" {
+		parsed.command = strings.Fields(v.rawCommand)
+		if len(parsed.command) == 0 {
+			return agentSessionArgs{}, usageErrorf("--command must not be empty")
+		}
 	}
 
 	// Workspace resolution.
@@ -216,8 +228,22 @@ func resolveAgentSessionArgs(
 	// Populate agent-type-specific fields.
 	if isRegistered {
 		parsed.configYaml = typeDef.configYaml
-		parsed.phases = typeDef.phases
 		parsed.readyMessage = typeDef.readyMessage
+	}
+
+	// Image resolution: if configYaml contains a top-level `image:`, the daemon
+	// uses that image and we leave parsed.image empty. Otherwise use defaultImage.
+	if isRegistered && typeDef.configYaml != "" {
+		var yamlConfig struct {
+			Image string `yaml:"image"`
+		}
+		if err := yaml.Unmarshal([]byte(typeDef.configYaml), &yamlConfig); err == nil && yamlConfig.Image != "" {
+			parsed.image = ""
+		} else {
+			parsed.image = defaultImage
+		}
+	} else {
+		parsed.image = defaultImage
 	}
 
 	return parsed, nil

--- a/cmd/agbox/cmd_agent_test.go
+++ b/cmd/agbox/cmd_agent_test.go
@@ -81,13 +81,20 @@ func TestResolveAgentSessionArgs_CustomCommandWithBuiltinTools(t *testing.T) {
 	}
 }
 
-func TestResolveAgentSessionArgs_MutualExclusion(t *testing.T) {
-	_, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "aider", workspace: "/work", workspaceOverridden: true}, "claude")
-	if err == nil {
-		t.Fatal("expected error for agent type + --command")
+func TestResolveAgentSessionArgs_CommandFlag_NotMutuallyExclusive(t *testing.T) {
+	// AT-C3: --command + agent type is NOW allowed.
+	tmpDir := realTempDir(t)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "aider", workspace: tmpDir, workspaceOverridden: true}, "claude")
+	if err != nil {
+		t.Fatalf("expected no error for agent type + --command, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "cannot use --command with agent type") {
-		t.Fatalf("unexpected error message: %v", err)
+	// rawCommand should override the type's default command.
+	if len(parsed.command) != 1 || parsed.command[0] != "aider" {
+		t.Fatalf("expected command=[aider], got %v", parsed.command)
+	}
+	// agentType is still set.
+	if parsed.agentType != "claude" {
+		t.Fatalf("expected agentType=claude, got %q", parsed.agentType)
 	}
 }
 
@@ -328,23 +335,16 @@ func TestResolveAgentSessionArgs_Openclaw(t *testing.T) {
 			t.Fatalf("builtinTools[%d]: expected %q, got %q", i, tool, parsed.builtinTools[i])
 		}
 	}
-	if len(parsed.phases) != 3 {
-		t.Fatalf("expected 3 phases, got %d", len(parsed.phases))
-	}
-	if parsed.phases[0].label != "Installing openclaw..." {
-		t.Fatalf("expected phases[0].label=%q, got %q", "Installing openclaw...", parsed.phases[0].label)
-	}
-	if parsed.phases[1].label != "Initializing config..." {
-		t.Fatalf("expected phases[1].label=%q, got %q", "Initializing config...", parsed.phases[1].label)
-	}
-	if parsed.phases[2].label != "Starting gateway..." {
-		t.Fatalf("expected phases[2].label=%q, got %q", "Starting gateway...", parsed.phases[2].label)
-	}
-	if len(parsed.command) != 0 {
-		t.Fatalf("expected empty command (phases replaces it), got %v", parsed.command)
-	}
 	if parsed.configYaml == "" {
 		t.Fatal("expected non-empty configYaml")
+	}
+	// configYaml should contain the image.
+	if !strings.Contains(parsed.configYaml, "image:") {
+		t.Fatalf("expected configYaml to contain image:, got:\n%s", parsed.configYaml)
+	}
+	// image should be empty because configYaml specifies it.
+	if parsed.image != "" {
+		t.Fatalf("expected empty image (configYaml provides it), got %q", parsed.image)
 	}
 
 	// openclaw typedef does not set copyWorkspace, so workspace should be empty.
@@ -359,7 +359,7 @@ func TestResolveAgentSessionArgs_SandboxID(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		re := regexp.MustCompile(`^openclaw-[0-9a-f]{4}$`)
+		re := regexp.MustCompile(`^openclaw-[0-9a-f]{6}$`)
 		if !re.MatchString(parsed.sandboxID) {
 			t.Fatalf("expected sandboxID matching %s, got %q", re.String(), parsed.sandboxID)
 		}
@@ -415,17 +415,16 @@ func TestAgentCommandRejectsPositionalAgentType(t *testing.T) {
 	}
 }
 
-func TestTopLevelCommandRejectsCommandFlag(t *testing.T) {
+func TestTopLevelCommandAllowsCommandFlag(t *testing.T) {
+	// --command is now allowed with top-level agent type commands (overrides default command).
 	cmd := newAgentTypeCommand("claude")
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{"--command", "foo"})
+	// The command will fail due to no daemon, but NOT due to mutual exclusion.
 	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected error for --command on top-level command")
-	}
-	if !strings.Contains(err.Error(), "cannot use --command with agent type") {
-		t.Fatalf("unexpected error message: %v", err)
+	if err != nil && strings.Contains(err.Error(), "cannot use --command with agent type") {
+		t.Fatalf("--command should no longer be rejected with agent type: %v", err)
 	}
 }
 
@@ -554,7 +553,7 @@ func TestResolveAgentSessionArgsFlags(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		re := regexp.MustCompile(`^openclaw-[0-9a-f]{4}$`)
+		re := regexp.MustCompile(`^openclaw-[0-9a-f]{6}$`)
 		if !re.MatchString(parsed.sandboxID) {
 			t.Fatalf("expected sandboxID matching %s, got %q", re.String(), parsed.sandboxID)
 		}
@@ -577,7 +576,7 @@ func TestResolveAgentSessionArgsFlags(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		re := regexp.MustCompile(`^openclaw-[0-9a-f]{4}$`)
+		re := regexp.MustCompile(`^openclaw-[0-9a-f]{6}$`)
 		if !re.MatchString(parsed.sandboxID) {
 			t.Fatalf("expected sandboxID matching %s, got %q", re.String(), parsed.sandboxID)
 		}
@@ -633,5 +632,150 @@ func TestTopLevelCommandsInheritNewFlags(t *testing.T) {
 				t.Fatalf("expected diskLimit=10g, got %q", parsed.diskLimit)
 			}
 		})
+	}
+}
+
+func TestResolveAgentSessionArgs_CommandFlag_Interactive(t *testing.T) {
+	// AT-C1: --command in interactive mode replaces TTY command.
+	tmpDir := realTempDir(t)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+		rawCommand: "my-custom-agent --flag",
+	}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.mode != agentModeInteractive {
+		t.Fatalf("expected mode=interactive, got %q", parsed.mode)
+	}
+	if len(parsed.command) != 2 || parsed.command[0] != "my-custom-agent" || parsed.command[1] != "--flag" {
+		t.Fatalf("expected command=[my-custom-agent --flag], got %v", parsed.command)
+	}
+
+	// Also test with registered type + --command override.
+	parsed2, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+		rawCommand:          "custom-cmd",
+		workspace:           tmpDir,
+		workspaceOverridden: true,
+	}, "claude")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed2.mode != agentModeInteractive {
+		t.Fatalf("expected mode=interactive, got %q", parsed2.mode)
+	}
+	if len(parsed2.command) != 1 || parsed2.command[0] != "custom-cmd" {
+		t.Fatalf("expected command=[custom-cmd], got %v", parsed2.command)
+	}
+}
+
+func TestResolveAgentSessionArgs_CommandFlag_LongRunning(t *testing.T) {
+	// AT-C2: --command in long-running mode replaces container primary command.
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+		rawCommand:     "my-service start",
+		mode:           "long-running",
+		modeOverridden: true,
+	}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.mode != agentModeLongRunning {
+		t.Fatalf("expected mode=long-running, got %q", parsed.mode)
+	}
+	if len(parsed.command) != 2 || parsed.command[0] != "my-service" || parsed.command[1] != "start" {
+		t.Fatalf("expected command=[my-service start], got %v", parsed.command)
+	}
+}
+
+func TestResolveAgentSessionArgs_Image_ConfigYamlWithImage_Empty(t *testing.T) {
+	// AT-C4: when configYaml contains image:, parsed.image should be empty.
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, "openclaw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.image != "" {
+		t.Fatalf("expected empty image when configYaml has image:, got %q", parsed.image)
+	}
+}
+
+func TestResolveAgentSessionArgs_Image_NoConfigYaml_UsesDefault(t *testing.T) {
+	// AT-C5: when no configYaml, parsed.image should be defaultImage.
+	tmpDir := realTempDir(t)
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+		workspace:           tmpDir,
+		workspaceOverridden: true,
+	}, "claude")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.image != defaultImage {
+		t.Fatalf("expected image=%q, got %q", defaultImage, parsed.image)
+	}
+}
+
+func TestResolveAgentSessionArgs_Image_ConfigYamlWithoutImage_UsesDefault(t *testing.T) {
+	// AT-C6: configYaml without image: uses defaultImage.
+	// Test with custom command (no configYaml).
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+		rawCommand: "sleep infinity",
+	}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.image != defaultImage {
+		t.Fatalf("expected image=%q, got %q", defaultImage, parsed.image)
+	}
+}
+
+func TestResolveAgentSessionArgs_EnvsIsolation_NoDefaultEnvInjection(t *testing.T) {
+	// AT-EN: envs should only contain user --env values, not configYaml envs.
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+		envs: []string{"MY_KEY=my_val"},
+	}, "openclaw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(parsed.envs) != 1 || parsed.envs["MY_KEY"] != "my_val" {
+		t.Fatalf("expected envs={MY_KEY:my_val}, got %v", parsed.envs)
+	}
+	// configYaml envs must NOT leak into parsed.envs.
+	if _, found := parsed.envs["OPENCLAW_STATE_DIR"]; found {
+		t.Fatal("configYaml envs should NOT be in parsed.envs")
+	}
+}
+
+func TestResolveAgentSessionArgs_BuiltinToolsIsCopy(t *testing.T) {
+	// AT-SB: builtinTools must be a defensive copy.
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, "openclaw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Mutating parsed.builtinTools must not affect typeDef.
+	original := make([]string, len(parsed.builtinTools))
+	copy(original, parsed.builtinTools)
+	parsed.builtinTools[0] = "MUTATED"
+
+	typeDef := agentTypeDefs["openclaw"]
+	if typeDef.builtinTools[0] == "MUTATED" {
+		t.Fatal("modifying parsed.builtinTools must not affect agentTypeDefs")
+	}
+	if typeDef.builtinTools[0] != original[0] {
+		t.Fatalf("expected typeDef.builtinTools[0]=%q, got %q", original[0], typeDef.builtinTools[0])
+	}
+}
+
+func TestResolveAgentSessionArgs_BuiltinToolsIsCopy_Paseo(t *testing.T) {
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, "paseo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := range parsed.builtinTools {
+		parsed.builtinTools[i] = "CORRUPTED"
+	}
+	parsed2, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, "paseo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed2.builtinTools[0] != "claude" {
+		t.Fatalf("agentTypeDefs[paseo].builtinTools polluted: got %q", parsed2.builtinTools[0])
 	}
 }

--- a/cmd/agbox/cmd_paseo_url.go
+++ b/cmd/agbox/cmd_paseo_url.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
+	"github.com/1996fanrui/agents-sandbox/internal/platform"
+	"github.com/1996fanrui/agents-sandbox/sdk/go/rawclient"
+	"github.com/spf13/cobra"
+)
+
+func newPaseoURLCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "url <sandbox_id>",
+		Short: "Print paseo pairing URL by running 'paseo daemon pair' inside the sandbox",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			lookupEnv := lookupEnvFromCmd(cmd)
+			socketPath, err := platform.SocketPath(lookupEnv)
+			if err != nil {
+				return runtimeErrorf("resolve daemon socket: %v", err)
+			}
+			client, err := rawclient.New(socketPath, rawclient.WithTimeout(0))
+			if err != nil {
+				return runtimeErrorf("connect daemon: %v", err)
+			}
+			defer client.Close()
+			return runPaseoURL(cmd.Context(), client, args[0], cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+}
+
+func runPaseoURL(ctx context.Context, client sandboxExecClient, sandboxID string, stdout, stderr io.Writer) error {
+	createResp, err := client.CreateExec(ctx, &agboxv1.CreateExecRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"/usr/local/bin/paseo", "daemon", "pair"},
+	})
+	if err != nil {
+		return runtimeErrorf("create exec: %v", err)
+	}
+
+	if err := waitForExecDone(ctx, client, createResp.GetExecId(), sandboxID); err != nil {
+		// Read stderr log if available.
+		if stderrLogPath := createResp.GetStderrLogPath(); stderrLogPath != "" {
+			if logData, readErr := os.ReadFile(stderrLogPath); readErr == nil && len(logData) > 0 {
+				_, _ = fmt.Fprintf(stderr, "%s", logData)
+			}
+		}
+		return err
+	}
+
+	// Read and print stdout log (contains the pair URL).
+	stdoutLogPath := createResp.GetStdoutLogPath()
+	if stdoutLogPath != "" {
+		logData, readErr := os.ReadFile(stdoutLogPath)
+		if readErr != nil {
+			return runtimeErrorf("read stdout log: %v", readErr)
+		}
+		_, _ = stdout.Write(logData)
+	}
+	return nil
+}

--- a/cmd/agbox/docs_consistency_test.go
+++ b/cmd/agbox/docs_consistency_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLongRunningDocsUpdated(t *testing.T) {
+	// AT-DF: verify 4 docs files contain updated content about the new
+	// long-running model (no CreateExec, container primary command).
+	tests := []struct {
+		path string
+		want []string
+	}{
+		{
+			"../../docs/sandbox_container_lifecycle.md",
+			[]string{
+				"primary command",
+				"READY",
+			},
+		},
+		{
+			"../../docs/container_dependency_strategy.md",
+			[]string{
+				"primary command",
+				"Does not use `CreateExec` for the service process",
+			},
+		},
+		{
+			"../../docs/agent_guide.md",
+			[]string{
+				"openclaw",
+				"paseo",
+				"container primary command",
+			},
+		},
+		{
+			"../../docs/cli_reference.md",
+			[]string{
+				"--command",
+				"container primary command",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			data, err := os.ReadFile(tt.path)
+			if err != nil {
+				t.Fatalf("read %s: %v", tt.path, err)
+			}
+			content := string(data)
+			for _, want := range tt.want {
+				if !strings.Contains(content, want) {
+					t.Fatalf("%s missing %q", tt.path, want)
+				}
+			}
+		})
+	}
+}

--- a/cmd/agbox/openclaw.go
+++ b/cmd/agbox/openclaw.go
@@ -19,15 +19,24 @@ func randomHexSuffix(n int) string {
 	return hex.EncodeToString(b)
 }
 
-// openclawSandboxIDGen returns a sandbox ID with prefix "openclaw-" followed by 4 hex characters.
+// openclawSandboxIDGen returns a sandbox ID with prefix "openclaw-" followed by 6 hex characters.
 func openclawSandboxIDGen() string {
-	return "openclaw-" + randomHexSuffix(2)
+	return "openclaw-" + randomHexSuffix(3)
 }
 
 // openclawConfigYaml is the embedded YAML config for the openclaw sandbox.
 // The daemon handles ~ expansion for mounts but NOT for envs, so env values
 // use the absolute /home/agbox path.
-const openclawConfigYaml = `mounts:
+var openclawConfigYaml = `image: ghcr.io/agents-sandbox/openclaw-runtime:latest
+command:
+  - openclaw
+  - gateway
+  - run
+  - "--port"
+  - "18789"
+  - "--bind"
+  - lan
+mounts:
   - source: "~/.openclaw"
     target: "~/.openclaw"
     writable: true
@@ -37,7 +46,6 @@ ports:
 envs:
   OPENCLAW_STATE_DIR: "/home/agbox/.openclaw"
   OPENCLAW_CONFIG_PATH: "/home/agbox/.openclaw/config/openclaw.json"
-  PATH: "/home/agbox/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 `
 
 // openclawAuthGuide is printed to stderr when auth validation fails.
@@ -48,9 +56,9 @@ const openclawAuthGuide = `OpenClaw LLM auth not found. Complete authentication 
 `
 
 // openclawPreFlight verifies that LLM auth profiles exist on the host.
-// Gateway config initialization is handled inside the sandbox via `openclaw onboard`
-// to avoid coupling with OpenClaw's config schema.
-func openclawPreFlight(stderr io.Writer) error {
+// Gateway config initialization is handled inside the sandbox via the
+// openclaw-runtime entrypoint to avoid coupling with OpenClaw's config schema.
+func openclawPreFlight(stderr io.Writer, _ *agentSessionArgs) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("resolve home directory: %w", err)
@@ -118,12 +126,14 @@ OpenClaw gateway is running.
   Gateway:    %s
   Sandbox ID: %s
 
+Note: gateway may take a few seconds to accept traffic after sandbox READY.
+curl %s until it responds if you need to block.
+
 Manage:
   agbox sandbox stop %s      # stop gateway
-  agbox sandbox resume %s    # restart container only (gateway process lost)
-  # To redeploy after resume: delete and recreate
+  agbox sandbox resume %s    # restart container (gateway primary command restarts with it)
   agbox sandbox delete %s && agbox openclaw
   agbox sandbox delete %s    # delete sandbox
   agbox exec list %s         # list running execs
-`, gatewayURL, sandboxID, sandboxID, sandboxID, sandboxID, sandboxID, sandboxID)
+`, gatewayURL, sandboxID, gatewayURL, sandboxID, sandboxID, sandboxID, sandboxID, sandboxID)
 }

--- a/cmd/agbox/openclaw_image_test.go
+++ b/cmd/agbox/openclaw_image_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestOpenclawRuntimeDockerfile_Structure(t *testing.T) {
+	// AT-I1: verify Dockerfile exists and contains expected directives.
+	data, err := os.ReadFile("../../images/openclaw-runtime/Dockerfile")
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	content := string(data)
+
+	for _, want := range []string{
+		"FROM ghcr.io/agents-sandbox/coding-runtime:latest",
+		"ARG OPENCLAW_VERSION",
+		"ENTRYPOINT",
+		"CMD",
+		"openclaw-entrypoint.sh",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("Dockerfile missing %q", want)
+		}
+	}
+}

--- a/cmd/agbox/openclaw_test.go
+++ b/cmd/agbox/openclaw_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -87,7 +88,7 @@ func TestRandomHexSuffix(t *testing.T) {
 }
 
 func TestOpenclawSandboxIDGen(t *testing.T) {
-	re := regexp.MustCompile(`^openclaw-[0-9a-f]{4}$`)
+	re := regexp.MustCompile(`^openclaw-[0-9a-f]{6}$`)
 	id := openclawSandboxIDGen()
 	if !re.MatchString(id) {
 		t.Fatalf("expected sandbox ID matching %s, got %q", re.String(), id)
@@ -114,4 +115,84 @@ func containsAll(s string, subs ...string) bool {
 		}
 	}
 	return true
+}
+
+func TestOpenclawConfigYaml_Content(t *testing.T) {
+	// AT-O1: verify openclawConfigYaml contains expected fields.
+	for _, want := range []string{
+		"image: ghcr.io/agents-sandbox/openclaw-runtime:",
+		"command:",
+		"openclaw",
+		"gateway",
+		"mounts:",
+		"ports:",
+		"OPENCLAW_STATE_DIR",
+		"OPENCLAW_CONFIG_PATH",
+	} {
+		if !strings.Contains(openclawConfigYaml, want) {
+			t.Fatalf("openclawConfigYaml missing %q, got:\n%s", want, openclawConfigYaml)
+		}
+	}
+	// Standalone PATH env key should NOT be present (openclaw is preinstalled in the image).
+	// Use a line-based check to avoid matching OPENCLAW_CONFIG_PATH.
+	if strings.Contains(openclawConfigYaml, "\n  PATH:") || strings.HasPrefix(openclawConfigYaml, "PATH:") {
+		t.Fatal("openclawConfigYaml should not contain standalone PATH env")
+	}
+	if strings.Contains(openclawConfigYaml, "npm install") {
+		t.Fatal("openclawConfigYaml should not contain npm install")
+	}
+	if strings.Contains(openclawConfigYaml, "bash -c") {
+		t.Fatal("openclawConfigYaml should not contain bash -c")
+	}
+}
+
+func TestOpenclawConfigYaml_CommandIsGatewayRun(t *testing.T) {
+	// AT-O2: verify the command contains gateway run.
+	if !strings.Contains(openclawConfigYaml, "gateway") {
+		t.Fatal("openclawConfigYaml command should contain gateway")
+	}
+	if !strings.Contains(openclawConfigYaml, `"18789"`) {
+		t.Fatal("openclawConfigYaml command should contain port 18789")
+	}
+}
+
+func TestOpenclawPreFlight_AcceptsParsedArgs(t *testing.T) {
+	// AT-O5: verify openclawPreFlight accepts *agentSessionArgs parameter.
+	home := t.TempDir()
+	writeValidAuth(t, home)
+
+	// Override the function to use the test home.
+	var stderr bytes.Buffer
+	// Call openclawPreFlightWithHome directly since openclawPreFlight
+	// just resolves home and delegates.
+	err := openclawPreFlightWithHome(&stderr, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the function signature matches the new preFlight type.
+	typeDef := agentTypeDefs["openclaw"]
+	if typeDef.preFlight == nil {
+		t.Fatal("openclaw preFlight should not be nil")
+	}
+}
+
+func TestOpenclawReadyMessage_Content(t *testing.T) {
+	// AT-O6: verify readyMessage contains expected content.
+	msg := openclawReadyMessage("sb-test", "container-test")
+	for _, want := range []string{
+		"OpenClaw gateway is running",
+		"Gateway:",
+		"http://localhost:18789",
+		"sb-test",
+		"may take a few seconds",
+		"agbox sandbox stop sb-test",
+		"agbox sandbox resume sb-test",
+		"gateway primary command restarts with it",
+		"agbox sandbox delete sb-test",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("readyMessage missing %q, got:\n%s", want, msg)
+		}
+	}
 }

--- a/cmd/agbox/paseo.go
+++ b/cmd/agbox/paseo.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/1996fanrui/agents-sandbox/internal/profile"
+)
+
+var paseoConfigYaml = `image: ghcr.io/agents-sandbox/paseo-runtime:latest
+command:
+  - /usr/local/bin/paseo
+  - daemon
+  - start
+  - "--listen"
+  - "0.0.0.0:6767"
+  - "--hostnames"
+  - "true"
+  - "--foreground"
+envs:
+  PASEO_DICTATION_ENABLED: "0"
+  PASEO_VOICE_MODE_ENABLED: "0"
+  OPENCODE_DISABLE_EXTERNAL_SKILLS: "1"
+`
+
+func paseoSandboxIDGen() string {
+	return "paseo-" + randomHexSuffix(3)
+}
+
+// paseoPreFlight filters parsed.builtinTools by checking whether each tool's
+// required (non-Optional) mounts exist on the host. Unknown tools are kept
+// (daemon will fail-fast). The filtered list may be empty.
+func paseoPreFlight(stderr io.Writer, parsed *agentSessionArgs) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+	return paseoPreFlightWithHome(stderr, parsed, home)
+}
+
+func paseoPreFlightWithHome(stderr io.Writer, parsed *agentSessionArgs, home string) error {
+	filtered := parsed.builtinTools[:0]
+	for _, tool := range parsed.builtinTools {
+		cap, ok := profile.CapabilityByID(tool)
+		if !ok {
+			// Unknown tool: pass through to daemon for fail-fast.
+			filtered = append(filtered, tool)
+			continue
+		}
+		missing := ""
+		for _, mid := range cap.MountIDs {
+			m, _ := profile.MountByID(mid)
+			if m.Optional {
+				continue
+			}
+			hostPath := expandHostPath(m.DefaultHostPath, home)
+			if hostPath == "" {
+				missing = m.DefaultHostPath
+				break
+			}
+			if _, err := os.Stat(hostPath); err != nil {
+				missing = m.DefaultHostPath
+				break
+			}
+		}
+		if missing != "" {
+			fmt.Fprintf(stderr, "paseo: skipping builtin tool %q: required host path %q not found\n", tool, missing)
+			continue
+		}
+		filtered = append(filtered, tool)
+	}
+	parsed.builtinTools = filtered
+	return nil
+}
+
+// expandHostPath resolves ~ to the given home directory and environment variables.
+func expandHostPath(p, home string) string {
+	if p == "" {
+		return ""
+	}
+	if strings.HasPrefix(p, "~/") {
+		p = home + p[1:]
+	} else if p == "~" {
+		p = home
+	} else {
+		p = os.ExpandEnv(p)
+	}
+	return p
+}
+
+// paseoReadyMessageFactory returns a readyMessage closure that captures the
+// filtered builtin tools list. The factory makes a defensive copy of activeTools
+// to prevent caller mutation from affecting the closure.
+func paseoReadyMessageFactory(activeTools []string) func(sandboxID, containerName string) string {
+	clone := append([]string(nil), activeTools...)
+	return func(sandboxID, containerName string) string {
+		toolsLine := "(none)"
+		if len(clone) > 0 {
+			toolsLine = strings.Join(clone, ", ")
+		}
+		return fmt.Sprintf(`
+Paseo daemon is running.
+  Pair URL:   agbox paseo url %s
+  Active builtin tools: %s
+
+Manage:
+  agbox sandbox stop %s      # stop sandbox
+  agbox sandbox resume %s    # restart container (primary command restarts with it)
+  agbox sandbox delete %s    # delete sandbox
+  agbox exec list %s         # list running execs
+`, sandboxID, toolsLine, sandboxID, sandboxID, sandboxID, sandboxID)
+	}
+}

--- a/cmd/agbox/paseo_test.go
+++ b/cmd/agbox/paseo_test.go
@@ -1,0 +1,607 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
+	"github.com/1996fanrui/agents-sandbox/sdk/go/rawclient"
+	"gopkg.in/yaml.v3"
+)
+
+// --- Config YAML tests ---
+
+func TestPaseoConfigYaml_ParsesImageCommandEnvs(t *testing.T) {
+	// AT-P1: yaml.Unmarshal, check image/command/envs/no mounts.
+	var cfg struct {
+		Image   string            `yaml:"image"`
+		Command []string          `yaml:"command"`
+		Envs    map[string]string `yaml:"envs"`
+		Mounts  []any             `yaml:"mounts"`
+		Ports   []any             `yaml:"ports"`
+	}
+	if err := yaml.Unmarshal([]byte(paseoConfigYaml), &cfg); err != nil {
+		t.Fatalf("failed to parse paseoConfigYaml: %v", err)
+	}
+
+	if !strings.HasPrefix(cfg.Image, "ghcr.io/agents-sandbox/paseo-runtime:") {
+		t.Fatalf("unexpected image: %q", cfg.Image)
+	}
+
+	if len(cfg.Command) == 0 || cfg.Command[0] != "/usr/local/bin/paseo" {
+		t.Fatalf("unexpected command: %v", cfg.Command)
+	}
+	if !containsStr(cfg.Command, "daemon") || !containsStr(cfg.Command, "start") {
+		t.Fatalf("command missing daemon/start: %v", cfg.Command)
+	}
+
+	if cfg.Envs["PASEO_DICTATION_ENABLED"] != "0" {
+		t.Fatalf("expected PASEO_DICTATION_ENABLED=0, got %q", cfg.Envs["PASEO_DICTATION_ENABLED"])
+	}
+	if cfg.Envs["PASEO_VOICE_MODE_ENABLED"] != "0" {
+		t.Fatalf("expected PASEO_VOICE_MODE_ENABLED=0, got %q", cfg.Envs["PASEO_VOICE_MODE_ENABLED"])
+	}
+	if cfg.Envs["OPENCODE_DISABLE_EXTERNAL_SKILLS"] != "1" {
+		t.Fatalf("expected OPENCODE_DISABLE_EXTERNAL_SKILLS=1, got %q", cfg.Envs["OPENCODE_DISABLE_EXTERNAL_SKILLS"])
+	}
+
+	if len(cfg.Mounts) != 0 {
+		t.Fatalf("expected no mounts, got %v", cfg.Mounts)
+	}
+	if len(cfg.Ports) != 0 {
+		t.Fatalf("expected no ports, got %v", cfg.Ports)
+	}
+}
+
+func TestPaseoSandboxIDGen_Format(t *testing.T) {
+	// AT-P3: regex ^paseo-[0-9a-f]{6}$.
+	re := regexp.MustCompile(`^paseo-[0-9a-f]{6}$`)
+	for i := 0; i < 10; i++ {
+		id := paseoSandboxIDGen()
+		if !re.MatchString(id) {
+			t.Fatalf("expected sandbox ID matching %s, got %q", re.String(), id)
+		}
+	}
+}
+
+// --- PreFlight tests ---
+
+// setupPaseoHome creates a temp home with the specified paths.
+// paths are relative to home (e.g. ".claude", ".claude.json", ".codex").
+// Files ending in .json are created as files; others as directories.
+func setupPaseoHome(t *testing.T, paths ...string) string {
+	t.Helper()
+	home := t.TempDir()
+	for _, p := range paths {
+		full := filepath.Join(home, p)
+		if strings.HasSuffix(p, ".json") {
+			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(full, []byte("{}"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			if err := os.MkdirAll(full, 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	return home
+}
+
+func defaultPaseoTools() []string {
+	return []string{"claude", "codex", "npm", "uv", "apt", "opencode"}
+}
+
+func TestPaseoPreFlight_ClaudeDirMissing(t *testing.T) {
+	// AT-P4: .claude.json present, .codex present, but .claude missing.
+	home := setupPaseoHome(t, ".claude.json", ".codex")
+	tools := defaultPaseoTools()
+	parsed := &agentSessionArgs{builtinTools: tools}
+	var stderr bytes.Buffer
+
+	err := paseoPreFlightWithHome(&stderr, parsed, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// claude should be filtered out (missing .claude dir).
+	for _, tool := range parsed.builtinTools {
+		if tool == "claude" {
+			t.Fatal("claude should have been filtered out (missing .claude dir)")
+		}
+	}
+	// codex should remain.
+	if !containsStr(parsed.builtinTools, "codex") {
+		t.Fatalf("codex should remain, got %v", parsed.builtinTools)
+	}
+	if !strings.Contains(stderr.String(), "skipping builtin tool \"claude\"") {
+		t.Fatalf("expected skip message for claude, got: %s", stderr.String())
+	}
+}
+
+func TestPaseoPreFlight_ClaudeJSONMissing(t *testing.T) {
+	// AT-P5: .claude dir present, .codex present, but .claude.json missing.
+	home := setupPaseoHome(t, ".claude", ".codex")
+	tools := defaultPaseoTools()
+	parsed := &agentSessionArgs{builtinTools: tools}
+	var stderr bytes.Buffer
+
+	err := paseoPreFlightWithHome(&stderr, parsed, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, tool := range parsed.builtinTools {
+		if tool == "claude" {
+			t.Fatal("claude should have been filtered out (missing .claude.json)")
+		}
+	}
+	if !containsStr(parsed.builtinTools, "codex") {
+		t.Fatalf("codex should remain, got %v", parsed.builtinTools)
+	}
+}
+
+func TestPaseoPreFlight_CodexDirMissing(t *testing.T) {
+	// AT-P6: .claude and .claude.json present, but .codex missing.
+	home := setupPaseoHome(t, ".claude", ".claude.json")
+	tools := defaultPaseoTools()
+	parsed := &agentSessionArgs{builtinTools: tools}
+	var stderr bytes.Buffer
+
+	err := paseoPreFlightWithHome(&stderr, parsed, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !containsStr(parsed.builtinTools, "claude") {
+		t.Fatalf("claude should remain, got %v", parsed.builtinTools)
+	}
+	for _, tool := range parsed.builtinTools {
+		if tool == "codex" {
+			t.Fatal("codex should have been filtered out (missing .codex dir)")
+		}
+	}
+	if !strings.Contains(stderr.String(), "skipping builtin tool \"codex\"") {
+		t.Fatalf("expected skip message for codex, got: %s", stderr.String())
+	}
+}
+
+func TestPaseoPreFlight_AllNonOptionalPresent(t *testing.T) {
+	// AT-P7: all non-optional paths present → all 6 tools kept.
+	home := setupPaseoHome(t, ".claude", ".claude.json", ".codex")
+	tools := defaultPaseoTools()
+	parsed := &agentSessionArgs{builtinTools: tools}
+	var stderr bytes.Buffer
+
+	err := paseoPreFlightWithHome(&stderr, parsed, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(parsed.builtinTools) != 6 {
+		t.Fatalf("expected 6 tools, got %d: %v", len(parsed.builtinTools), parsed.builtinTools)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no skip messages, got: %s", stderr.String())
+	}
+}
+
+func TestPaseoPreFlight_OptionalOnlyToolsNeverFiltered(t *testing.T) {
+	// AT-P8: empty HOME, only optional-mount tools → never filtered.
+	home := t.TempDir() // empty
+	tools := []string{"npm", "uv", "apt", "opencode"}
+	parsed := &agentSessionArgs{builtinTools: tools}
+	var stderr bytes.Buffer
+
+	err := paseoPreFlightWithHome(&stderr, parsed, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(parsed.builtinTools) != 4 {
+		t.Fatalf("expected 4 tools, got %d: %v", len(parsed.builtinTools), parsed.builtinTools)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no skip messages, got: %s", stderr.String())
+	}
+}
+
+func TestPaseoPreFlight_UnknownToolKept(t *testing.T) {
+	// AT-P9: unknown tool "foo" preserved.
+	home := t.TempDir()
+	tools := []string{"foo"}
+	parsed := &agentSessionArgs{builtinTools: tools}
+	var stderr bytes.Buffer
+
+	err := paseoPreFlightWithHome(&stderr, parsed, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(parsed.builtinTools) != 1 || parsed.builtinTools[0] != "foo" {
+		t.Fatalf("expected [foo], got %v", parsed.builtinTools)
+	}
+}
+
+func TestPaseoPreFlight_EmptyAfterFilter(t *testing.T) {
+	// AT-PA: empty HOME, only claude+codex → empty list.
+	home := t.TempDir() // empty
+	tools := []string{"claude", "codex"}
+	parsed := &agentSessionArgs{builtinTools: tools}
+	var stderr bytes.Buffer
+
+	err := paseoPreFlightWithHome(&stderr, parsed, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(parsed.builtinTools) != 0 {
+		t.Fatalf("expected empty tools, got %v", parsed.builtinTools)
+	}
+	if !strings.Contains(stderr.String(), "claude") || !strings.Contains(stderr.String(), "codex") {
+		t.Fatalf("expected skip messages for claude and codex, got: %s", stderr.String())
+	}
+}
+
+// --- resolveAgentSessionArgs tests ---
+
+func TestResolveAgentSessionArgs_Paseo(t *testing.T) {
+	// AT-PB: mode, configYaml, builtinTools, sandboxID prefix.
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, "paseo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if parsed.mode != agentModeLongRunning {
+		t.Fatalf("expected mode=long-running, got %q", parsed.mode)
+	}
+
+	expectedTools := []string{"claude", "codex", "npm", "uv", "apt", "opencode"}
+	if len(parsed.builtinTools) != len(expectedTools) {
+		t.Fatalf("expected builtinTools=%v, got %v", expectedTools, parsed.builtinTools)
+	}
+	for i, tool := range expectedTools {
+		if parsed.builtinTools[i] != tool {
+			t.Fatalf("builtinTools[%d]: expected %q, got %q", i, tool, parsed.builtinTools[i])
+		}
+	}
+
+	if parsed.configYaml == "" {
+		t.Fatal("expected non-empty configYaml")
+	}
+	if !strings.Contains(parsed.configYaml, "image:") {
+		t.Fatalf("expected configYaml to contain image:, got:\n%s", parsed.configYaml)
+	}
+	// image should be empty because configYaml specifies it.
+	if parsed.image != "" {
+		t.Fatalf("expected empty image (configYaml provides it), got %q", parsed.image)
+	}
+
+	// sandboxID should match paseo-XXXX.
+	re := regexp.MustCompile(`^paseo-[0-9a-f]{6}$`)
+	if !re.MatchString(parsed.sandboxID) {
+		t.Fatalf("expected sandboxID matching %s, got %q", re.String(), parsed.sandboxID)
+	}
+
+	// paseo does not copy workspace.
+	if parsed.workspace != "" {
+		t.Fatalf("expected empty workspace, got %q", parsed.workspace)
+	}
+}
+
+// --- runAgentSession / runLongRunningSession tests ---
+
+func TestRunAgentSession_Paseo_ReadyMessageIncludesFilteredTools(t *testing.T) {
+	// AT-PC: fake client, observe stderr for active builtin tools.
+	home := setupPaseoHome(t, ".claude", ".claude.json") // codex missing → filtered
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, "paseo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Simulate the preFlight and factory injection that runAgentSession does.
+	var preFlightStderr bytes.Buffer
+	if err := paseoPreFlightWithHome(&preFlightStderr, &parsed, home); err != nil {
+		t.Fatalf("preFlight error: %v", err)
+	}
+	parsed.readyMessage = paseoReadyMessageFactory(parsed.builtinTools)
+
+	mock := newReadyOnlyMock()
+	var stdout, stderr bytes.Buffer
+	err = runLongRunningSession(context.Background(), mock, parsed, "paseo", &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stderrStr := stderr.String()
+	if !strings.Contains(stderrStr, "Paseo daemon is running") {
+		t.Fatalf("stderr missing Paseo readyMessage, got:\n%s", stderrStr)
+	}
+	if !strings.Contains(stderrStr, "claude") {
+		t.Fatalf("stderr should contain claude in active tools, got:\n%s", stderrStr)
+	}
+	// codex was filtered out, should not appear in tools line.
+	// But "codex" could appear in "agbox sandbox..." commands - check the tools line specifically.
+	if strings.Contains(stderrStr, "Active builtin tools: ") {
+		toolsLineStart := strings.Index(stderrStr, "Active builtin tools: ")
+		toolsLineEnd := strings.Index(stderrStr[toolsLineStart:], "\n")
+		toolsLine := stderrStr[toolsLineStart : toolsLineStart+toolsLineEnd]
+		if strings.Contains(toolsLine, "codex") {
+			t.Fatalf("codex should have been filtered from active tools, got line: %s", toolsLine)
+		}
+	}
+}
+
+// --- Ready message factory tests ---
+
+func TestPaseoReadyMessageFactory_WithTools(t *testing.T) {
+	// AT-PD: factory with tools.
+	factory := paseoReadyMessageFactory([]string{"claude", "npm", "uv"})
+	msg := factory("paseo-abc0", "agbox-primary-paseo-abc0")
+
+	if !strings.Contains(msg, "Paseo daemon is running") {
+		t.Fatalf("missing Paseo header, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "agbox paseo url paseo-abc0") {
+		t.Fatalf("missing pair URL command, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "claude, npm, uv") {
+		t.Fatalf("expected tools list, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "agbox sandbox stop paseo-abc0") {
+		t.Fatalf("missing stop command, got:\n%s", msg)
+	}
+}
+
+func TestPaseoReadyMessageFactory_EmptyTools(t *testing.T) {
+	// AT-PE: factory with nil/empty.
+	for _, input := range [][]string{nil, {}} {
+		factory := paseoReadyMessageFactory(input)
+		msg := factory("paseo-0001", "c")
+		if !strings.Contains(msg, "(none)") {
+			t.Fatalf("expected (none) for empty tools, got:\n%s", msg)
+		}
+	}
+}
+
+func TestPaseoReadyMessageFactory_DefensiveCopy(t *testing.T) {
+	// AT-PF: mutate input after factory.
+	tools := []string{"claude", "npm"}
+	factory := paseoReadyMessageFactory(tools)
+	tools[0] = "MUTATED"
+
+	msg := factory("x", "y")
+	if strings.Contains(msg, "MUTATED") {
+		t.Fatal("factory should have made a defensive copy")
+	}
+	if !strings.Contains(msg, "claude") {
+		t.Fatal("factory should still reference original tools")
+	}
+}
+
+// --- Paseo URL command tests ---
+
+func TestPaseoURLCommand_InvokesCreateExec(t *testing.T) {
+	// AT-PG: fake client, check Command.
+	var capturedReq *agboxv1.CreateExecRequest
+	sandboxID := "paseo-test"
+
+	stdoutDir := t.TempDir()
+	stdoutLog := filepath.Join(stdoutDir, "stdout.log")
+	if err := os.WriteFile(stdoutLog, []byte("https://paseo.sh/pair/abc123\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockAgentClient{
+		createExecFn: func(_ context.Context, req *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
+			capturedReq = req
+			return &agboxv1.CreateExecResponse{
+				ExecId:        "exec-pair",
+				StdoutLogPath: stdoutLog,
+			}, nil
+		},
+		getExecFn: func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
+			return &agboxv1.GetExecResponse{
+				Exec: &agboxv1.ExecStatus{
+					ExecId:            "exec-pair",
+					SandboxId:         sandboxID,
+					State:             agboxv1.ExecState_EXEC_STATE_FINISHED,
+					ExitCode:          0,
+					LastEventSequence: 3,
+				},
+			}, nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runPaseoURL(context.Background(), mock, sandboxID, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedReq == nil {
+		t.Fatal("CreateExec not called")
+	}
+	if capturedReq.SandboxId != sandboxID {
+		t.Fatalf("expected SandboxId=%q, got %q", sandboxID, capturedReq.SandboxId)
+	}
+	cmd := capturedReq.Command
+	if len(cmd) != 3 || cmd[0] != "/usr/local/bin/paseo" || cmd[1] != "daemon" || cmd[2] != "pair" {
+		t.Fatalf("expected command=[/usr/local/bin/paseo daemon pair], got %v", cmd)
+	}
+}
+
+func TestPaseoURLCommand_PrintsStdoutLog(t *testing.T) {
+	// AT-PH: fake exec, check stdout.
+	expectedURL := "https://paseo.sh/pair/xyz789\n"
+
+	stdoutDir := t.TempDir()
+	stdoutLog := filepath.Join(stdoutDir, "stdout.log")
+	if err := os.WriteFile(stdoutLog, []byte(expectedURL), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockAgentClient{
+		createExecFn: func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
+			return &agboxv1.CreateExecResponse{
+				ExecId:        "exec-pair",
+				StdoutLogPath: stdoutLog,
+			}, nil
+		},
+		getExecFn: func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
+			return &agboxv1.GetExecResponse{
+				Exec: &agboxv1.ExecStatus{
+					ExecId:            "exec-pair",
+					SandboxId:         "paseo-test",
+					State:             agboxv1.ExecState_EXEC_STATE_FINISHED,
+					ExitCode:          0,
+					LastEventSequence: 3,
+				},
+			}, nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runPaseoURL(context.Background(), mock, "paseo-test", &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdout.String() != expectedURL {
+		t.Fatalf("expected stdout=%q, got %q", expectedURL, stdout.String())
+	}
+}
+
+func TestPaseoURLCommand_NonZeroExit(t *testing.T) {
+	// AT-PI: fake exec failed.
+	stderrDir := t.TempDir()
+	stderrLog := filepath.Join(stderrDir, "stderr.log")
+	if err := os.WriteFile(stderrLog, []byte("daemon not running\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockAgentClient{
+		createExecFn: func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
+			return &agboxv1.CreateExecResponse{
+				ExecId:        "exec-pair",
+				StderrLogPath: stderrLog,
+			}, nil
+		},
+		getExecFn: func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
+			return &agboxv1.GetExecResponse{
+				Exec: &agboxv1.ExecStatus{
+					ExecId:            "exec-pair",
+					SandboxId:         "paseo-test",
+					State:             agboxv1.ExecState_EXEC_STATE_FINISHED,
+					ExitCode:          1,
+					LastEventSequence: 3,
+				},
+			}, nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runPaseoURL(context.Background(), mock, "paseo-test", &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit code")
+	}
+	// stderr log should have been printed.
+	if !strings.Contains(stderr.String(), "daemon not running") {
+		t.Fatalf("expected stderr to contain exec stderr log, got: %s", stderr.String())
+	}
+}
+
+func TestPaseoURLCommand_ArgsValidation(t *testing.T) {
+	// AT-PJ: 0 args and 2 args.
+	t.Run("zero_args", func(t *testing.T) {
+		cmd := newPaseoURLCommand()
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for zero args")
+		}
+	})
+
+	t.Run("two_args", func(t *testing.T) {
+		cmd := newPaseoURLCommand()
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{"id1", "id2"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for two args")
+		}
+	})
+}
+
+func TestTopLevelPaseoInheritsGenericFlags(t *testing.T) {
+	// AT-PK: parse flags.
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+		envs:        []string{"K=V"},
+		cpuLimit:    "2",
+		memoryLimit: "4g",
+		sandboxID:   "paseo-custom",
+	}, "paseo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.envs["K"] != "V" {
+		t.Fatalf("expected envs[K]=V, got %v", parsed.envs)
+	}
+	if parsed.cpuLimit != "2" {
+		t.Fatalf("expected cpuLimit=2, got %q", parsed.cpuLimit)
+	}
+	if parsed.memoryLimit != "4g" {
+		t.Fatalf("expected memoryLimit=4g, got %q", parsed.memoryLimit)
+	}
+	if parsed.sandboxID != "paseo-custom" {
+		t.Fatalf("expected sandboxID=paseo-custom, got %q", parsed.sandboxID)
+	}
+
+	// Verify the paseo command has the expected flags.
+	cmd := newPaseoTopLevelCommand()
+	for _, flagName := range []string{"env", "cpu-limit", "memory-limit", "disk-limit", "sandbox-id", "builtin-tool", "workspace", "mode", "command"} {
+		if cmd.Flags().Lookup(flagName) == nil {
+			t.Fatalf("paseo command missing flag %q", flagName)
+		}
+	}
+
+	// Verify url subcommand is present.
+	urlCmd, _, err := cmd.Find([]string{"url"})
+	if err != nil || urlCmd == nil || urlCmd.Name() != "url" {
+		t.Fatal("paseo command should have a 'url' subcommand")
+	}
+}
+
+// --- Helpers ---
+
+// containsStr checks if a string slice contains a given string.
+func containsStr(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Verify mockAgentClient satisfies sandboxExecClient at compile time.
+var _ sandboxExecClient = (*mockAgentClient)(nil)
+
+// Ensure newReadyOnlyMock is accessible (defined in agent_session_test.go).
+var _ = newReadyOnlyMock
+
+// Ensure fmt is used.
+var _ = fmt.Sprintf
+
+// Ensure rawclient import is referenced (used by agent_session_test.go mockEventStream).
+var _ rawclient.SandboxEventStream = (*mockEventStream)(nil)

--- a/cmd/agbox/root.go
+++ b/cmd/agbox/root.go
@@ -51,6 +51,7 @@ func run(
 		newAgentTypeCommand("claude"),
 		newAgentTypeCommand("codex"),
 		newAgentTypeCommand("openclaw"),
+		newPaseoTopLevelCommand(),
 	)
 
 	err := rootCmd.ExecuteContext(ctx)
@@ -67,8 +68,12 @@ func run(
 		return exitCodeForError(err)
 	}
 
-	// Cobra flag parse errors are usage errors: print error + usage to stderr.
-	_, _ = fmt.Fprintln(stderr, err)
+	// Cobra flag/arg parse errors are usage errors: print error + usage to stderr.
+	_, _ = fmt.Fprintf(stderr, "Error: %s\n", err)
+	if sub, _, findErr := rootCmd.Find(args); findErr == nil && sub != nil {
+		_, _ = fmt.Fprintln(stderr)
+		_, _ = fmt.Fprint(stderr, sub.UsageString())
+	}
 	return exitCodeUsageError
 }
 

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -1,7 +1,7 @@
 # Agent Guide
 
-The agent commands (`agbox claude`, `agbox codex`, `agbox openclaw`, and
-`agbox agent --command "..."`) create a sandbox, install tools, and run an AI
+The agent commands (`agbox claude`, `agbox codex`, `agbox openclaw`, `agbox paseo`,
+and `agbox agent --command "..."`) create a sandbox, install tools, and run an AI
 agent in a single step. Each registered agent type has its own top-level command;
 `agbox agent` itself is reserved exclusively for the `--command` custom-agent mode.
 
@@ -17,6 +17,7 @@ to confirm before copying.
 | `claude` | interactive | Launches Claude Code with a TTY — type prompts, see responses in real time |
 | `codex` | interactive | Launches Codex CLI with a TTY |
 | `openclaw` | long-running | Deploys an OpenClaw gateway accessible via browser |
+| `paseo` | long-running | Deploys a Paseo daemon inside a sandbox |
 | `--command` | interactive (default) | Runs any custom command inside a sandbox |
 
 ## Claude / Codex
@@ -41,6 +42,10 @@ Deploys an [OpenClaw](https://docs.openclaw.ai) gateway inside a sandbox. Unlike
 Claude/Codex, this is a long-running service — the sandbox persists after the CLI
 exits.
 
+The gateway runs as the container primary command (under tini) in a dedicated
+`openclaw-runtime` image. The CLI creates the sandbox, waits for READY, then
+detaches. The gateway may take a few seconds to accept traffic after READY.
+
 ### Prerequisites
 
 Add LLM credentials to `~/.openclaw` on the host (mounted into the sandbox — see [Architecture](#architecture)):
@@ -59,7 +64,8 @@ OPENCLAW_STATE_DIR=~/.openclaw openclaw models auth add --provider openai --api-
 agbox openclaw
 ```
 
-The CLI creates a sandbox, installs `openclaw@latest`, and starts the gateway.
+The CLI creates a sandbox with the gateway as the container primary command and waits
+for it to become READY.
 
 ### Access the Gateway
 
@@ -93,15 +99,42 @@ graph TD
     browser -->|port mapping| gw
 ```
 
-Use [sandbox commands](cli_reference.md) to stop/delete/list sandboxes.
-`agbox sandbox resume` does not restart the gateway — to redeploy, delete and recreate:
+`agbox sandbox resume` restarts the container (and the gateway primary command restarts with it).
+To force a full redeployment, delete and recreate:
 `agbox sandbox delete <sandbox-id> && agbox openclaw`.
+
+## Paseo
+
+Deploys a [Paseo](https://paseo.sh) daemon inside a sandbox. Like OpenClaw,
+this is a long-running service — the sandbox persists after the CLI exits.
+
+```bash
+agbox paseo
+```
+
+The paseo daemon starts as the container primary command. Three environment
+variables are set by default to disable STT/TTS model downloads and
+external skills.
+
+To get the pairing URL:
+
+```bash
+agbox paseo url <sandbox-id>
+```
+
+### Builtin Tool Filtering
+
+Paseo declares a broad set of builtin tools (`claude`, `codex`, `npm`, `uv`,
+`apt`, `opencode`). During pre-flight, the CLI checks whether each tool's
+required host paths exist. Tools whose required (non-optional) mounts are
+missing are silently filtered out — a skip message is printed to stderr.
+Tools with only optional mounts are never filtered.
 
 ## Custom Command
 
 `agbox agent` is the only entry point for the custom-command mode; it requires
 `--command` and does not accept a positional agent type (use `agbox claude` /
-`agbox codex` / `agbox openclaw` for those).
+`agbox codex` / `agbox openclaw` / `agbox paseo` for those).
 
 Run any command inside a sandbox:
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -33,6 +33,7 @@ agbox exec list
 agbox claude
 agbox codex
 agbox openclaw
+agbox paseo
 # Launch a custom agent via --command (only use-case for `agbox agent`)
 agbox agent --command "<binary> [args...]"
 # Generate shell autocompletion script (bash, zsh, fish, powershell)
@@ -85,6 +86,7 @@ The CLI exposes one top-level command per registered agent type. Use them direct
 agbox claude
 agbox codex
 agbox openclaw                                         # deploy OpenClaw gateway (long-running)
+agbox paseo                                            # deploy Paseo daemon (long-running)
 
 # Custom workspace
 agbox codex --workspace /path/to/project
@@ -107,33 +109,32 @@ The agent command supports two session modes, controlled by `--mode`. The mode d
 
 | Strategy | Interactive (default) | Long-running |
 |----------|----------------------|-------------|
-| Execution method | `docker exec -it` (TTY attached, real-time output) | `CreateExec` RPC + event subscription waiting for terminal state |
-| Wait behavior | Blocks until `docker exec` subprocess exits | Blocks until exec reaches terminal state (FINISHED/FAILED/CANCELLED) |
-| Ctrl+C behavior | Signal forwarded to container process → wait for exit → delete sandbox | CLI detaches, sandbox and exec continue running |
-| Output display | Real-time stdout/stderr streamed via TTY | No streaming; prints status at submission and at terminal state |
-| Sandbox cleanup on exit | Always deleted | Cleaned up only on pre-delivery failure; sandbox persists after delivery |
+| Execution method | `docker exec -it` (TTY attached, real-time output) | Container primary command (under tini); CLI waits for READY and detaches |
+| Wait behavior | Blocks until `docker exec` subprocess exits | Blocks until sandbox reaches READY state |
+| Ctrl+C behavior | Signal forwarded to container process → wait for exit → delete sandbox | CLI detaches, sandbox keeps running |
+| Output display | Real-time stdout/stderr streamed via TTY | No streaming; prints readyMessage (if defined) and sandbox ID |
+| Sandbox cleanup on exit | Always deleted | Cleaned up only on pre-READY failure; sandbox persists after READY |
 | idle_ttl | 10d (safety net) | 0 (disabled) |
 
 ### Agent Type Capabilities
 
 Agent types declare their own capabilities, orthogonal to session mode. Each capability is controlled by exactly one dimension (mode or agent type), never both:
 
-| Capability | Description | claude | codex | openclaw | Custom `--command` | User override flag |
-|-----------|-------------|--------|-------|----------|-------------------|-------------------|
-| mode | Default session mode | interactive | interactive | long-running | interactive | `--mode` |
-| command | Container command | Fixed | Fixed | Fixed (multi-phase) | User-specified | `--command` |
-| builtinTools | Pre-installed tools | Fixed | Fixed | Fixed | User-specified | `--builtin-tool` |
-| workspace copy | Copy local directory to /workspace | Yes (default: cwd) | Yes (default: cwd) | No | No | `--workspace` (explicit to enable) |
-| .git check | Confirm when workspace lacks .git | Yes | Yes | No | No | None (automatic) |
-| envs | Environment variables for container | None | None | None | None | `--env` (repeatable, `KEY=VAL` form) |
-| cpuLimit | CPU limit | None | None | None | None | `--cpu-limit` (Docker `--cpus` format) |
-| memoryLimit | Memory limit | None | None | None | None | `--memory-limit` (Docker `--memory` format) |
-| diskLimit | Disk limit | None | None | None | None | `--disk-limit` (Docker `--storage-opt size=` format) |
-| sandboxIDGen | Custom ID generator | No | No | openclaw-XXXX | No | `--sandbox-id` |
-| configYaml | Embedded sandbox config | No | No | Yes (mounts, ports, envs) | No | None |
-| preFlight | Pre-flight validation | No | No | Auth + config check | No | None |
-| phases | Multi-phase startup | No | No | install + start | No | None |
-| readyMessage | Custom ready output | No | No | Management commands | No | None |
+| Capability | Description | claude | codex | openclaw | paseo | Custom `--command` | User override flag |
+|-----------|-------------|--------|-------|----------|-------|-------------------|-------------------|
+| mode | Default session mode | interactive | interactive | long-running | long-running | interactive | `--mode` |
+| command | Container primary command (under tini in long-running; docker exec in interactive) | Fixed | Fixed | Fixed (gateway run) | Fixed (daemon start) | User-specified | `--command` |
+| builtinTools | Pre-installed tools | Fixed | Fixed | Fixed | Fixed (filtered by preFlight) | User-specified | `--builtin-tool` |
+| workspace copy | Copy local directory to /workspace | Yes (default: cwd) | Yes (default: cwd) | No | No | No | `--workspace` (explicit to enable) |
+| .git check | Confirm when workspace lacks .git | Yes | Yes | No | No | No | None (automatic) |
+| envs | Environment variables for container | None | None | None | None | None | `--env` (repeatable, `KEY=VAL` form) |
+| cpuLimit | CPU limit | None | None | None | None | None | `--cpu-limit` (Docker `--cpus` format) |
+| memoryLimit | Memory limit | None | None | None | None | None | `--memory-limit` (Docker `--memory` format) |
+| diskLimit | Disk limit | None | None | None | None | None | `--disk-limit` (Docker `--storage-opt size=` format) |
+| sandboxIDGen | Custom ID generator | No | No | openclaw-XXXXXX | paseo-XXXXXX | No | `--sandbox-id` |
+| configYaml | Embedded sandbox config | No | No | Yes (image, command, mounts, ports, envs) | Yes (image, command, envs) | No | None |
+| preFlight | Pre-flight validation | No | No | Auth check | Builtin tool host-path filter | No | None |
+| readyMessage | Custom ready output | No | No | Management commands | Management commands + active tools | No | None |
 
 - `--workspace` is optional at the top level.
   - claude/codex declare workspace copy and default to cwd.
@@ -141,15 +142,28 @@ Agent types declare their own capabilities, orthogonal to session mode. Each cap
   - Custom `--command` does not copy by default; passing `--workspace` explicitly enables it.
   - `/` and `$HOME` are rejected as workspace paths (symlinks are resolved before comparison).
 - `.git` check is declared per agent type (claude/codex enable it; openclaw and custom `--command` do not). When enabled, it triggers if the workspace directory lacks a `.git` entry.
-- openclaw auto-generates sandbox IDs matching `openclaw-XXXX` (4 hex chars); other types let the daemon generate IDs. `--sandbox-id` overrides any generator; empty or omitted values fall through to the generator or daemon auto-generation.
+- openclaw auto-generates sandbox IDs matching `openclaw-XXXXXX` (6 hex chars); paseo auto-generates `paseo-XXXXXX`; other types let the daemon generate IDs. `--sandbox-id` overrides any generator; empty or omitted values fall through to the generator or daemon auto-generation.
 - `--env` passes environment variables to `CreateSpec.Envs`. Multiple `--env` flags are merged; duplicate keys use the last value. The daemon performs key-level merge with `configYaml` envs.
 - `--cpu-limit`, `--memory-limit`, and `--disk-limit` pass resource limits directly to `CreateSpec` fields. Values are not validated by the CLI; invalid formats are rejected by the daemon or Docker.
 
 ### Command Surface
 
-Each registered agent type has its own dedicated top-level command: `agbox claude`, `agbox codex`, `agbox openclaw`. They do not accept positional arguments — the agent type is implicit in the command name. All of them reuse the same underlying session flags (`--mode`, `--workspace`, `--builtin-tool`, `--env`, `--cpu-limit`, `--memory-limit`, `--disk-limit`, `--sandbox-id`).
+Each registered agent type has its own dedicated top-level command: `agbox claude`, `agbox codex`, `agbox openclaw`, `agbox paseo`. They do not accept positional arguments — the agent type is implicit in the command name. All of them reuse the same underlying session flags (`--mode`, `--workspace`, `--builtin-tool`, `--command`, `--env`, `--cpu-limit`, `--memory-limit`, `--disk-limit`, `--sandbox-id`).
+
+`--command` can be used with registered agent types to override the default command. In interactive mode, it replaces the TTY command launched via `docker exec`. In long-running mode, it replaces the container primary command (under tini). The value is split by whitespace via `strings.Fields` (no shell quoting).
 
 `agbox agent` is reserved exclusively for the custom-command mode: you must pass `--command` and it does not accept a positional agent type. The old `agbox agent <type>` form has been removed — use the per-type top-level command instead.
+
+### Paseo Subcommands
+
+The `agbox paseo` command additionally exposes subcommands:
+
+```bash
+# Print the paseo pairing URL (runs `paseo daemon pair` inside the sandbox)
+agbox paseo url <sandbox_id>
+```
+
+- `url`: creates an exec running `/usr/local/bin/paseo daemon pair` inside the sandbox, waits for it to finish, and prints the stdout (pairing URL).
 
 ## Exit Codes
 

--- a/docs/container_dependency_strategy.md
+++ b/docs/container_dependency_strategy.md
@@ -34,6 +34,7 @@ Tools are the user-facing names passed in `builtin_tools`. Each tool resolves to
 | `uv` | `~/.cache/uv` → `/home/agbox/.cache/uv` (rw), `~/.local/share/uv` → `/home/agbox/.local/share/uv` (rw) |
 | `npm` | `~/.npm` → `/home/agbox/.npm` (read-write) |
 | `apt` | `~/.cache/agents-sandbox-apt` → `/var/cache/apt/archives` (read-write) |
+| `opencode` | `~/.config/opencode` → `/home/agbox/.config/opencode` (rw), `~/.local/share/opencode` → `/home/agbox/.local/share/opencode` (rw) |
 
 Notes:
 - `codex` mounts both `~/.codex` and `~/.agents`; `~/.agents` is the shared agents state directory.
@@ -104,13 +105,13 @@ Docker objects without these labels are never inspected, stopped, or removed by 
 
 The rule that all Docker access goes through the daemon's structured runtime client has one deliberate exception: the CLI agent commands in interactive mode.
 
-These commands — the per-type top-level entries (`agbox claude`, `agbox codex`, `agbox openclaw`) and the custom-command entry (`agbox agent --command "..."`) — create a sandbox via gRPC, wait for it to become READY, then — depending on the session mode — either attach directly or delegate to the daemon's exec model:
+These commands — the per-type top-level entries (`agbox claude`, `agbox codex`, `agbox openclaw`, `agbox paseo`) and the custom-command entry (`agbox agent --command "..."`) — create a sandbox via gRPC, wait for it to become READY, then — depending on the session mode — either attach directly or delegate to the daemon's exec model:
 
 - **Interactive mode** (default): Calls `docker exec -it` directly from the CLI process to attach an interactive TTY session into the primary container. On exit, the sandbox is deleted via gRPC.
-- **Long-running mode** (`--mode long-running`): Submits the agent command via `CreateExec` RPC and waits for exec completion via event subscription. Does not call `docker exec` directly. On exit, the sandbox is not deleted and must be managed manually.
+- **Long-running mode** (`--mode long-running`): Creates the sandbox with the service process as the container primary command (under tini). The CLI waits for sandbox READY and detaches. Does not use `CreateExec` for the service process. On exit, the sandbox is not deleted and must be managed manually.
 
 Two agent definition surfaces are supported:
-- **Pre-registered tool:** `agbox claude`, `agbox codex`, `agbox openclaw` — each is its own top-level command that uses the built-in command and builtin-tool defaults from the agent tool registry. The old `agbox agent <type>` form has been removed.
+- **Pre-registered tool:** `agbox claude`, `agbox codex`, `agbox openclaw`, `agbox paseo` — each is its own top-level command that uses the built-in command and builtin-tool defaults from the agent tool registry. The old `agbox agent <type>` form has been removed.
 - **Custom command:** `agbox agent --command "aider --yes" --workspace /path/to/project` — the only remaining use of `agbox agent`; the user provides the full command and specifies the workspace directory.
 
 **Why the interactive-mode exception is necessary:**

--- a/docs/sandbox_container_lifecycle.md
+++ b/docs/sandbox_container_lifecycle.md
@@ -6,7 +6,7 @@ This document describes the runtime lifecycle contract owned by `agents-sandbox`
 
 | Resource | Notes |
 |----------|-------|
-| Primary container | Main execution target for `CreateExec` |
+| Primary container | Runs the service process as its primary command (under tini) |
 | Dedicated network | One per sandbox; shared bridge and host network are not supported. On Linux, an nftables DOCKER-USER rule blocks container→host traffic (applied on create, re-applied on daemon restart recovery, removed on delete). On macOS, `host.docker.internal` is overridden to `0.0.0.0` via `--add-host`. |
 | Companion containers | Declared via `CompanionContainerSpec`, on the same network |
 | Persistent event history | Stored in bbolt; lifecycle and exec events survive daemon restart until retention cleanup |
@@ -17,13 +17,13 @@ Docker object labels use the reverse-DNS namespace `io.github.1996fanrui.agents-
 
 ## CLI Agent Modes
 
-The agent commands (`agbox claude`, `agbox codex`, `agbox openclaw`, and
-`agbox agent --command "..."`) support two modes:
+The agent commands (`agbox claude`, `agbox codex`, `agbox openclaw`,
+`agbox paseo`, and `agbox agent --command "..."`) support two modes:
 
 - **Interactive** (`--mode interactive`, default): Attaches a TTY to the agent process. The CLI deletes the sandbox on exit. Uses `idle_ttl=10d` as a safety net.
-- **Long-running** (`--mode long-running`): Submits the agent command via `CreateExec` and waits for completion. The CLI can detach (Ctrl+C) without affecting the sandbox. Uses `idle_ttl=0` (disable idle stop). The sandbox must be managed manually via `agbox sandbox stop/delete`.
+- **Long-running** (`--mode long-running`): Creates the sandbox and waits for it to become READY, then detaches. The container primary command (declared in configYaml or overridden via `--command`) runs as the service process under tini. Uses `idle_ttl=0` (disable idle stop). The sandbox must be managed manually via `agbox sandbox stop/delete`.
 
-In long-running mode, if sandbox setup or exec creation fails before delivery, the sandbox is automatically cleaned up.
+In long-running mode, if sandbox setup fails before READY, the sandbox is automatically cleaned up.
 
 ## Primary Container Main Process
 

--- a/images/openclaw-runtime/Dockerfile
+++ b/images/openclaw-runtime/Dockerfile
@@ -1,0 +1,10 @@
+FROM ghcr.io/agents-sandbox/coding-runtime:latest
+
+ARG OPENCLAW_VERSION
+RUN npm install -g "openclaw@${OPENCLAW_VERSION}"
+
+COPY entrypoint.sh /usr/local/bin/openclaw-entrypoint.sh
+RUN chmod +x /usr/local/bin/openclaw-entrypoint.sh
+
+ENTRYPOINT ["openclaw-entrypoint.sh"]
+CMD ["openclaw", "gateway", "run", "--port", "18789", "--bind", "lan"]

--- a/images/openclaw-runtime/entrypoint.sh
+++ b/images/openclaw-runtime/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Openclaw-runtime entrypoint: delegates to coding-runtime entrypoint for
+# user setup (HOST_UID/HOST_GID/HOME + gosu), then performs idempotent
+# openclaw initialization as the container user.
+set -eu
+
+# Phase 1 (root): delegate to base entrypoint which creates the container user
+# and re-execs this script via gosu. Use a marker env var to detect re-entry.
+if [ -z "${_OPENCLAW_INIT_DONE:-}" ]; then
+    export _OPENCLAW_INIT_DONE=1
+    exec /usr/local/bin/entrypoint.sh "$0" "$@"
+fi
+
+# Phase 2 (container user): idempotent config initialization.
+if [ ! -f "$HOME/.openclaw/config/openclaw.json" ]; then
+    openclaw onboard --mode local --non-interactive --accept-risk \
+        --gateway-auth token --gateway-bind lan --gateway-port 18789 \
+        --no-install-daemon --skip-channels --skip-skills --skip-health --skip-search --skip-ui \
+        --auth-choice skip
+    openclaw config set gateway.controlUi.dangerouslyDisableDeviceAuth true --strict-json
+fi
+
+openclaw config set agents.defaults.elevatedDefault full
+
+exec "$@"


### PR DESCRIPTION
## Summary

Two commits addressing [#189](https://github.com/1996fanrui/agents-sandbox/issues/189):

### Commit 1: Refactor openclaw to clean primary-command model + unify CLI long-running path

- **New `images/openclaw-runtime/`**: Dockerfile (FROM coding-runtime, npm install openclaw, CMD gateway run) + entrypoint.sh (idempotent init, exec "$@")
- **New `.github/workflows/publish-openclaw-runtime.yml`**: Mirrors paseo workflow
- **Deleted**: `execPhase` struct, `phases` field, `longRunningExecResult` helper
- **`runLongRunningSession`** collapsed to single path: CreateSandbox → READY → detach → print readyMessage → stdout sandboxID
- **`--command`** unified: interactive → TTY command, long-running → `CreateSpec.Command`. Mutual exclusion with agent type removed.
- **`parsed.image`**: When configYaml has `image:` field → empty (daemon uses yaml); otherwise → defaultImage
- **`CreateSpec.Envs`**: Only carries user `--env` values; configYaml envs merged by daemon
- Docs updated: sandbox_container_lifecycle.md, container_dependency_strategy.md, agent_guide.md, cli_reference.md

### Commit 2: Add paseo as first-class agent type

- **New `cmd/agbox/paseo.go`**: configYaml (image pin, paseo daemon start, 3 default envs), sandboxIDGen (`paseo-XXXX`), preFlight filter (drops tools with missing non-optional mounts), readyMessageFactory
- **New `cmd/agbox/cmd_paseo_url.go`**: `agbox paseo url <sandbox_id>` runs `paseo daemon pair` inside sandbox
- **New `cmd/agbox/paseo_test.go`**: 19 tests
- `agentTypeDefs["paseo"]` with nil readyMessage → injected after preFlight via factory
- `root.go` registers `newPaseoTopLevelCommand()`

### Test coverage

- 184 Go tests pass (`go test ./cmd/agbox/... -count=1`)
- Each commit independently builds and passes tests
- Full suite green (`go test ./... -count=1`)

Closes #189
