### PR TITLE
[ISSUE-197] Auto-print paseo pair URL at startup

### DIFF
--- a/cmd/agbox/agent_session.go
+++ b/cmd/agbox/agent_session.go
@@ -64,11 +64,6 @@ func runAgentSession(
 		}
 	}
 
-	// Inject paseo readyMessage factory after preFlight has filtered builtinTools.
-	if parsed.agentType == "paseo" {
-		parsed.readyMessage = paseoReadyMessageFactory(parsed.builtinTools)
-	}
-
 	// Workspace existence check (only when workspace is non-empty).
 	if parsed.workspace != "" {
 		if _, err := os.Stat(parsed.workspace); err != nil {
@@ -333,8 +328,19 @@ func runLongRunningSession(
 	_, _ = fmt.Fprintf(stderr, "  Shell: docker exec -it --user agbox %s bash\n", containerName)
 
 	// After READY, container is running. Set detachSuccess so deferred cleanup
-	// does not delete the sandbox.
+	// does not delete the sandbox. Any error beyond this point leaves the
+	// sandbox alive so the user can still interact with it (e.g. via
+	// `agbox paseo url`).
 	detachSuccess = true
+
+	// For paseo, fetch the pair URL now and inject it into the ready message.
+	if parsed.agentType == "paseo" {
+		pairURL, err := fetchPaseoPairURL(ctx, client, sandboxID, stderr)
+		if err != nil {
+			return err
+		}
+		parsed.readyMessage = paseoReadyMessageFactory(parsed.builtinTools, pairURL)
+	}
 
 	// Print readyMessage if defined.
 	if parsed.readyMessage != nil {

--- a/cmd/agbox/agent_types.go
+++ b/cmd/agbox/agent_types.go
@@ -55,6 +55,6 @@ var agentTypeDefs = map[string]agentTypeDef{
 		configYaml:   paseoConfigYaml,
 		sandboxIDGen: paseoSandboxIDGen,
 		preFlight:    paseoPreFlight,
-		// readyMessage injected by runAgentSession after preFlight filters builtinTools.
+		// readyMessage injected by runLongRunningSession after fetching the pair URL.
 	},
 }

--- a/cmd/agbox/cmd_paseo_url.go
+++ b/cmd/agbox/cmd_paseo_url.go
@@ -2,11 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"os"
 
-	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
 	"github.com/1996fanrui/agents-sandbox/internal/platform"
 	"github.com/1996fanrui/agents-sandbox/sdk/go/rawclient"
 	"github.com/spf13/cobra"
@@ -34,32 +31,12 @@ func newPaseoURLCommand() *cobra.Command {
 }
 
 func runPaseoURL(ctx context.Context, client sandboxExecClient, sandboxID string, stdout, stderr io.Writer) error {
-	createResp, err := client.CreateExec(ctx, &agboxv1.CreateExecRequest{
-		SandboxId: sandboxID,
-		Command:   []string{"/usr/local/bin/paseo", "daemon", "pair"},
-	})
+	urlOutput, err := fetchPaseoPairURL(ctx, client, sandboxID, stderr)
 	if err != nil {
-		return runtimeErrorf("create exec: %v", err)
-	}
-
-	if err := waitForExecDone(ctx, client, createResp.GetExecId(), sandboxID); err != nil {
-		// Read stderr log if available.
-		if stderrLogPath := createResp.GetStderrLogPath(); stderrLogPath != "" {
-			if logData, readErr := os.ReadFile(stderrLogPath); readErr == nil && len(logData) > 0 {
-				_, _ = fmt.Fprintf(stderr, "%s", logData)
-			}
-		}
 		return err
 	}
-
-	// Read and print stdout log (contains the pair URL).
-	stdoutLogPath := createResp.GetStdoutLogPath()
-	if stdoutLogPath != "" {
-		logData, readErr := os.ReadFile(stdoutLogPath)
-		if readErr != nil {
-			return runtimeErrorf("read stdout log: %v", readErr)
-		}
-		_, _ = stdout.Write(logData)
+	if urlOutput != "" {
+		_, _ = stdout.Write([]byte(urlOutput))
 	}
 	return nil
 }

--- a/cmd/agbox/paseo.go
+++ b/cmd/agbox/paseo.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
+	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
 	"github.com/1996fanrui/agents-sandbox/internal/profile"
 )
 
@@ -91,25 +93,68 @@ func expandHostPath(p, home string) string {
 }
 
 // paseoReadyMessageFactory returns a readyMessage closure that captures the
-// filtered builtin tools list. The factory makes a defensive copy of activeTools
-// to prevent caller mutation from affecting the closure.
-func paseoReadyMessageFactory(activeTools []string) func(sandboxID, containerName string) string {
+// filtered builtin tools list and the pair URL fetched at startup. The factory
+// makes a defensive copy of activeTools to prevent caller mutation from
+// affecting the closure. pairURL is embedded verbatim (trailing whitespace
+// trimmed); multi-line output is preserved with aligned indentation.
+func paseoReadyMessageFactory(activeTools []string, pairURL string) func(sandboxID, containerName string) string {
 	clone := append([]string(nil), activeTools...)
+	trimmed := strings.TrimRight(pairURL, " \t\r\n")
 	return func(sandboxID, containerName string) string {
 		toolsLine := "(none)"
 		if len(clone) > 0 {
 			toolsLine = strings.Join(clone, ", ")
 		}
+		// For multi-line URL output, indent continuation lines to align under
+		// the first line, so the block reads as a single logical field.
+		pairBlock := trimmed
+		if strings.Contains(trimmed, "\n") {
+			pairBlock = strings.ReplaceAll(trimmed, "\n", "\n    ")
+		}
 		return fmt.Sprintf(`
 Paseo daemon is running.
-  Pair URL:   agbox paseo url %s
+  Pair URL: %s
   Active builtin tools: %s
+  Get URL again: agbox paseo url %s
 
 Manage:
   agbox sandbox stop %s      # stop sandbox
   agbox sandbox resume %s    # restart container (primary command restarts with it)
   agbox sandbox delete %s    # delete sandbox
   agbox exec list %s         # list running execs
-`, sandboxID, toolsLine, sandboxID, sandboxID, sandboxID, sandboxID)
+`, pairBlock, toolsLine, sandboxID, sandboxID, sandboxID, sandboxID, sandboxID)
 	}
+}
+
+// fetchPaseoPairURL runs `paseo daemon pair` inside the sandbox and returns
+// its stdout. On failure it writes the exec stderr log (if any) to errOut
+// before returning the error. Shared by `agbox paseo url` and the auto-fetch
+// path at session startup.
+func fetchPaseoPairURL(ctx context.Context, client sandboxExecClient, sandboxID string, errOut io.Writer) (string, error) {
+	createResp, err := client.CreateExec(ctx, &agboxv1.CreateExecRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"/usr/local/bin/paseo", "daemon", "pair"},
+	})
+	if err != nil {
+		return "", runtimeErrorf("create exec: %v", err)
+	}
+
+	if err := waitForExecDone(ctx, client, createResp.GetExecId(), sandboxID); err != nil {
+		if stderrLogPath := createResp.GetStderrLogPath(); stderrLogPath != "" {
+			if logData, readErr := os.ReadFile(stderrLogPath); readErr == nil && len(logData) > 0 {
+				_, _ = fmt.Fprintf(errOut, "%s", logData)
+			}
+		}
+		return "", err
+	}
+
+	stdoutLogPath := createResp.GetStdoutLogPath()
+	if stdoutLogPath == "" {
+		return "", nil
+	}
+	logData, readErr := os.ReadFile(stdoutLogPath)
+	if readErr != nil {
+		return "", runtimeErrorf("read stdout log: %v", readErr)
+	}
+	return string(logData), nil
 }

--- a/cmd/agbox/paseo_test.go
+++ b/cmd/agbox/paseo_test.go
@@ -307,18 +307,42 @@ func TestRunAgentSession_Paseo_ReadyMessageIncludesFilteredTools(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Simulate the preFlight and factory injection that runAgentSession does.
+	// Simulate the preFlight that runAgentSession does; the readyMessage
+	// factory is now injected by runLongRunningSession after fetching the
+	// pair URL, so set agentType so that path is exercised.
 	var preFlightStderr bytes.Buffer
 	if err := paseoPreFlightWithHome(&preFlightStderr, &parsed, home); err != nil {
 		t.Fatalf("preFlight error: %v", err)
 	}
-	parsed.readyMessage = paseoReadyMessageFactory(parsed.builtinTools)
+	parsed.agentType = "paseo"
+
+	stdoutDir := t.TempDir()
+	stdoutLog := filepath.Join(stdoutDir, "stdout.log")
+	if err := os.WriteFile(stdoutLog, []byte("https://paseo.sh/pair/auto-fetch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	mock := newReadyOnlyMock()
+	mock.createExecFn = func(_ context.Context, _ *agboxv1.CreateExecRequest) (*agboxv1.CreateExecResponse, error) {
+		return &agboxv1.CreateExecResponse{ExecId: "exec-pair", StdoutLogPath: stdoutLog}, nil
+	}
+	mock.getExecFn = func(_ context.Context, _ string) (*agboxv1.GetExecResponse, error) {
+		return &agboxv1.GetExecResponse{Exec: &agboxv1.ExecStatus{
+			ExecId:            "exec-pair",
+			SandboxId:         "sb-001",
+			State:             agboxv1.ExecState_EXEC_STATE_FINISHED,
+			ExitCode:          0,
+			LastEventSequence: 3,
+		}}, nil
+	}
+
 	var stdout, stderr bytes.Buffer
 	err = runLongRunningSession(context.Background(), mock, parsed, "paseo", &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "https://paseo.sh/pair/auto-fetch") {
+		t.Fatalf("stderr should contain fetched pair URL, got:\n%s", stderr.String())
 	}
 
 	stderrStr := stderr.String()
@@ -344,14 +368,22 @@ func TestRunAgentSession_Paseo_ReadyMessageIncludesFilteredTools(t *testing.T) {
 
 func TestPaseoReadyMessageFactory_WithTools(t *testing.T) {
 	// AT-PD: factory with tools.
-	factory := paseoReadyMessageFactory([]string{"claude", "npm", "uv"})
+	factory := paseoReadyMessageFactory([]string{"claude", "npm", "uv"}, "https://paseo.sh/pair/abc123\n")
 	msg := factory("paseo-abc0", "agbox-primary-paseo-abc0")
 
 	if !strings.Contains(msg, "Paseo daemon is running") {
 		t.Fatalf("missing Paseo header, got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "agbox paseo url paseo-abc0") {
-		t.Fatalf("missing pair URL command, got:\n%s", msg)
+	if !strings.Contains(msg, "Pair URL: https://paseo.sh/pair/abc123") {
+		t.Fatalf("missing fetched pair URL, got:\n%s", msg)
+	}
+	// Trailing whitespace from the URL output must be trimmed so the line
+	// does not carry a dangling newline before the next field.
+	if strings.Contains(msg, "https://paseo.sh/pair/abc123\n\n") {
+		t.Fatalf("pair URL trailing whitespace not trimmed, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Get URL again: agbox paseo url paseo-abc0") {
+		t.Fatalf("missing retry hint, got:\n%s", msg)
 	}
 	if !strings.Contains(msg, "claude, npm, uv") {
 		t.Fatalf("expected tools list, got:\n%s", msg)
@@ -361,10 +393,19 @@ func TestPaseoReadyMessageFactory_WithTools(t *testing.T) {
 	}
 }
 
+func TestPaseoReadyMessageFactory_MultiLineURL(t *testing.T) {
+	// Continuation lines must be indented to align under the first line.
+	factory := paseoReadyMessageFactory(nil, "line1\nline2\n")
+	msg := factory("paseo-xyz", "c")
+	if !strings.Contains(msg, "Pair URL: line1\n    line2") {
+		t.Fatalf("multi-line URL not aligned, got:\n%s", msg)
+	}
+}
+
 func TestPaseoReadyMessageFactory_EmptyTools(t *testing.T) {
 	// AT-PE: factory with nil/empty.
 	for _, input := range [][]string{nil, {}} {
-		factory := paseoReadyMessageFactory(input)
+		factory := paseoReadyMessageFactory(input, "https://paseo.sh/pair/x")
 		msg := factory("paseo-0001", "c")
 		if !strings.Contains(msg, "(none)") {
 			t.Fatalf("expected (none) for empty tools, got:\n%s", msg)
@@ -375,7 +416,7 @@ func TestPaseoReadyMessageFactory_EmptyTools(t *testing.T) {
 func TestPaseoReadyMessageFactory_DefensiveCopy(t *testing.T) {
 	// AT-PF: mutate input after factory.
 	tools := []string{"claude", "npm"}
-	factory := paseoReadyMessageFactory(tools)
+	factory := paseoReadyMessageFactory(tools, "https://paseo.sh/pair/x")
 	tools[0] = "MUTATED"
 
 	msg := factory("x", "y")

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -116,7 +116,8 @@ The paseo daemon starts as the container primary command. Three environment
 variables are set by default to disable STT/TTS model downloads and
 external skills.
 
-To get the pairing URL:
+On successful startup, the ready message embeds the pairing URL (fetched by
+running `paseo daemon pair` inside the sandbox). To fetch it again later:
 
 ```bash
 agbox paseo url <sandbox-id>

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -163,7 +163,7 @@ The `agbox paseo` command additionally exposes subcommands:
 agbox paseo url <sandbox_id>
 ```
 
-- `url`: creates an exec running `/usr/local/bin/paseo daemon pair` inside the sandbox, waits for it to finish, and prints the stdout (pairing URL).
+- `url`: creates an exec running `/usr/local/bin/paseo daemon pair` inside the sandbox, waits for it to finish, and prints the stdout (pairing URL). The same URL is also embedded in the ready message printed by `agbox paseo` on successful startup; this subcommand is used to re-fetch it later.
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

- Auto-fetch the paseo pair URL at startup (by running `paseo daemon pair` inside the sandbox) and embed it directly into the ready message printed by `agbox paseo`.
- Preserve the `agbox paseo url <sandbox_id>` subcommand for later retrieval. Its stdout output is byte-for-byte unchanged.
- Failure handling mirrors the `url` subcommand: surface exec stderr, return the error. Sandbox stays alive (detachSuccess is set before the fetch) so the user can re-run `agbox paseo url` later.

Closes #197

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/agbox/...` (new + existing tests)
- [x] `cmd_paseo_url.go` refactored to share a single helper (`fetchPaseoPairURL`) with the startup path; `agbox paseo url` behavior unchanged
- [ ] Manual end-to-end run with a real paseo runtime (pending human verification)
