### PR TITLE
[ISSUE-207] Append-merge daemon arrays + add --mount/--port/--copy/--label flags

### DIFF
--- a/cmd/agbox/agent_session.go
+++ b/cmd/agbox/agent_session.go
@@ -137,32 +137,13 @@ func runInteractiveSession(
 	defer signal.Stop(sigintCh)
 	defer signal.Stop(sigtermCh)
 
-	// Build copies list conditionally based on workspace.
-	copies := []*agboxv1.CopySpec{}
-	if parsed.workspace != "" {
-		copies = append(copies, &agboxv1.CopySpec{Source: parsed.workspace, Target: "/workspace"})
-	}
-
 	// Use a large idle TTL as a safety net: the CLI always cleans up on exit,
 	// but if the process is killed without cleanup (e.g., SIGKILL), the daemon
 	// will reclaim the sandbox after agentSessionIdleTTL.
 	createResp, err := client.CreateSandbox(ctx, &agboxv1.CreateSandboxRequest{
 		SandboxId:  parsed.sandboxID,
 		ConfigYaml: configYamlBytes(parsed.configYaml),
-		CreateSpec: &agboxv1.CreateSpec{
-			Image:        parsed.image,
-			BuiltinTools: parsed.builtinTools,
-			Copies:       copies,
-			Envs:         parsed.envs,
-			CpuLimit:     parsed.cpuLimit,
-			MemoryLimit:  parsed.memoryLimit,
-			DiskLimit:    parsed.diskLimit,
-			Labels: map[string]string{
-				"created-by": "agbox-cli",
-				"agent-type": agentLabel,
-			},
-			IdleTtl: durationpb.New(agentSessionIdleTTL),
-		},
+		CreateSpec: buildAgentCreateSpec(parsed, agentLabel, durationpb.New(agentSessionIdleTTL), nil),
 	})
 	if err != nil {
 		return runtimeErrorf("create sandbox: %v", err)
@@ -264,31 +245,11 @@ func runLongRunningSession(
 	defer signal.Stop(sigintCh)
 	defer signal.Stop(sigtermCh)
 
-	// Build copies list conditionally based on workspace.
-	copies := []*agboxv1.CopySpec{}
-	if parsed.workspace != "" {
-		copies = append(copies, &agboxv1.CopySpec{Source: parsed.workspace, Target: "/workspace"})
-	}
-
 	// idle_ttl=0 disables idle stop; the sandbox stays alive until explicit stop/delete.
 	createResp, err := client.CreateSandbox(ctx, &agboxv1.CreateSandboxRequest{
 		SandboxId:  parsed.sandboxID,
 		ConfigYaml: configYamlBytes(parsed.configYaml),
-		CreateSpec: &agboxv1.CreateSpec{
-			Image:        parsed.image,
-			Command:      parsed.command,
-			BuiltinTools: parsed.builtinTools,
-			Copies:       copies,
-			Envs:         parsed.envs,
-			CpuLimit:     parsed.cpuLimit,
-			MemoryLimit:  parsed.memoryLimit,
-			DiskLimit:    parsed.diskLimit,
-			Labels: map[string]string{
-				"created-by": "agbox-cli",
-				"agent-type": agentLabel,
-			},
-			IdleTtl: durationpb.New(0),
-		},
+		CreateSpec: buildAgentCreateSpec(parsed, agentLabel, durationpb.New(0), parsed.command),
 	})
 	if err != nil {
 		return runtimeErrorf("create sandbox: %v", err)
@@ -613,6 +574,47 @@ func pumpSandboxEvents(stream rawclient.SandboxEventStream, eventCh chan<- sandb
 			return
 		}
 		eventCh <- sandboxEventResult{event: event}
+	}
+}
+
+// buildAgentCreateSpec assembles the CreateSpec sent to the daemon for an
+// agent session. Layout rules:
+//   - Copies: workspace first (when present), then user --copy entries.
+//   - Mounts/Ports: user --mount/--port entries appended; preset YAML mounts
+//     and ports are merged in by the daemon (base + override append).
+//   - Labels: built-in labels (created-by, agent-type) written first, then
+//     user --label entries overlay (last write wins via Go map semantics).
+//   - command: caller-controlled — interactive sessions pass nil so the
+//     primary command from the preset YAML is used; long-running sessions
+//     pass parsed.command to set the container primary command.
+func buildAgentCreateSpec(parsed agentSessionArgs, agentLabel string, idleTTL *durationpb.Duration, command []string) *agboxv1.CreateSpec {
+	copies := []*agboxv1.CopySpec{}
+	if parsed.workspace != "" {
+		copies = append(copies, &agboxv1.CopySpec{Source: parsed.workspace, Target: "/workspace"})
+	}
+	copies = append(copies, parsed.userCopies...)
+
+	labels := map[string]string{
+		"created-by": "agbox-cli",
+		"agent-type": agentLabel,
+	}
+	for k, v := range parsed.userLabels {
+		labels[k] = v
+	}
+
+	return &agboxv1.CreateSpec{
+		Image:        parsed.image,
+		Command:      command,
+		BuiltinTools: parsed.builtinTools,
+		Mounts:       parsed.userMounts,
+		Copies:       copies,
+		Ports:        parsed.userPorts,
+		Envs:         parsed.envs,
+		CpuLimit:     parsed.cpuLimit,
+		MemoryLimit:  parsed.memoryLimit,
+		DiskLimit:    parsed.diskLimit,
+		Labels:       labels,
+		IdleTtl:      idleTTL,
 	}
 }
 

--- a/cmd/agbox/cmd_agent.go
+++ b/cmd/agbox/cmd_agent.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
+	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -21,6 +23,10 @@ type agentSessionFlagVars struct {
 	memoryLimit  string
 	diskLimit    string
 	sandboxID    string
+	mounts       []string
+	ports        []string
+	copies       []string
+	labels       []string
 	// Track which flags were explicitly set by the user:
 	modeOverridden         bool
 	workspaceOverridden    bool
@@ -38,6 +44,10 @@ func registerAgentSessionFlags(cmd *cobra.Command, v *agentSessionFlagVars) {
 	cmd.Flags().StringVar(&v.memoryLimit, "memory-limit", "", "Memory limit (Docker --memory format, e.g. 4g, 512m)")
 	cmd.Flags().StringVar(&v.diskLimit, "disk-limit", "", "Disk limit (Docker --storage-opt size= format, e.g. 10g)")
 	cmd.Flags().StringVar(&v.sandboxID, "sandbox-id", "", "Custom sandbox ID (overrides agent type default)")
+	cmd.Flags().StringArrayVar(&v.mounts, "mount", nil, "Bind mount in host:container[:writable] form (repeatable; default read-only)")
+	cmd.Flags().StringArrayVar(&v.ports, "port", nil, "Port mapping in host:container[/proto] form (repeatable; proto = tcp|udp|sctp, default tcp)")
+	cmd.Flags().StringArrayVar(&v.copies, "copy", nil, "File/directory copy in host:container form (repeatable; appended after the workspace copy)")
+	cmd.Flags().StringArrayVar(&v.labels, "label", nil, "Sandbox label in key=value form (repeatable; user values override built-in created-by/agent-type)")
 }
 
 // newPaseoTopLevelCommand builds the top-level `agbox paseo` command with the
@@ -79,6 +89,14 @@ type agentSessionArgs struct {
 	configYaml   string                                       // embedded YAML config
 	image        string                                       // container image (empty = daemon uses configYaml image)
 	readyMessage func(sandboxID, containerName string) string // custom ready message
+	// Parsed --mount / --port / --copy / --label values, ready to splice into
+	// CreateSpec.Mounts/Ports/Copies/Labels at request build time. Built-in
+	// labels (created-by, agent-type) are written first; userLabels overlay
+	// last so users can override them via --label.
+	userMounts []*agboxv1.MountSpec
+	userPorts  []*agboxv1.PortMapping
+	userCopies []*agboxv1.CopySpec
+	userLabels map[string]string
 }
 
 // newAgentCommand builds `agbox agent --command "..."` for running a custom
@@ -217,6 +235,48 @@ func resolveAgentSessionArgs(
 	parsed.memoryLimit = v.memoryLimit
 	parsed.diskLimit = v.diskLimit
 
+	// Parse repeatable structured flags. Each parser returns a usageError on
+	// invalid input; failures are surfaced verbatim so cobra prints usage.
+	for _, raw := range v.mounts {
+		m, err := parseMountFlag(raw)
+		if err != nil {
+			return agentSessionArgs{}, err
+		}
+		parsed.userMounts = append(parsed.userMounts, m)
+	}
+	for _, raw := range v.ports {
+		p, err := parsePortFlag(raw)
+		if err != nil {
+			return agentSessionArgs{}, err
+		}
+		parsed.userPorts = append(parsed.userPorts, p)
+	}
+	for _, raw := range v.copies {
+		c, err := parseCopyFlag(raw)
+		if err != nil {
+			return agentSessionArgs{}, err
+		}
+		parsed.userCopies = append(parsed.userCopies, c)
+	}
+	if len(v.labels) > 0 {
+		labelMap := make(map[string]string, len(v.labels))
+		for _, raw := range v.labels {
+			key, value, err := parseKeyValueAssignment(raw, "--label")
+			if err != nil {
+				return agentSessionArgs{}, err
+			}
+			// parseKeyValueAssignment only enforces the presence of '='; an
+			// empty key (e.g. "=value") is meaningless for a label and is
+			// rejected here so users see a usageError instead of a silently
+			// dropped/odd map entry.
+			if key == "" {
+				return agentSessionArgs{}, usageErrorf("--label key must not be empty")
+			}
+			labelMap[key] = value // last occurrence wins
+		}
+		parsed.userLabels = labelMap
+	}
+
 	// Sandbox ID resolution: --sandbox-id overrides the type's generator.
 	if v.sandboxID != "" {
 		parsed.sandboxID = v.sandboxID
@@ -278,4 +338,101 @@ func validateWorkspacePath(workspace string) (string, error) {
 	}
 
 	return realWorkspace, nil
+}
+
+// parseMountFlag parses a --mount value of the form "host:container" or
+// "host:container:writable" into a MountSpec. The optional third component
+// must be the literal word "writable"; any other suffix (e.g. ":ro", ":rw")
+// is rejected to keep the surface small and the default (read-only) explicit.
+func parseMountFlag(s string) (*agboxv1.MountSpec, error) {
+	parts := strings.Split(s, ":")
+	switch len(parts) {
+	case 2:
+		if parts[0] == "" || parts[1] == "" {
+			return nil, usageErrorf("--mount %q: source and target must be non-empty", s)
+		}
+		return &agboxv1.MountSpec{Source: parts[0], Target: parts[1]}, nil
+	case 3:
+		if parts[0] == "" || parts[1] == "" {
+			return nil, usageErrorf("--mount %q: source and target must be non-empty", s)
+		}
+		if parts[2] != "writable" {
+			return nil, usageErrorf("--mount %q: only the literal suffix \":writable\" is supported (got %q); omit the suffix for read-only", s, parts[2])
+		}
+		return &agboxv1.MountSpec{Source: parts[0], Target: parts[1], Writable: true}, nil
+	default:
+		return nil, usageErrorf("--mount %q: must be host:container or host:container:writable", s)
+	}
+}
+
+// parsePortFlag parses a --port value of the form "host:container[/proto]"
+// into a PortMapping. host and container must be integers in [1, 65535];
+// proto (case-insensitive) defaults to TCP and accepts tcp/udp/sctp.
+func parsePortFlag(s string) (*agboxv1.PortMapping, error) {
+	if s == "" {
+		return nil, usageErrorf("--port: value must not be empty")
+	}
+	hostContainer := s
+	protoStr := "tcp"
+	if idx := strings.Index(s, "/"); idx >= 0 {
+		hostContainer = s[:idx]
+		protoStr = s[idx+1:]
+		if protoStr == "" {
+			return nil, usageErrorf("--port %q: protocol must not be empty after '/'", s)
+		}
+	}
+	parts := strings.Split(hostContainer, ":")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, usageErrorf("--port %q: must be host:container[/proto]", s)
+	}
+	hostPort, err := parsePortNumber(parts[0], "--port host_port", s)
+	if err != nil {
+		return nil, err
+	}
+	containerPort, err := parsePortNumber(parts[1], "--port container_port", s)
+	if err != nil {
+		return nil, err
+	}
+	var proto agboxv1.PortProtocol
+	switch strings.ToLower(protoStr) {
+	case "tcp":
+		proto = agboxv1.PortProtocol_PORT_PROTOCOL_TCP
+	case "udp":
+		proto = agboxv1.PortProtocol_PORT_PROTOCOL_UDP
+	case "sctp":
+		proto = agboxv1.PortProtocol_PORT_PROTOCOL_SCTP
+	default:
+		return nil, usageErrorf("--port %q: unsupported protocol %q; must be tcp, udp, or sctp", s, protoStr)
+	}
+	return &agboxv1.PortMapping{
+		HostPort:      uint32(hostPort),
+		ContainerPort: uint32(containerPort),
+		Protocol:      proto,
+	}, nil
+}
+
+// parsePortNumber parses a port string and validates the [1, 65535] range.
+func parsePortNumber(raw, role, full string) (int, error) {
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, usageErrorf("%s %q: %q is not an integer", role, full, raw)
+	}
+	if n < 1 || n > 65535 {
+		return 0, usageErrorf("%s %q: %d is out of range (1..65535)", role, full, n)
+	}
+	return n, nil
+}
+
+// parseCopyFlag parses a --copy value of the form "host:container" into a
+// CopySpec. The split is on the first ':' so the container path may itself
+// contain colons; both source and target must be non-empty.
+func parseCopyFlag(s string) (*agboxv1.CopySpec, error) {
+	source, target, found := strings.Cut(s, ":")
+	if !found {
+		return nil, usageErrorf("--copy %q: must be host:container", s)
+	}
+	if source == "" || target == "" {
+		return nil, usageErrorf("--copy %q: source and target must be non-empty", s)
+	}
+	return &agboxv1.CopySpec{Source: source, Target: target}, nil
 }

--- a/cmd/agbox/cmd_agent_flags_test.go
+++ b/cmd/agbox/cmd_agent_flags_test.go
@@ -1,0 +1,485 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+	"gopkg.in/yaml.v3"
+)
+
+// TestParseMountFlag covers the host:container[:writable] syntax. Any suffix
+// other than the literal ":writable" must be rejected with a hint pointing at
+// :writable so users do not accidentally mimic Docker's :ro / :rw vocabulary.
+func TestParseMountFlag(t *testing.T) {
+	t.Run("two_parts_writable_false", func(t *testing.T) {
+		got, err := parseMountFlag("/a:/b")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetSource() != "/a" || got.GetTarget() != "/b" || got.GetWritable() {
+			t.Fatalf("unexpected MountSpec: %+v", got)
+		}
+	})
+
+	t.Run("three_parts_writable_true", func(t *testing.T) {
+		got, err := parseMountFlag("/a:/b:writable")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetSource() != "/a" || got.GetTarget() != "/b" || !got.GetWritable() {
+			t.Fatalf("unexpected MountSpec: %+v", got)
+		}
+	})
+
+	cases := []struct {
+		name     string
+		input    string
+		errFrag  string
+		wantHint bool // expects ":writable" hint in error message
+	}{
+		{"reject_ro", "/a:/b:ro", "writable", true},
+		{"reject_rw", "/a:/b:rw", "writable", true},
+		{"reject_foo", "/a:/b:foo", "writable", true},
+		{"only_colon", ":", "non-empty", false},
+		{"empty_source", ":/b", "non-empty", false},
+		{"empty_target", "/a:", "non-empty", false},
+		{"missing_colon", "/a/b", "host:container", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseMountFlag(tc.input)
+			if err == nil {
+				t.Fatalf("expected error for %q", tc.input)
+			}
+			if !strings.Contains(err.Error(), tc.errFrag) {
+				t.Fatalf("error %q missing %q", err.Error(), tc.errFrag)
+			}
+			if tc.wantHint && !strings.Contains(err.Error(), ":writable") {
+				t.Fatalf("error %q missing :writable hint", err.Error())
+			}
+		})
+	}
+}
+
+// TestParsePortFlag covers host:container[/proto] syntax with proto defaulting
+// to TCP and case-insensitive parsing.
+func TestParsePortFlag(t *testing.T) {
+	good := []struct {
+		name     string
+		input    string
+		host     uint32
+		ctr      uint32
+		protocol agboxv1.PortProtocol
+	}{
+		{"tcp_default", "8080:9090", 8080, 9090, agboxv1.PortProtocol_PORT_PROTOCOL_TCP},
+		{"udp_lower", "8080:9090/udp", 8080, 9090, agboxv1.PortProtocol_PORT_PROTOCOL_UDP},
+		{"sctp_upper", "8080:9090/SCTP", 8080, 9090, agboxv1.PortProtocol_PORT_PROTOCOL_SCTP},
+		{"tcp_explicit_upper", "1:65535/TCP", 1, 65535, agboxv1.PortProtocol_PORT_PROTOCOL_TCP},
+	}
+	for _, tc := range good {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parsePortFlag(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.GetHostPort() != tc.host || got.GetContainerPort() != tc.ctr || got.GetProtocol() != tc.protocol {
+				t.Fatalf("unexpected PortMapping: %+v", got)
+			}
+		})
+	}
+
+	bad := []struct {
+		name  string
+		input string
+	}{
+		{"missing_container", "8080"},
+		{"container_zero", "8080:0"},
+		{"host_zero", "0:9090"},
+		{"non_integer", "abc:9090"},
+		{"out_of_range", "8080:65536"},
+		{"unknown_proto", "8080:9090/foo"},
+		{"empty", ""},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parsePortFlag(tc.input); err == nil {
+				t.Fatalf("expected error for %q", tc.input)
+			}
+		})
+	}
+}
+
+// TestParseCopyFlag covers the host:container syntax. The split is on the
+// first ':' so container paths may contain colons.
+func TestParseCopyFlag(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		got, err := parseCopyFlag("/a:/b")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetSource() != "/a" || got.GetTarget() != "/b" {
+			t.Fatalf("unexpected CopySpec: %+v", got)
+		}
+	})
+
+	bad := []struct {
+		name  string
+		input string
+	}{
+		{"missing_colon", "/a/b"},
+		{"empty_source", ":/b"},
+		{"empty_target", "/a:"},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseCopyFlag(tc.input); err == nil {
+				t.Fatalf("expected error for %q", tc.input)
+			}
+		})
+	}
+}
+
+// TestResolveAgentSessionArgs_NewFlags exercises the end-to-end path: raw
+// flag strings → agentSessionArgs → CreateSpec, asserting both that the flags
+// are correctly parsed and that buildAgentCreateSpec splices them into the
+// request the daemon receives.
+func TestResolveAgentSessionArgs_NewFlags(t *testing.T) {
+	v := &agentSessionFlagVars{
+		rawCommand: "sleep infinity",
+		mounts:     []string{"/host1:/c1", "/host2:/c2:writable"},
+		ports:      []string{"8080:9090", "5353:53/udp"},
+		copies:     []string{"/src1:/dst1", "/src2:/dst2"},
+		labels:     []string{"k1=v1", "k2=v2"},
+	}
+	parsed, err := resolveAgentSessionArgs(v, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(parsed.userMounts) != 2 || parsed.userMounts[0].GetTarget() != "/c1" || !parsed.userMounts[1].GetWritable() {
+		t.Fatalf("unexpected userMounts: %+v", parsed.userMounts)
+	}
+	if len(parsed.userPorts) != 2 || parsed.userPorts[1].GetProtocol() != agboxv1.PortProtocol_PORT_PROTOCOL_UDP {
+		t.Fatalf("unexpected userPorts: %+v", parsed.userPorts)
+	}
+	if len(parsed.userCopies) != 2 || parsed.userCopies[0].GetTarget() != "/dst1" {
+		t.Fatalf("unexpected userCopies: %+v", parsed.userCopies)
+	}
+	if parsed.userLabels["k1"] != "v1" || parsed.userLabels["k2"] != "v2" {
+		t.Fatalf("unexpected userLabels: %+v", parsed.userLabels)
+	}
+
+	spec := buildAgentCreateSpec(parsed, "test", nil, parsed.command)
+	if len(spec.GetMounts()) != 2 || len(spec.GetPorts()) != 2 || len(spec.GetCopies()) != 2 {
+		t.Fatalf("unexpected spec lengths: mounts=%d ports=%d copies=%d", len(spec.GetMounts()), len(spec.GetPorts()), len(spec.GetCopies()))
+	}
+	wantLabels := map[string]string{
+		"created-by": "agbox-cli",
+		"agent-type": "test",
+		"k1":         "v1",
+		"k2":         "v2",
+	}
+	for k, want := range wantLabels {
+		if got := spec.GetLabels()[k]; got != want {
+			t.Fatalf("label %q: want %q got %q", k, want, got)
+		}
+	}
+}
+
+// TestResolveAgentSessionArgs_NewFlags_InvalidLabelKey ensures the empty-key
+// check on top of parseKeyValueAssignment is wired in.
+func TestResolveAgentSessionArgs_NewFlags_InvalidLabelKey(t *testing.T) {
+	_, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+		rawCommand: "sleep infinity",
+		labels:     []string{"=value"},
+	}, "")
+	if err == nil {
+		t.Fatal("expected error for empty label key")
+	}
+	if !strings.Contains(err.Error(), "--label key must not be empty") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+// agentCommandsForHelpTest returns the five agent command names whose --help
+// output must include the new flags. Keep this list in sync with the agent
+// subcommand registry in cmd/agbox/main.go.
+func agentCommandsForHelpTest() []string {
+	return []string{"claude", "codex", "openclaw", "paseo", "agent"}
+}
+
+// buildAgentCommandForHelp constructs the cobra command for an agent type so
+// that --help renders the same flag set the user would see.
+func buildAgentCommandForHelp(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	switch name {
+	case "claude", "codex", "openclaw":
+		return newAgentTypeCommand(name)
+	case "paseo":
+		return newPaseoTopLevelCommand()
+	case "agent":
+		return newAgentCommand()
+	default:
+		t.Fatalf("unknown agent command %q", name)
+		return nil
+	}
+}
+
+// captureHelp returns the --help output of an agent command.
+func captureHelp(t *testing.T, name string) string {
+	t.Helper()
+	cmd := buildAgentCommandForHelp(t, name)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute --help on %q: %v", name, err)
+	}
+	return buf.String()
+}
+
+// TestAgentCommandHelp_IncludesNewFlags asserts every agent subcommand's
+// --help output advertises the four new flags.
+func TestAgentCommandHelp_IncludesNewFlags(t *testing.T) {
+	wantFlags := []string{"--mount", "--port", "--copy", "--label"}
+	for _, name := range agentCommandsForHelpTest() {
+		t.Run(name, func(t *testing.T) {
+			out := captureHelp(t, name)
+			for _, flag := range wantFlags {
+				if !strings.Contains(out, flag) {
+					t.Fatalf("agbox %s --help missing %q\n%s", name, flag, out)
+				}
+			}
+		})
+	}
+}
+
+// TestAgentCommandHelp_NoExcludedFlags asserts excluded flags never appear in
+// any agent subcommand's --help output, guarding against accidental future
+// regressions (--idle-ttl belongs to sandbox create, --image is preset-only,
+// --companion-container is YAML-only per design §5).
+func TestAgentCommandHelp_NoExcludedFlags(t *testing.T) {
+	excluded := []string{"--idle-ttl", "--image", "--companion-container"}
+	for _, name := range agentCommandsForHelpTest() {
+		t.Run(name, func(t *testing.T) {
+			out := captureHelp(t, name)
+			for _, flag := range excluded {
+				if strings.Contains(out, flag) {
+					t.Fatalf("agbox %s --help unexpectedly contains %q\n%s", name, flag, out)
+				}
+			}
+		})
+	}
+}
+
+// TestLabelOverride_BuiltinAndUserOrder ensures that user --label values
+// overwrite the built-in created-by / agent-type entries (Go map last-write
+// semantics) and that repeated --label k=... favours the latest occurrence.
+func TestLabelOverride_BuiltinAndUserOrder(t *testing.T) {
+	t.Run("user_overrides_builtin", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand: "sleep infinity",
+			labels:     []string{"created-by=other", "agent-type=custom"},
+		}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		spec := buildAgentCreateSpec(parsed, "ignored", nil, parsed.command)
+		if got := spec.GetLabels()["created-by"]; got != "other" {
+			t.Fatalf("created-by: want %q got %q", "other", got)
+		}
+		if got := spec.GetLabels()["agent-type"]; got != "custom" {
+			t.Fatalf("agent-type: want %q got %q", "custom", got)
+		}
+	})
+
+	t.Run("repeated_label_last_wins", func(t *testing.T) {
+		parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{
+			rawCommand: "sleep infinity",
+			labels:     []string{"k=old", "k=new"},
+		}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		spec := buildAgentCreateSpec(parsed, "test", nil, parsed.command)
+		if got := spec.GetLabels()["k"]; got != "new" {
+			t.Fatalf("label k: want %q got %q", "new", got)
+		}
+	})
+}
+
+// TestAgentDefault_PreservesPresets ensures that, with no new flags passed,
+// the post-merge CreateSpec for each registered agent type retains the preset
+// YAML's mounts/ports verbatim and the built-in labels stay in place. The
+// merge is simulated using the same field semantics as
+// internal/control.mergeCreateSpecs so the test reflects end-to-end behaviour
+// without depending on a daemon process.
+func TestAgentDefault_PreservesPresets(t *testing.T) {
+	cases := []struct {
+		name       string
+		agentType  string
+		wantMounts []string // mount targets
+		wantPorts  []uint32 // host ports
+	}{
+		{name: "claude", agentType: "claude"},
+		{name: "codex", agentType: "codex"},
+		{name: "openclaw", agentType: "openclaw", wantMounts: []string{"~/.openclaw"}, wantPorts: []uint32{18789}},
+		{name: "paseo", agentType: "paseo"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{}, tc.agentType)
+			if err != nil {
+				t.Fatalf("resolveAgentSessionArgs: %v", err)
+			}
+			override := buildAgentCreateSpec(parsed, tc.agentType, nil, parsed.command)
+			merged := simulateDaemonMerge(t, parsed.configYaml, override)
+
+			gotTargets := make([]string, 0, len(merged.GetMounts()))
+			for _, m := range merged.GetMounts() {
+				gotTargets = append(gotTargets, m.GetTarget())
+			}
+			if !equalStrings(gotTargets, tc.wantMounts) {
+				t.Fatalf("%s mounts: want %v got %v", tc.agentType, tc.wantMounts, gotTargets)
+			}
+
+			gotPorts := make([]uint32, 0, len(merged.GetPorts()))
+			for _, p := range merged.GetPorts() {
+				gotPorts = append(gotPorts, p.GetHostPort())
+			}
+			if !equalUint32(gotPorts, tc.wantPorts) {
+				t.Fatalf("%s ports: want %v got %v", tc.agentType, tc.wantPorts, gotPorts)
+			}
+
+			if merged.GetLabels()["created-by"] != "agbox-cli" {
+				t.Fatalf("%s created-by: %q", tc.agentType, merged.GetLabels()["created-by"])
+			}
+			if merged.GetLabels()["agent-type"] != tc.agentType {
+				t.Fatalf("%s agent-type label: %q", tc.agentType, merged.GetLabels()["agent-type"])
+			}
+		})
+	}
+}
+
+// simulateDaemonMerge mirrors internal/control.mergeCreateSpecs (private to
+// the daemon package) so the CLI tests can assert end-to-end behaviour. Only
+// the fields touched by Stage 2 (mounts/ports/copies/labels) and the preset
+// surface (image/command/envs) need to be modelled. Stage 1 already pins the
+// authoritative semantics in internal/control unit tests.
+func simulateDaemonMerge(t *testing.T, configYAML string, override *agboxv1.CreateSpec) *agboxv1.CreateSpec {
+	t.Helper()
+	base := loadPresetSpec(t, configYAML)
+	if base == nil {
+		return proto.Clone(override).(*agboxv1.CreateSpec)
+	}
+	if override == nil {
+		return base
+	}
+	result := proto.Clone(base).(*agboxv1.CreateSpec)
+
+	if override.GetImage() != "" {
+		result.Image = override.GetImage()
+	}
+	result.Mounts = append(result.Mounts, override.GetMounts()...)
+	result.Copies = append(result.Copies, override.GetCopies()...)
+	result.Ports = append(result.Ports, override.GetPorts()...)
+	if len(override.GetCommand()) > 0 {
+		result.Command = append([]string(nil), override.GetCommand()...)
+	}
+	if len(override.GetLabels()) > 0 {
+		if result.Labels == nil {
+			result.Labels = make(map[string]string)
+		}
+		for k, v := range override.GetLabels() {
+			result.Labels[k] = v
+		}
+	}
+	if len(override.GetEnvs()) > 0 {
+		if result.Envs == nil {
+			result.Envs = make(map[string]string)
+		}
+		for k, v := range override.GetEnvs() {
+			result.Envs[k] = v
+		}
+	}
+	return result
+}
+
+// loadPresetSpec parses an agent preset YAML into a CreateSpec equivalent.
+// It only models the fields the agent presets actually use today (image,
+// command, mounts, ports, envs); other fields stay zero.
+func loadPresetSpec(t *testing.T, configYAML string) *agboxv1.CreateSpec {
+	t.Helper()
+	if configYAML == "" {
+		return nil
+	}
+	type yamlMount struct {
+		Source   string `yaml:"source"`
+		Target   string `yaml:"target"`
+		Writable bool   `yaml:"writable"`
+	}
+	type yamlPort struct {
+		HostPort      uint32 `yaml:"host_port"`
+		ContainerPort uint32 `yaml:"container_port"`
+		Protocol      string `yaml:"protocol"`
+	}
+	type yamlCfg struct {
+		Image   string            `yaml:"image"`
+		Command []string          `yaml:"command"`
+		Mounts  []yamlMount       `yaml:"mounts"`
+		Ports   []yamlPort        `yaml:"ports"`
+		Envs    map[string]string `yaml:"envs"`
+	}
+	var cfg yamlCfg
+	if err := yaml.Unmarshal([]byte(configYAML), &cfg); err != nil {
+		t.Fatalf("yaml unmarshal preset: %v", err)
+	}
+	spec := &agboxv1.CreateSpec{
+		Image:   cfg.Image,
+		Command: cfg.Command,
+		Envs:    cfg.Envs,
+	}
+	for _, m := range cfg.Mounts {
+		spec.Mounts = append(spec.Mounts, &agboxv1.MountSpec{
+			Source:   m.Source,
+			Target:   m.Target,
+			Writable: m.Writable,
+		})
+	}
+	for _, p := range cfg.Ports {
+		spec.Ports = append(spec.Ports, &agboxv1.PortMapping{
+			HostPort:      p.HostPort,
+			ContainerPort: p.ContainerPort,
+		})
+	}
+	return spec
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalUint32(a, b []uint32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -96,6 +96,16 @@ agbox claude --mode long-running
 agbox claude --cpu-limit 2 --memory-limit 4g --disk-limit 10g --env MY_API_KEY=secret
 # Override sandbox ID
 agbox codex --sandbox-id my-custom-sandbox
+# Bind-mount a host directory (read-only by default; suffix :writable to enable writes)
+agbox claude --mount /var/data:/data
+agbox openclaw --mount /var/cache:/cache:writable
+# Publish a host:container port (default tcp; append /udp or /sctp to switch protocol)
+agbox paseo --port 6767:6767
+agbox openclaw --port 5353:53/udp
+# Copy extra files alongside the workspace (host:container; appended after the workspace copy)
+agbox claude --copy /etc/myapp/config.yaml:/home/agbox/config.yaml
+# Apply user labels (override built-in created-by / agent-type if needed)
+agbox codex --label team=infra --label created-by=ci-bot
 
 # Custom agent via `agbox agent --command` (the ONLY supported form of `agbox agent`)
 agbox agent --command "claude --dangerously-skip-permissions" --builtin-tool claude --builtin-tool git --builtin-tool uv --builtin-tool npm
@@ -135,6 +145,10 @@ Agent types declare their own capabilities, orthogonal to session mode. Each cap
 | configYaml | Embedded sandbox config | No | No | Yes (image, command, mounts, ports, envs) | Yes (image, command, envs) | No | None |
 | preFlight | Pre-flight validation | No | No | Auth check | Builtin tool host-path filter | No | None |
 | readyMessage | Custom ready output | No | No | Management commands | Management commands + active tools | No | None |
+| mounts | Extra bind mounts (preset entries are kept; user entries appended) | None | None | Preset `~/.openclaw` | None | None | `--mount host:container[:writable]` (repeatable) |
+| ports | Extra port mappings (preset entries are kept; user entries appended) | None | None | Preset `18789:18789/tcp` | None | None | `--port host:container[/proto]` (repeatable; proto = tcp/udp/sctp) |
+| copies | Extra copies (workspace copy is preserved; user entries appended) | None | None | None | None | None | `--copy host:container` (repeatable) |
+| labels | Sandbox labels (built-in `created-by` / `agent-type` written first; user values overlay) | Built-in | Built-in | Built-in | Built-in | Built-in | `--label key=value` (repeatable) |
 
 - `--workspace` is optional at the top level.
   - claude/codex declare workspace copy and default to cwd.
@@ -145,10 +159,14 @@ Agent types declare their own capabilities, orthogonal to session mode. Each cap
 - openclaw auto-generates sandbox IDs matching `openclaw-XXXXXX` (6 hex chars); paseo auto-generates `paseo-XXXXXX`; other types let the daemon generate IDs. `--sandbox-id` overrides any generator; empty or omitted values fall through to the generator or daemon auto-generation.
 - `--env` passes environment variables to `CreateSpec.Envs`. Multiple `--env` flags are merged; duplicate keys use the last value. The daemon performs key-level merge with `configYaml` envs.
 - `--cpu-limit`, `--memory-limit`, and `--disk-limit` pass resource limits directly to `CreateSpec` fields. Values are not validated by the CLI; invalid formats are rejected by the daemon or Docker.
+- `--mount` accepts `host:container` (read-only) or `host:container:writable`. Other Docker-style suffixes (`:ro`, `:rw`, etc.) are rejected — use `:writable` to opt into write access. User mounts are appended to any preset YAML mounts; the daemon rejects duplicate `target` paths between mounts and copies.
+- `--port` accepts `host:container[/proto]`. Both port numbers must be in `1..65535`; `proto` is case-insensitive and must be one of `tcp` (default), `udp`, or `sctp`. The daemon rejects duplicate `(host_port, protocol)` pairs across preset and user entries.
+- `--copy` accepts `host:container` and is appended **after** the workspace copy. The daemon rejects duplicate `target` paths between copies and mounts.
+- `--label` accepts `key=value` (repeatable). User entries are written after the built-in `created-by=agbox-cli` / `agent-type=<type>` labels, so passing `--label created-by=...` overrides the built-in value. Empty keys (`=value`) are rejected.
 
 ### Command Surface
 
-Each registered agent type has its own dedicated top-level command: `agbox claude`, `agbox codex`, `agbox openclaw`, `agbox paseo`. They do not accept positional arguments — the agent type is implicit in the command name. All of them reuse the same underlying session flags (`--mode`, `--workspace`, `--builtin-tool`, `--command`, `--env`, `--cpu-limit`, `--memory-limit`, `--disk-limit`, `--sandbox-id`).
+Each registered agent type has its own dedicated top-level command: `agbox claude`, `agbox codex`, `agbox openclaw`, `agbox paseo`. They do not accept positional arguments — the agent type is implicit in the command name. All of them reuse the same underlying session flags (`--mode`, `--workspace`, `--builtin-tool`, `--command`, `--env`, `--cpu-limit`, `--memory-limit`, `--disk-limit`, `--sandbox-id`, `--mount`, `--port`, `--copy`, `--label`).
 
 `--command` can be used with registered agent types to override the default command. In interactive mode, it replaces the TTY command launched via `docker exec`. In long-running mode, it replaces the container primary command (under tini). The value is split by whitespace via `strings.Fields` (no shell quoting).
 

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -47,7 +47,7 @@ The northbound API may override only a narrow subset of behavior:
 | Generic mounts | Yes | Each sandbox may bind explicit host paths to explicit container targets. `source` and `target` support `~` prefix: `source` expands to the host user's home directory; `target` expands to the container user's home directory. `~username` syntax is not supported. |
 | Generic copies | Yes | Each sandbox may copy explicit host files or trees into explicit container targets. `source` and `target` support `~` prefix: `source` expands to the host user's home directory; `target` expands to the container user's home directory. `~username` syntax is not supported. |
 | Built-in resources | Yes | Each sandbox may request daemon-defined resource shortcuts such as `claude`, `codex`, `opencode`, `git`, `uv`, `npm`, or `apt` |
-| Caller-provided `config_yaml` | Yes | Inline YAML configuration; when provided, field-level values from `CreateSpec` override the YAML (RFC 7396 merge semantics) |
+| Caller-provided `config_yaml` | Yes | Inline YAML configuration; when provided, the YAML is the base spec and `CreateSpec` is the override. Per-field merge follows the rules below. |
 | Caller-provided `sandbox_id` | Yes | If omitted, the daemon reserves a UUID v4 before accepting the request |
 | Caller-provided `exec_id` | Yes | If omitted, the daemon reserves a UUID v4 before accepting the request |
 | `companion_containers` | Yes | Each sandbox declares companion containers started concurrently with the primary container |
@@ -61,6 +61,17 @@ The northbound API may override only a narrow subset of behavior:
 | `CreateSpec.disk_limit` / `CompanionContainerSpec.disk_limit` | Yes | Docker `--storage-opt size=` style, e.g. `"10g"`. Per-container: the top-level value scopes to the primary container, each companion carries its own `disk_limit`. Wired to `HostConfig.StorageOpt["size"]`. `""` = unlimited. See [Resource Limits Prerequisites](#resource-limits-prerequisites). |
 
 The daemon persists sandbox event history in `ids.db`. For STOPPED sandboxes, once `runtime.cleanup_ttl` elapses since the sandbox entered STOPPED state, the daemon automatically removes Docker resources (containers, network) and deletes the sandbox record from the database. For DELETED sandboxes, once `runtime.cleanup_ttl` elapses since deletion, the daemon purges the retained event history and deletion metadata.
+
+### YAML / CreateSpec Merge Semantics
+
+The daemon merges the parsed YAML (base) with the `CreateSpec` (override) per field type:
+
+- Scalar fields (`image`, `cpu_limit`, `memory_limit`, `disk_limit`, `idle_ttl`): non-empty / non-nil override replaces base.
+- Map fields (`labels`, `envs`): key-level merge — override key wins, base-only keys preserved.
+- Repeated structured fields (`mounts`, `copies`, `ports`, `builtin_tools`, `companion_containers`): base + override append, base first. `builtin_tools` is deduped after append (preserving first-occurrence order); the other repeated fields keep every entry.
+- `command` (primary container only): override non-empty wins entirely. A command is a single executable invocation, so append has no executable meaning. Companion containers have no per-companion command-merge path: they are appended whole, and `validateCreateSpec` rejects duplicate companion `name`s.
+
+After merge the daemon runs `validateCreateSpec`, which rejects same-`target` collisions across `mounts` and `copies`, duplicate `(host_port, protocol)` ports, and duplicate companion container names.
 
 ## Resource Limits Prerequisites
 

--- a/docs/declarative_yaml_config.md
+++ b/docs/declarative_yaml_config.md
@@ -169,15 +169,16 @@ sandbox, err := client.CreateSandbox(ctx,
 
 ## Override Semantics
 
-When both YAML and explicit parameters are provided, explicit parameters override YAML values following [JSON Merge Patch (RFC 7396)](https://www.rfc-editor.org/rfc/rfc7396) semantics:
+When both YAML and explicit `CreateSpec` parameters are provided, the YAML is the base and `CreateSpec` is the override. Merge is per-field-type:
 
-| Field Type | Override Behavior |
+| Field Type | Merge Behavior |
 |---|---|
-| Scalar (`image`) | Non-empty explicit value overwrites YAML |
-| Repeated (`mounts`, `copies`, etc.) | Non-empty explicit value replaces YAML entirely |
-| Map (`labels`, `envs`) | Key-level merge: explicit keys overwrite; YAML-only keys preserved |
+| Scalar (`image`, `cpu_limit`, `memory_limit`, `disk_limit`, `idle_ttl`) | Non-empty / non-nil override replaces base |
+| Map (`labels`, `envs`) | Key-level merge: override key wins, base-only keys preserved |
+| Repeated structured (`mounts`, `copies`, `ports`, `builtin_tools`, `companion_containers`) | Base + override append, base first |
+| `command` (primary container only) | Override non-empty replaces base entirely (single-command semantics; append has no executable meaning) |
 
-**Known limitation**: callers cannot use explicit parameters to clear a repeated field defined in YAML. Empty values are treated as "not set."
+`builtin_tools` is deduped after append (preserving first-occurrence order) so declaring the same tool in both YAML and `CreateSpec` is accepted. All other repeated fields keep every appended entry; conflict detection (same mount/copy `target`, same `(host_port, protocol)`, same companion `name`) runs after merge in the daemon's `validateCreateSpec`.
 
 ## Environment Variable Inheritance
 

--- a/internal/control/docker_runtime_dockerapi.go
+++ b/internal/control/docker_runtime_dockerapi.go
@@ -77,6 +77,27 @@ type dockerExecSpec struct {
 	ExecID        string // Used to construct log file names when LogDir is set
 }
 
+// buildPortBindings translates dockerPortMapping entries into the Docker API
+// PortSet/PortMap pair. Multiple PortMappings sharing the same
+// (container_port, protocol) but differing host_port are appended into the
+// same PortMap entry; direct assignment would silently drop earlier bindings.
+func buildPortBindings(ports []dockerPortMapping) (nat.PortSet, nat.PortMap, error) {
+	exposedPorts := make(nat.PortSet)
+	portBindings := make(nat.PortMap)
+	for _, p := range ports {
+		natPort, err := nat.NewPort(p.Protocol, fmt.Sprintf("%d", p.ContainerPort))
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid port spec %d/%s: %w", p.ContainerPort, p.Protocol, err)
+		}
+		exposedPorts[natPort] = struct{}{}
+		portBindings[natPort] = append(portBindings[natPort], nat.PortBinding{
+			HostIP:   "127.0.0.1",
+			HostPort: fmt.Sprintf("%d", p.HostPort),
+		})
+	}
+	return exposedPorts, portBindings, nil
+}
+
 func ensureUniqueMountTargets(mounts []dockerMount) error {
 	targets := make(map[string]string, len(mounts))
 	for _, mount := range mounts {
@@ -153,19 +174,9 @@ func (backend *dockerRuntimeBackend) dockerContainerCreate(ctx context.Context, 
 			ReadOnly: item.ReadOnly,
 		})
 	}
-	// Build port bindings and exposed ports from the spec.
-	exposedPorts := make(nat.PortSet)
-	portBindings := make(nat.PortMap)
-	for _, p := range spec.Ports {
-		natPort, err := nat.NewPort(p.Protocol, fmt.Sprintf("%d", p.ContainerPort))
-		if err != nil {
-			return fmt.Errorf("invalid port spec %d/%s: %w", p.ContainerPort, p.Protocol, err)
-		}
-		exposedPorts[natPort] = struct{}{}
-		portBindings[natPort] = []nat.PortBinding{{
-			HostIP:   "127.0.0.1",
-			HostPort: fmt.Sprintf("%d", p.HostPort),
-		}}
+	exposedPorts, portBindings, err := buildPortBindings(spec.Ports)
+	if err != nil {
+		return err
 	}
 	hostConfig := &container.HostConfig{
 		Init:         ptrTo(true),

--- a/internal/control/docker_runtime_test.go
+++ b/internal/control/docker_runtime_test.go
@@ -233,3 +233,37 @@ func TestPrimaryContainerEnvironmentIncludesSshAuthSockWhenMounted(t *testing.T)
 		t.Fatalf("unexpected HOST_GID: got %q want %q", got, want)
 	}
 }
+
+// TestPortBindingsAppendsSharedContainerPort guards against a regression
+// where direct map assignment dropped earlier bindings whenever multiple
+// PortMappings shared the same (container_port, protocol) but differed in
+// host_port. After the fix, both host ports must be present in the
+// resulting nat.PortMap entry.
+func TestPortBindingsAppendsSharedContainerPort(t *testing.T) {
+	exposed, bindings, err := buildPortBindings([]dockerPortMapping{
+		{ContainerPort: 8080, HostPort: 18789, Protocol: "tcp"},
+		{ContainerPort: 8080, HostPort: 9999, Protocol: "tcp"},
+	})
+	if err != nil {
+		t.Fatalf("buildPortBindings: %v", err)
+	}
+	if len(exposed) != 1 {
+		t.Fatalf("expected 1 exposed port (deduped by key), got %d", len(exposed))
+	}
+	var entries []string
+	for natPort, list := range bindings {
+		if natPort.Port() != "8080" || natPort.Proto() != "tcp" {
+			continue
+		}
+		for _, b := range list {
+			entries = append(entries, b.HostPort)
+		}
+	}
+	hostPorts := map[string]bool{}
+	for _, e := range entries {
+		hostPorts[e] = true
+	}
+	if !hostPorts["18789"] || !hostPorts["9999"] {
+		t.Fatalf("expected both 18789 and 9999 host_port bindings preserved, got %v", entries)
+	}
+}

--- a/internal/control/merge_create_specs_test.go
+++ b/internal/control/merge_create_specs_test.go
@@ -1,0 +1,213 @@
+package control
+
+import (
+	"reflect"
+	"testing"
+
+	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
+)
+
+// TestMergeCreateSpecs_RepeatedFieldsAppend covers AT-MZ5V: every repeated
+// structured field (mounts / copies / builtin_tools / companion_containers /
+// ports) must follow base+override append with base-first ordering.
+func TestMergeCreateSpecs_RepeatedFieldsAppend(t *testing.T) {
+	base := &agboxv1.CreateSpec{
+		Mounts: []*agboxv1.MountSpec{
+			{Source: "/base/m1", Target: "/base/m1"},
+			{Source: "/base/m2", Target: "/base/m2"},
+		},
+		Copies: []*agboxv1.CopySpec{
+			{Source: "/base/c1", Target: "/base/c1"},
+		},
+		BuiltinTools: []string{"claude"},
+		CompanionContainers: []*agboxv1.CompanionContainerSpec{
+			{Name: "base-cc", Image: "base:1"},
+		},
+		Ports: []*agboxv1.PortMapping{
+			{ContainerPort: 8000, HostPort: 8000, Protocol: agboxv1.PortProtocol_PORT_PROTOCOL_TCP},
+		},
+	}
+	override := &agboxv1.CreateSpec{
+		Mounts: []*agboxv1.MountSpec{
+			{Source: "/ovr/m3", Target: "/ovr/m3"},
+		},
+		Copies: []*agboxv1.CopySpec{
+			{Source: "/ovr/c2", Target: "/ovr/c2"},
+			{Source: "/ovr/c3", Target: "/ovr/c3"},
+		},
+		BuiltinTools: []string{"uv"},
+		CompanionContainers: []*agboxv1.CompanionContainerSpec{
+			{Name: "ovr-cc1", Image: "ovr:1"},
+			{Name: "ovr-cc2", Image: "ovr:2"},
+		},
+		Ports: []*agboxv1.PortMapping{
+			{ContainerPort: 9000, HostPort: 9000, Protocol: agboxv1.PortProtocol_PORT_PROTOCOL_TCP},
+		},
+	}
+
+	result := mergeCreateSpecs(base, override)
+
+	// mounts: 2 base + 1 override = 3, base-first.
+	if got := len(result.GetMounts()); got != 3 {
+		t.Fatalf("mounts: expected 3, got %d", got)
+	}
+	if result.GetMounts()[0].GetTarget() != "/base/m1" || result.GetMounts()[1].GetTarget() != "/base/m2" || result.GetMounts()[2].GetTarget() != "/ovr/m3" {
+		t.Fatalf("mounts ordering wrong: %v", result.GetMounts())
+	}
+
+	// copies: 1 base + 2 override = 3, base-first.
+	if got := len(result.GetCopies()); got != 3 {
+		t.Fatalf("copies: expected 3, got %d", got)
+	}
+	if result.GetCopies()[0].GetTarget() != "/base/c1" || result.GetCopies()[1].GetTarget() != "/ovr/c2" || result.GetCopies()[2].GetTarget() != "/ovr/c3" {
+		t.Fatalf("copies ordering wrong: %v", result.GetCopies())
+	}
+
+	// builtin_tools: 1 base + 1 override = 2, base-first.
+	if got := result.GetBuiltinTools(); !reflect.DeepEqual(got, []string{"claude", "uv"}) {
+		t.Fatalf("builtin_tools ordering wrong: %v", got)
+	}
+
+	// companion_containers: 1 base + 2 override = 3, base-first.
+	if got := len(result.GetCompanionContainers()); got != 3 {
+		t.Fatalf("companion_containers: expected 3, got %d", got)
+	}
+	cc := result.GetCompanionContainers()
+	if cc[0].GetName() != "base-cc" || cc[1].GetName() != "ovr-cc1" || cc[2].GetName() != "ovr-cc2" {
+		t.Fatalf("companion_containers ordering wrong: %v", cc)
+	}
+
+	// ports: 1 base + 1 override = 2, base-first.
+	if got := len(result.GetPorts()); got != 2 {
+		t.Fatalf("ports: expected 2, got %d", got)
+	}
+	if result.GetPorts()[0].GetHostPort() != 8000 || result.GetPorts()[1].GetHostPort() != 9000 {
+		t.Fatalf("ports ordering wrong: %v", result.GetPorts())
+	}
+}
+
+// TestMergeCreateSpecs_CommandReplace covers AT-MZ5V: command stays replace
+// (single-command semantics, append has no executable meaning).
+func TestMergeCreateSpecs_CommandReplace(t *testing.T) {
+	base := &agboxv1.CreateSpec{Command: []string{"base", "serve"}}
+	override := &agboxv1.CreateSpec{Command: []string{"override"}}
+	result := mergeCreateSpecs(base, override)
+	if got := result.GetCommand(); !reflect.DeepEqual(got, []string{"override"}) {
+		t.Fatalf("expected override command to replace base, got %v", got)
+	}
+
+	// Empty override preserves base command.
+	result = mergeCreateSpecs(base, &agboxv1.CreateSpec{})
+	if got := result.GetCommand(); !reflect.DeepEqual(got, []string{"base", "serve"}) {
+		t.Fatalf("expected base command preserved with empty override, got %v", got)
+	}
+}
+
+// TestMergeCreateSpecs_MapKeyMerge covers AT-MZ5V: labels and envs merge by
+// key — base-only keys preserved, same key in override wins, override-only
+// keys appended.
+func TestMergeCreateSpecs_MapKeyMerge(t *testing.T) {
+	base := &agboxv1.CreateSpec{
+		Labels: map[string]string{"a": "1", "b": "2"},
+		Envs:   map[string]string{"a": "1", "b": "2"},
+	}
+	override := &agboxv1.CreateSpec{
+		Labels: map[string]string{"b": "3", "c": "4"},
+		Envs:   map[string]string{"b": "3", "c": "4"},
+	}
+	result := mergeCreateSpecs(base, override)
+
+	wantMap := map[string]string{"a": "1", "b": "3", "c": "4"}
+	if got := result.GetLabels(); !reflect.DeepEqual(got, wantMap) {
+		t.Fatalf("labels merge wrong: got %v want %v", got, wantMap)
+	}
+	if got := result.GetEnvs(); !reflect.DeepEqual(got, wantMap) {
+		t.Fatalf("envs merge wrong: got %v want %v", got, wantMap)
+	}
+}
+
+// TestMergeCreateSpecs_BuiltinToolsDedup covers AT-OJB2: builtin_tools is
+// deduped after append, preserving first-occurrence order, so that declaring
+// the same tool in both base and override is accepted (does not trigger the
+// downstream duplicate check in validateCreateSpec).
+func TestMergeCreateSpecs_BuiltinToolsDedup(t *testing.T) {
+	base := &agboxv1.CreateSpec{BuiltinTools: []string{"claude", "git"}}
+	override := &agboxv1.CreateSpec{BuiltinTools: []string{"git", "uv"}}
+	result := mergeCreateSpecs(base, override)
+	want := []string{"claude", "git", "uv"}
+	if got := result.GetBuiltinTools(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v after dedupe, got %v", want, got)
+	}
+}
+
+// openclawPresetCreateSpec mirrors cmd/agbox/openclaw.go's openclawConfigYaml
+// at the YAMLConfig level. The CLI package is not importable from here, so
+// the fixture is hand-coded to match the openclaw preset structure exactly:
+// 1 mount (~/.openclaw → ~/.openclaw, writable) and 1 port (18789/tcp).
+// If the openclaw preset YAML changes, this fixture must be updated to match.
+func openclawPresetCreateSpec(t *testing.T) *agboxv1.CreateSpec {
+	t.Helper()
+	cfg := &YAMLConfig{
+		Image: "ghcr.io/agents-sandbox/openclaw-runtime:latest",
+		Mounts: []YAMLMountSpec{
+			{Source: "/tmp/openclaw-fixture", Target: "/home/agbox/.openclaw", Writable: true},
+		},
+		Ports: []YAMLPortMapping{
+			{HostPort: 18789, ContainerPort: 18789},
+		},
+		Envs: map[string]string{
+			"OPENCLAW_STATE_DIR":   "/home/agbox/.openclaw",
+			"OPENCLAW_CONFIG_PATH": "/home/agbox/.openclaw/config/openclaw.json",
+		},
+		Command: &[]string{"openclaw", "gateway", "run", "--port", "18789", "--bind", "lan"},
+	}
+	spec, err := yamlConfigToCreateSpec(cfg)
+	if err != nil {
+		t.Fatalf("build openclaw preset spec: %v", err)
+	}
+	return spec
+}
+
+// TestMergeCreateSpecs_OpenClawPresetAppend covers AT-BLIH: the openclaw
+// preset (1 mount + 1 port) plus a user override (1 mount with different
+// target + 1 port with different host_port,protocol) must merge to 2 mounts
+// and 2 ports, with openclaw's preset entries still present.
+func TestMergeCreateSpecs_OpenClawPresetAppend(t *testing.T) {
+	base := openclawPresetCreateSpec(t)
+	override := &agboxv1.CreateSpec{
+		Mounts: []*agboxv1.MountSpec{
+			{Source: "/host/extra", Target: "/container/extra"},
+		},
+		Ports: []*agboxv1.PortMapping{
+			{ContainerPort: 18789, HostPort: 9999, Protocol: agboxv1.PortProtocol_PORT_PROTOCOL_UDP},
+		},
+	}
+
+	result := mergeCreateSpecs(base, override)
+
+	if got := len(result.GetMounts()); got != 2 {
+		t.Fatalf("expected 2 mounts after append, got %d", got)
+	}
+	foundOpenclaw := false
+	for _, m := range result.GetMounts() {
+		if m.GetTarget() == "/home/agbox/.openclaw" {
+			foundOpenclaw = true
+		}
+	}
+	if !foundOpenclaw {
+		t.Fatalf("openclaw preset mount lost after append: %v", result.GetMounts())
+	}
+
+	if got := len(result.GetPorts()); got != 2 {
+		t.Fatalf("expected 2 ports after append, got %d", got)
+	}
+	foundPreset := false
+	for _, p := range result.GetPorts() {
+		if p.GetHostPort() == 18789 && p.GetProtocol() == agboxv1.PortProtocol_PORT_PROTOCOL_TCP {
+			foundPreset = true
+		}
+	}
+	if !foundPreset {
+		t.Fatalf("openclaw preset port (18789/tcp) lost after append: %v", result.GetPorts())
+	}
+}

--- a/internal/control/service_clone.go
+++ b/internal/control/service_clone.go
@@ -103,6 +103,8 @@ func cloneCompanionContainerSpecs(items []*agboxv1.CompanionContainerSpec) []*ag
 			Healthcheck:        cloneHealthcheck(item.GetHealthcheck()),
 			PostStartOnPrimary: slices.Clone(item.GetPostStartOnPrimary()),
 			Command:            slices.Clone(item.GetCommand()),
+			CpuLimit:           item.GetCpuLimit(),
+			MemoryLimit:        item.GetMemoryLimit(),
 			DiskLimit:          item.GetDiskLimit(),
 		})
 	}

--- a/internal/control/service_clone_test.go
+++ b/internal/control/service_clone_test.go
@@ -1,0 +1,36 @@
+package control
+
+import (
+	"testing"
+
+	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
+)
+
+// TestCloneCompanionContainerSpecsPreservesResourceLimits guards against a
+// regression where cloneCompanionContainerSpecs silently dropped CpuLimit
+// and MemoryLimit, so any code path going through this clone (e.g. merging
+// companion_containers) lost these fields before reaching the runtime.
+func TestCloneCompanionContainerSpecsPreservesResourceLimits(t *testing.T) {
+	src := []*agboxv1.CompanionContainerSpec{
+		{
+			Name:        "redis",
+			Image:       "redis:7",
+			CpuLimit:    "0.5",
+			MemoryLimit: "256m",
+			DiskLimit:   "1g",
+		},
+	}
+	cloned := cloneCompanionContainerSpecs(src)
+	if len(cloned) != 1 {
+		t.Fatalf("expected 1 clone, got %d", len(cloned))
+	}
+	if got, want := cloned[0].GetCpuLimit(), "0.5"; got != want {
+		t.Fatalf("CpuLimit: got %q want %q", got, want)
+	}
+	if got, want := cloned[0].GetMemoryLimit(), "256m"; got != want {
+		t.Fatalf("MemoryLimit: got %q want %q", got, want)
+	}
+	if got, want := cloned[0].GetDiskLimit(), "1g"; got != want {
+		t.Fatalf("DiskLimit: got %q want %q", got, want)
+	}
+}

--- a/internal/control/service_validation_test.go
+++ b/internal/control/service_validation_test.go
@@ -4,7 +4,10 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	agboxv1 "github.com/1996fanrui/agents-sandbox/api/generated/agboxv1"
 )
 
 func TestValidateGenericSourcePath_AcceptsUnixSocket(t *testing.T) {
@@ -64,5 +67,119 @@ func TestValidateGenericSourcePath_RejectsSymlink(t *testing.T) {
 	err := validateGenericSourcePath("mount", link)
 	if err == nil {
 		t.Error("expected error for symlink, got nil")
+	}
+}
+
+// validationConflictSource creates two real paths inside t.TempDir so each
+// CreateSpec entry passes validateGenericSourcePath. Returns paths suitable
+// for use as MountSpec / CopySpec source fields.
+func validationConflictSource(t *testing.T, basename string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, basename)
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", p, err)
+	}
+	return p
+}
+
+// TestValidateCreateSpec_MountTargetConflict covers AT-7JER: two mounts with
+// the same target are rejected and the error mentions the conflicting target.
+func TestValidateCreateSpec_MountTargetConflict(t *testing.T) {
+	src1 := validationConflictSource(t, "src1")
+	src2 := validationConflictSource(t, "src2")
+	spec := &agboxv1.CreateSpec{
+		Mounts: []*agboxv1.MountSpec{
+			{Source: src1, Target: "/data"},
+			{Source: src2, Target: "/data"},
+		},
+	}
+	err := validateCreateSpec(spec)
+	if err == nil {
+		t.Fatal("expected mount target conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "/data") {
+		t.Fatalf("error must include conflicting target /data, got %q", err.Error())
+	}
+}
+
+// TestValidateCreateSpec_MountCopyTargetConflict covers AT-7JER: a mount and
+// a copy sharing a target are rejected (mounts and copies share the same
+// target namespace).
+func TestValidateCreateSpec_MountCopyTargetConflict(t *testing.T) {
+	mountSrc := validationConflictSource(t, "msrc")
+	copySrc := validationConflictSource(t, "csrc")
+	spec := &agboxv1.CreateSpec{
+		Mounts: []*agboxv1.MountSpec{
+			{Source: mountSrc, Target: "/x"},
+		},
+		Copies: []*agboxv1.CopySpec{
+			{Source: copySrc, Target: "/x"},
+		},
+	}
+	err := validateCreateSpec(spec)
+	if err == nil {
+		t.Fatal("expected mount/copy target conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "/x") {
+		t.Fatalf("error must include conflicting target /x, got %q", err.Error())
+	}
+}
+
+// TestValidateCreateSpec_CopyTargetConflict covers AT-7JER: two copies with
+// the same target are rejected.
+func TestValidateCreateSpec_CopyTargetConflict(t *testing.T) {
+	src1 := validationConflictSource(t, "csrc1")
+	src2 := validationConflictSource(t, "csrc2")
+	spec := &agboxv1.CreateSpec{
+		Copies: []*agboxv1.CopySpec{
+			{Source: src1, Target: "/x"},
+			{Source: src2, Target: "/x"},
+		},
+	}
+	err := validateCreateSpec(spec)
+	if err == nil {
+		t.Fatal("expected copy target conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "/x") {
+		t.Fatalf("error must include conflicting target /x, got %q", err.Error())
+	}
+}
+
+// TestValidateCreateSpec_PortHostProtocolConflict covers AT-7JER: two port
+// mappings sharing (host_port, protocol) are rejected and the error mentions
+// the conflicting host_port literal.
+func TestValidateCreateSpec_PortHostProtocolConflict(t *testing.T) {
+	spec := &agboxv1.CreateSpec{
+		Ports: []*agboxv1.PortMapping{
+			{ContainerPort: 8080, HostPort: 8080, Protocol: agboxv1.PortProtocol_PORT_PROTOCOL_TCP},
+			{ContainerPort: 9090, HostPort: 8080, Protocol: agboxv1.PortProtocol_PORT_PROTOCOL_TCP},
+		},
+	}
+	err := validateCreateSpec(spec)
+	if err == nil {
+		t.Fatal("expected duplicate host_port/protocol error, got nil")
+	}
+	if !strings.Contains(err.Error(), "8080") {
+		t.Fatalf("error must include conflicting host_port 8080, got %q", err.Error())
+	}
+}
+
+// TestValidateCreateSpec_CompanionNameConflict covers AT-7JER: two companion
+// containers sharing a name are rejected and the error mentions the
+// conflicting name literal.
+func TestValidateCreateSpec_CompanionNameConflict(t *testing.T) {
+	spec := &agboxv1.CreateSpec{
+		CompanionContainers: []*agboxv1.CompanionContainerSpec{
+			{Name: "redis", Image: "redis:7"},
+			{Name: "redis", Image: "redis:7-alpine"},
+		},
+	}
+	err := validateCreateSpec(spec)
+	if err == nil {
+		t.Fatal("expected duplicate companion name error, got nil")
+	}
+	if !strings.Contains(err.Error(), "redis") {
+		t.Fatalf("error must include conflicting companion name redis, got %q", err.Error())
 	}
 }

--- a/internal/control/yaml_config.go
+++ b/internal/control/yaml_config.go
@@ -294,8 +294,19 @@ func parsePortProtocol(raw string) (agboxv1.PortProtocol, error) {
 }
 
 // mergeCreateSpecs merges two CreateSpecs: base provides defaults, override
-// takes precedence. Scalar strings overwrite when non-empty; repeated fields
-// replace entirely when non-nil (len > 0); map fields merge at key level.
+// takes precedence. Field-type-driven semantics:
+//   - scalar strings: override non-empty overwrites base
+//   - repeated structured fields (mounts / copies / builtin_tools /
+//     companion_containers / ports): base + override append, base first
+//   - command (repeated string with single-command semantics): override
+//     non-empty replaces base entirely; append has no executable meaning
+//   - map fields (labels / envs): key-level merge, override key overwrites
+//   - well-known scalar idle_ttl: non-nil override replaces base
+//
+// builtin_tools is deduped after append (preserving first-occurrence order)
+// because validateCreateSpec rejects duplicates; deduping here means that
+// declaring the same tool in both base and override is accepted, while still
+// letting validateCreateSpec catch genuine duplicates inside a single source.
 func mergeCreateSpecs(base, override *agboxv1.CreateSpec) *agboxv1.CreateSpec {
 	if base == nil && override == nil {
 		return &agboxv1.CreateSpec{}
@@ -323,24 +334,19 @@ func mergeCreateSpecs(base, override *agboxv1.CreateSpec) *agboxv1.CreateSpec {
 		result.DiskLimit = override.GetDiskLimit()
 	}
 
-	// Repeated: override non-nil (len > 0) replaces entirely.
-	if len(override.GetMounts()) > 0 {
-		result.Mounts = cloneMounts(override.GetMounts())
-	}
-	if len(override.GetCopies()) > 0 {
-		result.Copies = cloneCopies(override.GetCopies())
-	}
-	if len(override.GetBuiltinTools()) > 0 {
-		result.BuiltinTools = append([]string(nil), override.GetBuiltinTools()...)
-	}
-	if len(override.GetCompanionContainers()) > 0 {
-		result.CompanionContainers = cloneCompanionContainerSpecs(override.GetCompanionContainers())
-	}
-	if len(override.GetPorts()) > 0 {
-		result.Ports = clonePortMappings(override.GetPorts())
-	}
-	// command: len > 0 override replaces base entirely. Companion container
-	// commands ride along with the whole-spec replacement above.
+	// Repeated structured fields: base + override append (base first).
+	// Duplicate / conflict detection is delegated to validateCreateSpec.
+	result.Mounts = append(result.Mounts, cloneMounts(override.GetMounts())...)
+	result.Copies = append(result.Copies, cloneCopies(override.GetCopies())...)
+	result.CompanionContainers = append(result.CompanionContainers, cloneCompanionContainerSpecs(override.GetCompanionContainers())...)
+	result.Ports = append(result.Ports, clonePortMappings(override.GetPorts())...)
+
+	// builtin_tools: append then dedupe, preserving first-occurrence order.
+	// Dedup must run before validateCreateSpec so that declaring the same
+	// tool in base and override is not flagged as a duplicate.
+	result.BuiltinTools = dedupeStrings(append(result.BuiltinTools, override.GetBuiltinTools()...))
+
+	// command: single-command semantics; override non-empty replaces base.
 	if len(override.GetCommand()) > 0 {
 		result.Command = append([]string(nil), override.GetCommand()...)
 	}
@@ -370,5 +376,24 @@ func mergeCreateSpecs(base, override *agboxv1.CreateSpec) *agboxv1.CreateSpec {
 		result.IdleTtl = durationpb.New(override.GetIdleTtl().AsDuration())
 	}
 
+	return result
+}
+
+// dedupeStrings returns a slice with duplicate strings removed, preserving
+// the order of first occurrence. Returns nil for empty input to keep the
+// proto field unset rather than an explicit empty slice.
+func dedupeStrings(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(items))
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if _, exists := seen[item]; exists {
+			continue
+		}
+		seen[item] = struct{}{}
+		result = append(result, item)
+	}
 	return result
 }

--- a/internal/control/yaml_config_test.go
+++ b/internal/control/yaml_config_test.go
@@ -427,7 +427,7 @@ func TestMergeCreateSpecs(t *testing.T) {
 			},
 		},
 		{
-			name: "repeated_override",
+			name: "repeated_append_base_first",
 			base: &agboxv1.CreateSpec{
 				Mounts: []*agboxv1.MountSpec{{Source: "/base", Target: "/base"}},
 			},
@@ -435,8 +435,11 @@ func TestMergeCreateSpecs(t *testing.T) {
 				Mounts: []*agboxv1.MountSpec{{Source: "/override", Target: "/override"}},
 			},
 			check: func(t *testing.T, result *agboxv1.CreateSpec) {
-				if len(result.GetMounts()) != 1 || result.GetMounts()[0].GetSource() != "/override" {
-					t.Fatalf("expected override mounts, got %v", result.GetMounts())
+				if len(result.GetMounts()) != 2 {
+					t.Fatalf("expected 2 mounts after append, got %v", result.GetMounts())
+				}
+				if result.GetMounts()[0].GetSource() != "/base" || result.GetMounts()[1].GetSource() != "/override" {
+					t.Fatalf("expected base then override, got %v", result.GetMounts())
 				}
 			},
 		},
@@ -559,7 +562,7 @@ func TestMergeCreateSpecs(t *testing.T) {
 			},
 		},
 		{
-			name: "ports_override",
+			name: "ports_append",
 			base: &agboxv1.CreateSpec{
 				Ports: []*agboxv1.PortMapping{
 					{ContainerPort: 8080, HostPort: 8080, Protocol: agboxv1.PortProtocol_PORT_PROTOCOL_TCP},
@@ -572,11 +575,14 @@ func TestMergeCreateSpecs(t *testing.T) {
 				},
 			},
 			check: func(t *testing.T, result *agboxv1.CreateSpec) {
-				if len(result.GetPorts()) != 2 {
-					t.Fatalf("expected 2 ports, got %d", len(result.GetPorts()))
+				if len(result.GetPorts()) != 3 {
+					t.Fatalf("expected 3 ports after append, got %d", len(result.GetPorts()))
 				}
-				if result.GetPorts()[0].GetContainerPort() != 3000 {
-					t.Fatalf("expected override port 3000, got %d", result.GetPorts()[0].GetContainerPort())
+				if result.GetPorts()[0].GetContainerPort() != 8080 {
+					t.Fatalf("expected base port first, got %d", result.GetPorts()[0].GetContainerPort())
+				}
+				if result.GetPorts()[1].GetContainerPort() != 3000 || result.GetPorts()[2].GetContainerPort() != 53 {
+					t.Fatalf("expected override ports following base, got %v", result.GetPorts())
 				}
 			},
 		},


### PR DESCRIPTION
## Summary

close #207

Two-stage change exposing the remaining `CreateSpec` fields on agent subcommands (`agbox claude` / `codex` / `openclaw` / `paseo` / `agent`), and unifying daemon merge semantics so YAML preset arrays and `CreateSpec` arrays compose by `append` instead of `replace`.

### Stage 1 — daemon merge: `repeated` fields → append (commit `6e2c5fd`)

- `mergeCreateSpecs`: `mounts` / `copies` / `ports` / `companion_containers` now base+override append (base first); `builtin_tools` append+dedupe (preserves first-occurrence order); `command` keeps replace; `labels` / `envs` keep map key-merge.
- Conflict detection delegated to existing `validateCreateSpec` (mount/copy `target` namespace, `(host_port, protocol)`, companion `name`).
- Bug A — `docker_runtime_dockerapi.go`: `portBindings[natPort]` was assigned, dropping earlier entries when two `PortMapping`s share `(container_port, protocol)` but differ in `host_port`. Fixed to append.
- Bug B — `service_clone.go` `cloneCompanionContainerSpecs`: missing `CpuLimit` and `MemoryLimit`; added.
- Docs same commit: `docs/configuration_reference.md` and `docs/declarative_yaml_config.md` rewritten — RFC 7396 reference removed; per-field-type semantics described; obsolete "cannot clear a repeated field" limitation deleted.

### Stage 2 — agent CLI: `--mount` / `--port` / `--copy` / `--label` (commit `f551a1d`)

- All 4 flags repeatable; parse → append into `CreateSpec`.
- `--mount`: `host:container[:writable]`. Only `:writable` is accepted (no `:ro`/`:rw`/etc.) so the CLI string maps 1:1 onto YAML `writable: bool`.
- `--port`: `host:container[/proto]`. `host_port` is mandatory (no Docker-style omission), aligned with daemon's existing rejection of `host_port=0`. Range 1..65535. Protocols: tcp/udp/sctp.
- `--copy`: `host:container`.
- `--label`: `key=value`. Built-in labels (`created-by=agbox-cli`, `agent-type=<type>`) are written first; user labels overlay last (user wins; AgentsSandbox is unprivileged user-mode, no multi-tenant).
- Workspace `--copy` unchanged; user `--copy` appends after; daemon validates target uniqueness.
- Docs same commit: `docs/cli_reference.md` updated with the 4 new flags + capability matrix + usage examples.
- `docs/sandbox_container_lifecycle.md` reviewed — no relevant section, intentionally unchanged.

### Stage 3 — review fix (commit `81a14ca`)

- `docs/configuration_reference.md` & `docs/declarative_yaml_config.md`: clarified that `command` override-replace applies to the primary container only (companion containers are appended whole; duplicate companion `name` rejected by `validateCreateSpec`).
- `cmd/agbox/cmd_agent_flags_test.go`: removed an unused struct field.

> Pre-merge cleanup: this 3-commit history will be squashed back to the 2-stage layout (`Stage 1` + `Stage 2`) by `/organize-commit` before merge.

## Behavior preservation (REQ-AKQQ)

`TestAgentDefault_PreservesPresets` enumerates all 4 registered agent types and asserts that without any new flag the post-merge `CreateSpec` is identical to pre-change behavior — in particular openclaw still sees its preset `~/.openclaw` mount and `18789/tcp` port. The Bug A fix is what makes the openclaw port survive once a user later adds another port that shares `(container_port, protocol)`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (full suite incl. SDK Python tests via pre-commit hook)
- [x] L1 acceptance: `TestMergeCreateSpecs_*` (Append, CommandReplace, MapKeyMerge, BuiltinToolsDedup, OpenClawPresetAppend), 5 × `TestValidateCreateSpec_*Conflict`, `TestPortBindingsAppendsSharedContainerPort`, `TestCloneCompanionContainerSpecsPreservesResourceLimits`, parse + help include/exclude tests, label override + default-preserves-presets — all RUN+PASS
- [x] L2 end-to-end (manual via test agent on local daemon): `agbox paseo --mount /host:/shared` → container reads `hello-from-host`, write rejected with EROFS by default; `--mount /host:/shared:writable` → container write succeeds, host file updated
- [x] No interactive prompts / sudo during sandbox creation
