### PR TITLE
[ISSUE-203] Handle HOST_UID=0 in runtime image entrypoints

### DIFF
--- a/images/coding-runtime/entrypoint.sh
+++ b/images/coding-runtime/entrypoint.sh
@@ -19,22 +19,29 @@ fi
 USERNAME="agbox"
 USER_HOME="/home/agbox"
 
-if ! getent group "$HOST_GID" >/dev/null 2>&1; then
-    groupadd -g "$HOST_GID" "$USERNAME"
-fi
-
-if ! getent passwd "$HOST_UID" >/dev/null 2>&1; then
-    useradd -m -s /bin/bash -u "$HOST_UID" -g "$HOST_GID" -d "$USER_HOME" "$USERNAME"
+if [ "$HOST_UID" = "0" ]; then
+    # Host is root: add an agbox alias for uid=0 so "docker exec --user agbox" works.
+    if ! getent passwd agbox >/dev/null 2>&1; then
+        echo "agbox:x:0:0:agbox:${USER_HOME}:/bin/bash" >> /etc/passwd
+    fi
 else
-    EXISTING_USER=$(getent passwd "$HOST_UID" | cut -d: -f1)
-    if [ "$EXISTING_USER" != "$USERNAME" ]; then
-        usermod -l "$USERNAME" "$EXISTING_USER" 2>/dev/null || true
-        EXISTING_USER="$USERNAME"
+    if ! getent group "$HOST_GID" >/dev/null 2>&1; then
+        groupadd -g "$HOST_GID" "$USERNAME"
     fi
-    if [ "$(getent passwd "$HOST_UID" | cut -d: -f6)" != "$USER_HOME" ]; then
-        usermod -d "$USER_HOME" -m "$EXISTING_USER" 2>/dev/null || true
+
+    if ! getent passwd "$HOST_UID" >/dev/null 2>&1; then
+        useradd -m -s /bin/bash -u "$HOST_UID" -g "$HOST_GID" -d "$USER_HOME" "$USERNAME"
+    else
+        EXISTING_USER=$(getent passwd "$HOST_UID" | cut -d: -f1)
+        if [ "$EXISTING_USER" != "$USERNAME" ]; then
+            usermod -l "$USERNAME" "$EXISTING_USER" 2>/dev/null || true
+            EXISTING_USER="$USERNAME"
+        fi
+        if [ "$(getent passwd "$HOST_UID" | cut -d: -f6)" != "$USER_HOME" ]; then
+            usermod -d "$USER_HOME" -m "$EXISTING_USER" 2>/dev/null || true
+        fi
+        USERNAME="$EXISTING_USER"
     fi
-    USERNAME="$EXISTING_USER"
 fi
 
 mkdir -p "$USER_HOME"

--- a/images/paseo-runtime/entrypoint.sh
+++ b/images/paseo-runtime/entrypoint.sh
@@ -20,23 +20,30 @@ USERNAME="agbox"
 USER_HOME="/home/agbox"
 USER_SHELL="/bin/zsh"
 
-if ! getent group "$HOST_GID" >/dev/null 2>&1; then
-    groupadd -g "$HOST_GID" "$USERNAME"
-fi
-
-if ! getent passwd "$HOST_UID" >/dev/null 2>&1; then
-    useradd -m -s "$USER_SHELL" -u "$HOST_UID" -g "$HOST_GID" -d "$USER_HOME" "$USERNAME"
+if [ "$HOST_UID" = "0" ]; then
+    # Host is root: add an agbox alias for uid=0 so "docker exec --user agbox" works.
+    if ! getent passwd agbox >/dev/null 2>&1; then
+        echo "agbox:x:0:0:agbox:${USER_HOME}:${USER_SHELL}" >> /etc/passwd
+    fi
 else
-    EXISTING_USER=$(getent passwd "$HOST_UID" | cut -d: -f1)
-    if [ "$EXISTING_USER" != "$USERNAME" ]; then
-        usermod -l "$USERNAME" "$EXISTING_USER" 2>/dev/null || true
-        EXISTING_USER="$USERNAME"
+    if ! getent group "$HOST_GID" >/dev/null 2>&1; then
+        groupadd -g "$HOST_GID" "$USERNAME"
     fi
-    if [ "$(getent passwd "$HOST_UID" | cut -d: -f6)" != "$USER_HOME" ]; then
-        usermod -d "$USER_HOME" -m "$EXISTING_USER" 2>/dev/null || true
+
+    if ! getent passwd "$HOST_UID" >/dev/null 2>&1; then
+        useradd -m -s "$USER_SHELL" -u "$HOST_UID" -g "$HOST_GID" -d "$USER_HOME" "$USERNAME"
+    else
+        EXISTING_USER=$(getent passwd "$HOST_UID" | cut -d: -f1)
+        if [ "$EXISTING_USER" != "$USERNAME" ]; then
+            usermod -l "$USERNAME" "$EXISTING_USER" 2>/dev/null || true
+            EXISTING_USER="$USERNAME"
+        fi
+        if [ "$(getent passwd "$HOST_UID" | cut -d: -f6)" != "$USER_HOME" ]; then
+            usermod -d "$USER_HOME" -m "$EXISTING_USER" 2>/dev/null || true
+        fi
+        usermod -s "$USER_SHELL" "$EXISTING_USER" 2>/dev/null || true
+        USERNAME="$EXISTING_USER"
     fi
-    usermod -s "$USER_SHELL" "$EXISTING_USER" 2>/dev/null || true
-    USERNAME="$EXISTING_USER"
 fi
 
 mkdir -p "$USER_HOME"


### PR DESCRIPTION
## Summary

- Fix `HOST_UID=0` (root) support in `coding-runtime` and `paseo-runtime` entrypoints
- When `HOST_UID=0`, `usermod -l agbox root` silently fails (root is immutable), leaving `agbox` user uncreated and causing `docker exec --user agbox` to fail
- Fix: special-case `HOST_UID=0` — append an `agbox` alias entry for uid=0 to `/etc/passwd` so all agbox name lookups resolve correctly without any CLI changes
- `openclaw-runtime` delegates to `coding-runtime` entrypoint, so it is covered by the same fix

## Test plan

- [x] `docker run -e HOST_UID=0 -e HOST_GID=0 ... bash -c "getent passwd agbox"` → returns `agbox:x:0:0:agbox:/home/agbox:/bin/bash`
- [x] `docker exec --user agbox <container> id` → `uid=0(root) gid=0(root) groups=0(root)`
- [x] Non-root case (`HOST_UID=1000`) still works correctly
- [x] All unit tests pass

Close #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
