### PR TITLE
[ISSUE-211] CLI --builtin-tool appends to agent type defaults

### DIFF
--- a/cmd/agbox/cmd_agent.go
+++ b/cmd/agbox/cmd_agent.go
@@ -28,9 +28,8 @@ type agentSessionFlagVars struct {
 	copies       []string
 	labels       []string
 	// Track which flags were explicitly set by the user:
-	modeOverridden         bool
-	workspaceOverridden    bool
-	builtinToolsOverridden bool
+	modeOverridden      bool
+	workspaceOverridden bool
 }
 
 // registerAgentSessionFlags registers all agent session flags on a cobra command.
@@ -38,7 +37,7 @@ func registerAgentSessionFlags(cmd *cobra.Command, v *agentSessionFlagVars) {
 	cmd.Flags().StringVar(&v.rawCommand, "command", "", "Override the agent's default command.\n  interactive mode: replaces the TTY command launched via docker exec.\n  long-running mode: replaces the container primary command (under tini).\nValue is split by whitespace via strings.Fields (no shell quoting).")
 	cmd.Flags().StringVar(&v.mode, "mode", "", "Session mode: interactive or long-running (default depends on agent type)")
 	cmd.Flags().StringVar(&v.workspace, "workspace", "", "Directory to copy into the sandbox as workspace")
-	cmd.Flags().StringArrayVar(&v.builtinTools, "builtin-tool", nil, "Builtin tool to install (repeatable, overrides defaults)")
+	cmd.Flags().StringArrayVar(&v.builtinTools, "builtin-tool", nil, "Builtin tool to install (repeatable; appended to the agent type's defaults, deduped preserving first-occurrence order)")
 	cmd.Flags().StringArrayVar(&v.envs, "env", nil, "Environment variable in KEY=VAL form (repeatable)")
 	cmd.Flags().StringVar(&v.cpuLimit, "cpu-limit", "", "CPU limit (Docker --cpus format, e.g. 2, 0.5)")
 	cmd.Flags().StringVar(&v.memoryLimit, "memory-limit", "", "Memory limit (Docker --memory format, e.g. 4g, 512m)")
@@ -65,7 +64,6 @@ func buildAgentSessionRunE(agentType string, v *agentSessionFlagVars) func(*cobr
 	return func(cmd *cobra.Command, _ []string) error {
 		v.modeOverridden = cmd.Flags().Changed("mode")
 		v.workspaceOverridden = cmd.Flags().Changed("workspace")
-		v.builtinToolsOverridden = cmd.Flags().Changed("builtin-tool")
 		parsed, err := resolveAgentSessionArgs(v, agentType)
 		if err != nil {
 			return err
@@ -154,18 +152,19 @@ func resolveAgentSessionArgs(
 		isRegistered = true
 		parsed.agentType = agentType
 		parsed.command = typeDef.command
-		if v.builtinToolsOverridden {
-			parsed.builtinTools = v.builtinTools
-		} else {
-			parsed.builtinTools = append([]string(nil), typeDef.builtinTools...)
-		}
+		// --builtin-tool appends to the agent type's defaults; the daemon
+		// already dedupes in mergeCreateSpecs (see commit 9ceac68), but we
+		// dedupe at the CLI as well so that observable behavior (e.g. logs,
+		// echoed CreateSpec) matches what the daemon will actually act on.
+		parsed.builtinTools = dedupePreserveOrder(append(append([]string(nil), typeDef.builtinTools...), v.builtinTools...))
 	} else if v.rawCommand != "" {
 		// Custom command: split the string into argv.
 		parsed.command = strings.Fields(v.rawCommand)
 		if len(parsed.command) == 0 {
 			return agentSessionArgs{}, usageErrorf("--command must not be empty")
 		}
-		parsed.builtinTools = v.builtinTools
+		// Custom command has no defaults, but still dedupe user input for consistency.
+		parsed.builtinTools = dedupePreserveOrder(v.builtinTools)
 	} else {
 		return agentSessionArgs{}, usageErrorf("agbox agent requires --command; for pre-registered agents use agbox claude / agbox codex / agbox openclaw / agbox paseo")
 	}
@@ -421,6 +420,25 @@ func parsePortNumber(raw, role, full string) (int, error) {
 		return 0, usageErrorf("%s %q: %d is out of range (1..65535)", role, full, n)
 	}
 	return n, nil
+}
+
+// dedupePreserveOrder returns a slice with duplicates removed, preserving the
+// first-occurrence order. Empty input returns nil so the resulting CreateSpec
+// field stays nil (rather than becoming an empty non-nil slice).
+func dedupePreserveOrder(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
 }
 
 // parseCopyFlag parses a --copy value of the form "host:container" into a

--- a/cmd/agbox/cmd_agent_test.go
+++ b/cmd/agbox/cmd_agent_test.go
@@ -42,14 +42,24 @@ func TestResolveAgentSessionArgs_RegisteredType(t *testing.T) {
 	}
 }
 
-func TestResolveAgentSessionArgs_RegisteredTypeOverrideBuiltinTools(t *testing.T) {
+func TestResolveAgentSessionArgs_RegisteredTypeAppendBuiltinTools(t *testing.T) {
+	// --builtin-tool is appended to the agent type's defaults and deduped
+	// (preserving first-occurrence order). claude defaults are
+	// [claude, git, uv, npm, apt]; appending [git, foo] keeps the defaults
+	// in order, drops the duplicate "git", and appends the new "foo".
 	tmpDir := realTempDir(t)
-	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{workspace: tmpDir, workspaceOverridden: true, builtinTools: []string{"git"}, builtinToolsOverridden: true}, "claude")
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{workspace: tmpDir, workspaceOverridden: true, builtinTools: []string{"git", "foo"}}, "claude")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(parsed.builtinTools) != 1 || parsed.builtinTools[0] != "git" {
-		t.Fatalf("expected builtinTools=[git], got %v", parsed.builtinTools)
+	expected := []string{"claude", "git", "uv", "npm", "apt", "foo"}
+	if len(parsed.builtinTools) != len(expected) {
+		t.Fatalf("expected builtinTools=%v, got %v", expected, parsed.builtinTools)
+	}
+	for i, tool := range expected {
+		if parsed.builtinTools[i] != tool {
+			t.Fatalf("builtinTools[%d]: expected %q, got %q", i, tool, parsed.builtinTools[i])
+		}
 	}
 }
 
@@ -72,7 +82,7 @@ func TestResolveAgentSessionArgs_CustomCommand(t *testing.T) {
 
 func TestResolveAgentSessionArgs_CustomCommandWithBuiltinTools(t *testing.T) {
 	tmpDir := realTempDir(t)
-	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "aider", workspace: tmpDir, workspaceOverridden: true, builtinTools: []string{"git", "uv"}, builtinToolsOverridden: true}, "")
+	parsed, err := resolveAgentSessionArgs(&agentSessionFlagVars{rawCommand: "aider", workspace: tmpDir, workspaceOverridden: true, builtinTools: []string{"git", "uv"}}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -32,8 +32,8 @@ agbox codex
 # Use a specific project directory
 agbox claude --workspace /path/to/project
 
-# Override builtin tools (each sandbox image defines a default set)
-agbox codex --builtin-tool claude --builtin-tool git
+# Add extra builtin tools (appended to the agent type's defaults, deduped)
+agbox codex --builtin-tool claude --builtin-tool opencode
 ```
 
 ## OpenClaw

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -134,7 +134,7 @@ Agent types declare their own capabilities, orthogonal to session mode. Each cap
 |-----------|-------------|--------|-------|----------|-------|-------------------|-------------------|
 | mode | Default session mode | interactive | interactive | long-running | long-running | interactive | `--mode` |
 | command | Container primary command (under tini in long-running; docker exec in interactive) | Fixed | Fixed | Fixed (gateway run) | Fixed (daemon start) | User-specified | `--command` |
-| builtinTools | Pre-installed tools | Fixed | Fixed | Fixed | Fixed (filtered by preFlight) | User-specified | `--builtin-tool` |
+| builtinTools | Pre-installed tools (preset entries are kept; user entries appended and deduped, preserving first-occurrence order) | Preset `claude, git, uv, npm, apt` | Preset `codex, git, uv, npm, apt` | Preset `git, npm, uv, apt` | Preset `claude, codex, npm, uv, apt, opencode` (filtered by preFlight) | User-specified | `--builtin-tool` |
 | workspace copy | Copy local directory to /workspace | Yes (default: cwd) | Yes (default: cwd) | No | No | No | `--workspace` (explicit to enable) |
 | .git check | Confirm when workspace lacks .git | Yes | Yes | No | No | No | None (automatic) |
 | envs | Environment variables for container | None | None | None | None | None | `--env` (repeatable, `KEY=VAL` form) |
@@ -163,6 +163,7 @@ Agent types declare their own capabilities, orthogonal to session mode. Each cap
 - `--port` accepts `host:container[/proto]`. Both port numbers must be in `1..65535`; `proto` is case-insensitive and must be one of `tcp` (default), `udp`, or `sctp`. The daemon rejects duplicate `(host_port, protocol)` pairs across preset and user entries.
 - `--copy` accepts `host:container` and is appended **after** the workspace copy. The daemon rejects duplicate `target` paths between copies and mounts.
 - `--label` accepts `key=value` (repeatable). User entries are written after the built-in `created-by=agbox-cli` / `agent-type=<type>` labels, so passing `--label created-by=...` overrides the built-in value. Empty keys (`=value`) are rejected.
+- `--builtin-tool` is appended to the agent type's preset `builtinTools` (defaults are kept, not replaced) and deduped, preserving first-occurrence order. Example: `agbox paseo --builtin-tool git` yields `claude, codex, npm, uv, apt, opencode, git`. For custom `agbox agent --command`, only the user-supplied tools are used (no defaults).
 
 ### Command Surface
 


### PR DESCRIPTION
## Summary

- Switch CLI `--builtin-tool` from override to **append** semantics across all agent session commands (`agbox claude`, `agbox codex`, `agbox openclaw`, `agbox paseo`, `agbox agent --command`).
- User-supplied tools are appended to the agent type's preset `builtinTools` and deduped, preserving first-occurrence order — matching the daemon-side merge unified in #207 and aligning `--builtin-tool` with the other accumulating CLI flags (`--mount`, `--env`, `--port`, `--copy`, `--label`).
- Drop the now-unused `builtinToolsOverridden` flag tracking.
- Update `docs/cli_reference.md` capability table and add a paragraph describing the append+dedupe semantics, plus example correction in `docs/agent_guide.md`.

Before this change, `agbox paseo --builtin-tool git` left only `git` and dropped the 6 paseo defaults. Now it yields `claude, codex, npm, uv, apt, opencode, git`.

Removing a default tool from the CLI is intentionally not supported — there is no current use case. A separate flag can be added later if needed.

## Test plan

- [x] `go test ./...` — all green
- [x] `go test ./cmd/agbox/...` — covers append+dedupe via updated `TestResolveAgentSessionArgs_RegisteredTypeAppendBuiltinTools`
- [x] Python SDK tests — green
- [x] Pre-commit hooks (gofmt, proto regen, lints) — pass

Close #211
