### PR TITLE
[ISSUE-209] Resolve container login shell instead of hard-coding bash

### DIFF
--- a/cmd/agbox/agent_session.go
+++ b/cmd/agbox/agent_session.go
@@ -46,6 +46,85 @@ func primaryContainerName(sandboxID string) string {
 	return "agbox-primary-" + sanitizeContainerName(sandboxID)
 }
 
+// loginShellProbeTimeout caps the wait for the entrypoint to finish creating
+// the target user. SANDBOX_READY only means "container is running" — the
+// runtime image's entrypoint may still be executing useradd/usermod/gosu.
+// During that window, `docker exec --user agbox` fails because the user
+// does not exist yet. Three seconds is generous: paseo-runtime entrypoint
+// completes well under 1 s on a warm cache.
+const loginShellProbeTimeout = 3 * time.Second
+
+// resolveContainerLoginShell asks the container what login shell the target
+// user is configured with by reading /etc/passwd. Returns the absolute path
+// (e.g. "/bin/zsh", "/bin/bash"). The probe relies only on POSIX-mandatory
+// components (sh, awk, /etc/passwd colon format).
+//
+// SANDBOX_READY only means the container is running; the runtime image's
+// entrypoint may still be creating the agbox user. We loop on a single
+// shell pipeline that (1) waits until the user exists, (2) reads its login
+// shell. The wait happens inside the container, so we do not get exec 126
+// from a missing user.
+//
+// Indirected through a package-level variable so unit tests that use fake
+// runtimes (no real container) can stub it out.
+var resolveContainerLoginShell = func(ctx context.Context, containerName, user string) (string, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, loginShellProbeTimeout)
+	defer cancel()
+
+	// Inner shell, taking $1 as the target username:
+	//   1. Spin until /etc/passwd has an entry for that user (entrypoint's
+	//      useradd may still be running).
+	//   2. Print the 7th colon-separated field (login shell) for that user.
+	probe := `u="$1"; while ! awk -F: -v u="$u" '$1==u {found=1; exit} END {exit !found}' /etc/passwd; do sleep 0.01; done; awk -F: -v u="$u" '$1==u {print $7; exit}' /etc/passwd`
+	out, err := exec.CommandContext(probeCtx,
+		"docker", "exec", containerName, "sh", "-c", probe, "_probe", user,
+	).Output()
+	if err != nil {
+		stderr := ""
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr = strings.TrimSpace(string(exitErr.Stderr))
+		}
+		if stderr != "" {
+			return "", fmt.Errorf("probe login shell in %s: %w (%s)", containerName, err, stderr)
+		}
+		return "", fmt.Errorf("probe login shell in %s: %w", containerName, err)
+	}
+	shell := strings.TrimSpace(string(out))
+	if shell == "" {
+		return "", fmt.Errorf("probe login shell in %s: user %q has no shell entry in /etc/passwd", containerName, user)
+	}
+	return shell, nil
+}
+
+// waitReadyAndPrintShellHint waits for the sandbox to enter READY, prints
+// the elapsed wait time, then prints a copy-pasteable docker exec command
+// pointing at the user's actual login shell (resolved from the container's
+// /etc/passwd, not assumed). Returns the resolved container name.
+func waitReadyAndPrintShellHint(
+	ctx context.Context,
+	client sandboxExecClient,
+	stderr io.Writer,
+	sandboxID string,
+	lastEventSeq uint64,
+	sigintCh, sigtermCh <-chan os.Signal,
+) (string, error) {
+	containerName := primaryContainerName(sandboxID)
+	_, _ = fmt.Fprintf(stderr, "Waiting for sandbox to be ready...")
+	waitStart := time.Now()
+	if err := waitForSandboxReady(ctx, client, sandboxID, lastEventSeq, sigintCh, sigtermCh); err != nil {
+		_, _ = fmt.Fprintln(stderr)
+		return "", err
+	}
+	_, _ = fmt.Fprintf(stderr, "     [%.1fs]\n", time.Since(waitStart).Seconds())
+
+	loginShell, err := resolveContainerLoginShell(ctx, containerName, "agbox")
+	if err != nil {
+		return "", err
+	}
+	_, _ = fmt.Fprintf(stderr, "  Shell: docker exec -it --user agbox %s %s\n", containerName, loginShell)
+	return containerName, nil
+}
+
 // runAgentSession implements the shared flow for top-level per-type agent
 // commands (`agbox claude`, `agbox codex`, `agbox openclaw`) and for
 // `agbox agent --command "..."`. It validates inputs, connects to the
@@ -173,16 +252,10 @@ func runInteractiveSession(
 	default:
 	}
 
-	containerName := primaryContainerName(sandboxID)
-
-	_, _ = fmt.Fprintf(stderr, "Waiting for sandbox to be ready...")
-	waitStart := time.Now()
-	if err := waitForSandboxReady(ctx, client, sandboxID, lastEventSeq, sigintCh, sigtermCh); err != nil {
-		_, _ = fmt.Fprintln(stderr)
+	containerName, err := waitReadyAndPrintShellHint(ctx, client, stderr, sandboxID, lastEventSeq, sigintCh, sigtermCh)
+	if err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(stderr, "     [%.1fs]\n", time.Since(waitStart).Seconds())
-	_, _ = fmt.Fprintf(stderr, "  Shell: docker exec -it --user agbox %s bash\n", containerName)
 	dockerArgs := append([]string{"exec", "-it", "--user", "agbox", containerName}, parsed.command...)
 	cmd := exec.Command("docker", dockerArgs...) //nolint:gosec
 	cmd.Stdin = os.Stdin
@@ -277,16 +350,10 @@ func runLongRunningSession(
 	default:
 	}
 
-	containerName := primaryContainerName(sandboxID)
-
-	_, _ = fmt.Fprintf(stderr, "Waiting for sandbox to be ready...")
-	waitStart := time.Now()
-	if err := waitForSandboxReady(ctx, client, sandboxID, lastEventSeq, sigintCh, sigtermCh); err != nil {
-		_, _ = fmt.Fprintln(stderr)
+	containerName, err := waitReadyAndPrintShellHint(ctx, client, stderr, sandboxID, lastEventSeq, sigintCh, sigtermCh)
+	if err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(stderr, "     [%.1fs]\n", time.Since(waitStart).Seconds())
-	_, _ = fmt.Fprintf(stderr, "  Shell: docker exec -it --user agbox %s bash\n", containerName)
 
 	// After READY, container is running. Set detachSuccess so deferred cleanup
 	// does not delete the sandbox. Any error beyond this point leaves the

--- a/cmd/agbox/agent_session_test.go
+++ b/cmd/agbox/agent_session_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -12,6 +13,20 @@ import (
 	"github.com/1996fanrui/agents-sandbox/sdk/go/rawclient"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
+
+// TestMain stubs out resolveContainerLoginShell for all unit tests in this
+// package. The real probe runs `docker exec` against the sandbox container,
+// which does not exist in tests that use fake runtime backends. The stub
+// returns a fixed shell so the rendered hint stays deterministic.
+func TestMain(m *testing.M) {
+	original := resolveContainerLoginShell
+	resolveContainerLoginShell = func(_ context.Context, _, _ string) (string, error) {
+		return "/bin/bash", nil
+	}
+	code := m.Run()
+	resolveContainerLoginShell = original
+	os.Exit(code)
+}
 
 // --- Mock types for unit-testing runLongRunningSession and runInteractiveSession ---
 


### PR DESCRIPTION
## Summary

- Replace the hard-coded `bash` in the "Shell: docker exec ..." hint with the user's actual login shell, resolved from `/etc/passwd` inside the container.
- Fix a deterministic race: `SANDBOX_READY` fires before `entrypoint.sh`'s `useradd` finishes, so the previous (and any naive) `docker exec --user agbox` probe would return exit 126 on every cold sandbox. The new probe runs as root and waits inside the container until the user entry appears (10 ms poll, 3 s timeout).
- Extract the duplicated wait-for-ready + print-hint block in `runInteractiveSession` and `runLongRunningSession` into a single `waitReadyAndPrintShellHint`.
- Probe dependencies are POSIX-only (`sh`, `awk`, `/etc/passwd`); no `getent`, no `$SHELL` inheritance assumption.

Close #209

## Why this matters

`paseo-runtime` ships zsh as the user's login shell — oh-my-zsh, the `ll` alias, atuin Ctrl-R history all live in `~/.zshrc`. The old hint sent users into bash, which silently dropped every interactive feature and looked like a broken sandbox.

End-user view changes from:

```
Shell: docker exec -it --user agbox agbox-primary-paseo-xxx bash
```

to:

```
Shell: docker exec -it --user agbox agbox-primary-paseo-xxx /bin/zsh
```

Concrete absolute path, copy-pasteable, no quoting hazards, no environment-inheritance assumptions.

## Test plan

- [x] `go test ./cmd/agbox/...` — all green (TestMain stubs the probe so fake-runtime unit tests still work)
- [x] `go test ./...` — all packages green
- [x] Cold sandbox start (`agbox paseo --sandbox-id paseo-poc-209retry ...`): hint emits `/bin/zsh`, no exit-126 race
- [x] Repeat with 10 ms poll: hint emits `/bin/zsh`, sandbox boot stays at ~200 ms
- [x] Probe verified across 13 containers spanning 5 base-image families (debian / ubuntu / alpine glibc / alpine musl-busybox / agbox runtime images) — all return a valid shell path

## Notes for reviewers

- The probe is exposed as a package-level `var resolveContainerLoginShell` so tests can swap it out. Production code never assigns to it; only `TestMain` does.
- 3 s timeout on the probe is intentional — entrypoint completes in <100 ms on warm hardware, so 3 s only fires on a genuinely broken image. There is no fallback shell on failure; surfacing the error is preferable to silently lying about a `/bin/sh` that may not even exist on a distroless image.
- The two call sites previously held identical 10-line blocks; collapsing them is a separate concern but cheap to bundle here since the helper signature is short and the replacement is mechanical.
