### PR TITLE
fix: close two nftables host isolation gaps (DNAT + INPUT chain)

### DIFF
--- a/internal/control/docker_runtime_nftables_linux.go
+++ b/internal/control/docker_runtime_nftables_linux.go
@@ -29,16 +29,83 @@ func nftIfname(name string) []byte {
 // rtnLocal is the kernel RTN_LOCAL routing type value (see linux/rtnetlink.h).
 const rtnLocal = 2
 
+// ipsDstNAT is the IPS_DST_NAT bit from linux/netfilter/nf_conntrack_common.h.
+// When set in conntrack status, it indicates the packet's destination was
+// rewritten by DNAT (e.g. Docker port mapping via -p host:container).
+const ipsDstNAT = 1 << 5 // 32
+
 // buildHostIsolationExprs constructs the nftables expression list that drops
 // all traffic entering via `bridge` from `subnet` destined for any host-local
 // address. This is equivalent to:
 //
 //	iptables -I DOCKER-USER -i <bridge> -s <subnet> -m addrtype --dst-type LOCAL -j DROP
 func buildHostIsolationExprs(bridge string, subnet *net.IPNet) []expr.Any {
-	// Mask the subnet IP to its canonical network form (e.g. 172.18.0.0 for /16).
+	return buildBridgeSubnetMatchExprs(bridge, subnet, []expr.Any{
+		// Check if destination address type is LOCAL (fib lookup).
+		&expr.Fib{
+			Register:       1,
+			FlagDADDR:      true,
+			ResultADDRTYPE: true,
+		},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     binaryutil.NativeEndian.PutUint32(rtnLocal),
+		},
+		// DROP verdict.
+		&expr.Verdict{Kind: expr.VerdictDrop},
+	}...)
+}
+
+// buildDNATIsolationExprs constructs the nftables expression list that drops
+// all DNAT'd traffic entering via `bridge` from `subnet`. Docker port mappings
+// (-p host:container) rewrite the destination in PREROUTING/nat before packets
+// reach DOCKER-USER in filter/FORWARD, so the dst-type LOCAL check in
+// buildHostIsolationExprs never matches them. This rule catches that case by
+// matching conntrack status IPS_DST_NAT. Equivalent to:
+//
+//	iptables -I DOCKER-USER -i <bridge> -s <subnet> -m conntrack --ctstate DNAT -j DROP
+func buildDNATIsolationExprs(bridge string, subnet *net.IPNet) []expr.Any {
+	return buildBridgeSubnetMatchExprs(bridge, subnet, []expr.Any{
+		// Load conntrack status into register 1.
+		&expr.Ct{
+			Register: 1,
+			Key:      expr.CtKeySTATUS,
+		},
+		// Bitwise AND with IPS_DST_NAT to isolate the DNAT bit.
+		&expr.Bitwise{
+			SourceRegister: 1,
+			DestRegister:   1,
+			Len:            4,
+			Mask:           binaryutil.NativeEndian.PutUint32(ipsDstNAT),
+			Xor:            []byte{0, 0, 0, 0},
+		},
+		// If the DNAT bit is set (non-zero), this packet was DNAT'd.
+		&expr.Cmp{
+			Op:       expr.CmpOpNeq,
+			Register: 1,
+			Data:     binaryutil.NativeEndian.PutUint32(0),
+		},
+		// DROP verdict.
+		&expr.Verdict{Kind: expr.VerdictDrop},
+	}...)
+}
+
+// buildHostInputIsolationExprs constructs the nftables expression list that
+// drops packets from the sandbox subnet entering the host INPUT path via the
+// sandbox bridge. This blocks direct access to the bridge gateway address and
+// Docker userland-proxy listeners bound on host addresses.
+func buildHostInputIsolationExprs(bridge string, subnet *net.IPNet) []expr.Any {
+	return buildBridgeSubnetMatchExprs(bridge, subnet, &expr.Verdict{Kind: expr.VerdictDrop})
+}
+
+// buildBridgeSubnetMatchExprs constructs the common prefix expressions that
+// match traffic entering via `bridge` from `subnet`, followed by the provided
+// tail expressions. Both host isolation rules share this prefix.
+func buildBridgeSubnetMatchExprs(bridge string, subnet *net.IPNet, tail ...expr.Any) []expr.Any {
 	networkIP := subnet.IP.Mask(subnet.Mask)
 
-	return []expr.Any{
+	prefix := []expr.Any{
 		// Match input interface name.
 		&expr.Meta{Key: expr.MetaKeyIIFNAME, Register: 1},
 		&expr.Cmp{
@@ -67,45 +134,75 @@ func buildHostIsolationExprs(bridge string, subnet *net.IPNet) []expr.Any {
 			Register: 1,
 			Data:     []byte(networkIP.To4()),
 		},
-		// Check if destination address type is LOCAL (fib lookup).
-		&expr.Fib{
-			Register:       1,
-			FlagDADDR:      true,
-			ResultADDRTYPE: true,
-		},
-		&expr.Cmp{
-			Op:       expr.CmpOpEq,
-			Register: 1,
-			Data:     binaryutil.NativeEndian.PutUint32(rtnLocal),
-		},
-		// DROP verdict.
-		&expr.Verdict{Kind: expr.VerdictDrop},
 	}
+	return append(prefix, tail...)
 }
 
-// findDockerUserChain locates the DOCKER-USER chain in the IPv4 filter table.
-func findDockerUserChain(conn *nftables.Conn) (*nftables.Chain, *nftables.Table, error) {
+func findFilterChain(conn *nftables.Conn, name string) (*nftables.Chain, *nftables.Table, error) {
 	chains, err := conn.ListChainsOfTableFamily(nftables.TableFamilyIPv4)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list nftables chains: %w", err)
 	}
 	for _, chain := range chains {
-		if chain.Name == "DOCKER-USER" && chain.Table != nil && chain.Table.Name == "filter" {
+		if chain.Name == name && chain.Table != nil && chain.Table.Name == "filter" {
 			return chain, chain.Table, nil
 		}
 	}
-	return nil, nil, fmt.Errorf("DOCKER-USER chain not found in filter table")
+	return nil, nil, fmt.Errorf("%s chain not found in filter table", name)
+}
+
+// findDockerUserChain locates the DOCKER-USER chain in the IPv4 filter table.
+func findDockerUserChain(conn *nftables.Conn) (*nftables.Chain, *nftables.Table, error) {
+	return findFilterChain(conn, "DOCKER-USER")
+}
+
+func findInputChain(conn *nftables.Conn) (*nftables.Chain, *nftables.Table, error) {
+	return findFilterChain(conn, "INPUT")
+}
+
+// agboxInputChainName is the name of the nftables chain we create when the
+// standard INPUT chain is absent (native nftables mode, e.g. Ubuntu 24).
+const agboxInputChainName = "AGBOX-INPUT"
+
+func expectedDockerUserIsolationRules(bridge string, subnet *net.IPNet) [][]expr.Any {
+	return [][]expr.Any{
+		buildHostIsolationExprs(bridge, subnet),
+		buildDNATIsolationExprs(bridge, subnet),
+	}
+}
+
+func expectedInputIsolationRules(bridge string, subnet *net.IPNet) [][]expr.Any {
+	return [][]expr.Any{
+		buildHostInputIsolationExprs(bridge, subnet),
+	}
+}
+
+// expectedHostIsolationRules returns all nftables rules that together enforce
+// host isolation for one sandbox bridge.
+func expectedHostIsolationRules(bridge string, subnet *net.IPNet) [][]expr.Any {
+	return append(
+		expectedDockerUserIsolationRules(bridge, subnet),
+		expectedInputIsolationRules(bridge, subnet)...,
+	)
 }
 
 // matchesHostIsolationRule checks whether an existing nftables rule matches
-// the host isolation expressions for the given bridge and subnet.
+// any host isolation rule (host-local or DNAT) for the given bridge and subnet.
 func matchesHostIsolationRule(rule *nftables.Rule, bridge string, subnet *net.IPNet) bool {
-	expected := buildHostIsolationExprs(bridge, subnet)
+	for _, expected := range expectedHostIsolationRules(bridge, subnet) {
+		if matchesIsolationRule(rule, expected) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesIsolationRule checks whether a rule matches the expression shape used
+// by one expected isolation rule for a specific bridge/subnet pair.
+func matchesIsolationRule(rule *nftables.Rule, expected []expr.Any) bool {
 	if len(rule.Exprs) != len(expected) {
 		return false
 	}
-	// Compare interface name bytes (expression index 1) and subnet bytes (expression index 4).
-	// These two fields uniquely identify an isolation rule for a specific bridge/subnet pair.
 	if len(rule.Exprs) < 5 {
 		return false
 	}
@@ -113,17 +210,87 @@ func matchesHostIsolationRule(rule *nftables.Rule, bridge string, subnet *net.IP
 	if !ok {
 		return false
 	}
-	expectedIface := nftIfname(bridge)
-	if !bytes.Equal(cmpIface.Data, expectedIface) {
+	expectedIface, ok := expected[1].(*expr.Cmp)
+	if !ok {
+		return false
+	}
+	if !bytes.Equal(cmpIface.Data, expectedIface.Data) {
 		return false
 	}
 	cmpSubnet, ok := rule.Exprs[4].(*expr.Cmp)
 	if !ok {
 		return false
 	}
-	networkIP := subnet.IP.Mask(subnet.Mask)
-	if !bytes.Equal(cmpSubnet.Data, []byte(networkIP.To4())) {
+	expectedSubnet, ok := expected[4].(*expr.Cmp)
+	if !ok {
 		return false
+	}
+	if !bytes.Equal(cmpSubnet.Data, expectedSubnet.Data) {
+		return false
+	}
+	return matchesIsolationTail(rule.Exprs[5:], expected[5:])
+}
+
+func matchesIsolationTail(actual []expr.Any, expected []expr.Any) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for i := range expected {
+		switch expectedExpr := expected[i].(type) {
+		case *expr.Fib:
+			actualExpr, ok := actual[i].(*expr.Fib)
+			if !ok {
+				return false
+			}
+			if actualExpr.Register != expectedExpr.Register ||
+				actualExpr.FlagDADDR != expectedExpr.FlagDADDR ||
+				actualExpr.ResultADDRTYPE != expectedExpr.ResultADDRTYPE {
+				return false
+			}
+		case *expr.Ct:
+			actualExpr, ok := actual[i].(*expr.Ct)
+			if !ok {
+				return false
+			}
+			if actualExpr.Register != expectedExpr.Register ||
+				actualExpr.Key != expectedExpr.Key ||
+				actualExpr.SourceRegister != expectedExpr.SourceRegister ||
+				actualExpr.Direction != expectedExpr.Direction {
+				return false
+			}
+		case *expr.Bitwise:
+			actualExpr, ok := actual[i].(*expr.Bitwise)
+			if !ok {
+				return false
+			}
+			if actualExpr.SourceRegister != expectedExpr.SourceRegister ||
+				actualExpr.DestRegister != expectedExpr.DestRegister ||
+				actualExpr.Len != expectedExpr.Len ||
+				!bytes.Equal(actualExpr.Mask, expectedExpr.Mask) ||
+				!bytes.Equal(actualExpr.Xor, expectedExpr.Xor) {
+				return false
+			}
+		case *expr.Cmp:
+			actualExpr, ok := actual[i].(*expr.Cmp)
+			if !ok {
+				return false
+			}
+			if actualExpr.Op != expectedExpr.Op ||
+				actualExpr.Register != expectedExpr.Register ||
+				!bytes.Equal(actualExpr.Data, expectedExpr.Data) {
+				return false
+			}
+		case *expr.Verdict:
+			actualExpr, ok := actual[i].(*expr.Verdict)
+			if !ok {
+				return false
+			}
+			if actualExpr.Kind != expectedExpr.Kind {
+				return false
+			}
+		default:
+			return false
+		}
 	}
 	return true
 }
@@ -133,40 +300,120 @@ func (r *realNftablesConnector) applyHostIsolation(bridge string, subnet *net.IP
 	if err != nil {
 		return fmt.Errorf("open nftables connection: %w", err)
 	}
-	chain, table, err := findDockerUserChain(conn)
+	dockerUserChain, dockerUserTable, err := findDockerUserChain(conn)
 	if err != nil {
 		return err
 	}
 
-	// Check if the rule already exists (idempotency).
-	rules, err := conn.GetRules(table, chain)
+	inserted := 0
+
+	n, err := insertMissingIsolationRules(conn, dockerUserTable, dockerUserChain, expectedDockerUserIsolationRules(bridge, subnet))
 	if err != nil {
-		return fmt.Errorf("get nftables rules: %w", err)
+		return err
 	}
-	for _, rule := range rules {
-		if matchesHostIsolationRule(rule, bridge, subnet) {
-			r.logger.Info("nftables host isolation rule already exists",
-				slog.String("bridge", bridge),
-				slog.String("subnet", subnet.String()),
-			)
-			return nil
-		}
+	inserted += n
+
+	// Add INPUT isolation rules. On native nftables (Ubuntu 24+) the standard
+	// INPUT chain is absent; in that case we create our own AGBOX-INPUT chain
+	// with an input hook so docker-proxy traffic is blocked just as reliably.
+	inputN, err := r.applyInputIsolation(conn, dockerUserTable, bridge, subnet)
+	if err != nil {
+		return err
+	}
+	inserted += inputN
+
+	if inserted == 0 {
+		r.logger.Info("nftables host isolation rules already exist",
+			slog.String("bridge", bridge),
+			slog.String("subnet", subnet.String()),
+		)
+		return nil
 	}
 
-	// Insert rule at the top of the chain.
-	conn.InsertRule(&nftables.Rule{
-		Table: table,
-		Chain: chain,
-		Exprs: buildHostIsolationExprs(bridge, subnet),
-	})
 	if err := conn.Flush(); err != nil {
-		return fmt.Errorf("flush nftables rule for bridge %s: %w", bridge, err)
+		return fmt.Errorf("flush nftables rules for bridge %s: %w", bridge, err)
 	}
-	r.logger.Info("applied nftables host isolation rule",
+	r.logger.Info("applied nftables host isolation rules",
 		slog.String("bridge", bridge),
 		slog.String("subnet", subnet.String()),
+		slog.Int("inserted_rules", inserted),
 	)
 	return nil
+}
+
+// applyInputIsolation adds INPUT-path isolation rules for bridge/subnet.
+// It uses the existing INPUT chain when present; otherwise it finds or creates
+// the AGBOX-INPUT chain (hooked at input priority 0) inside the same filter
+// table used by Docker, so docker-proxy traffic is always blocked.
+func (r *realNftablesConnector) applyInputIsolation(
+	conn *nftables.Conn,
+	filterTable *nftables.Table,
+	bridge string,
+	subnet *net.IPNet,
+) (int, error) {
+	inputChain, inputTable, err := findInputChain(conn)
+	if err == nil {
+		return insertMissingIsolationRules(conn, inputTable, inputChain, expectedInputIsolationRules(bridge, subnet))
+	}
+
+	// Standard INPUT chain absent (native nftables mode). Find or create AGBOX-INPUT.
+	agboxChain, agboxTable, err := findFilterChain(conn, agboxInputChainName)
+	if err == nil {
+		return insertMissingIsolationRules(conn, agboxTable, agboxChain, expectedInputIsolationRules(bridge, subnet))
+	}
+
+	// AGBOX-INPUT doesn't exist yet. Create it and add rules in the same
+	// transaction; no GetRules needed since the chain is brand new.
+	newChain := conn.AddChain(&nftables.Chain{
+		Name:     agboxInputChainName,
+		Table:    filterTable,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookInput,
+		Priority: nftables.ChainPriorityFilter,
+	})
+	expected := expectedInputIsolationRules(bridge, subnet)
+	for _, exprs := range expected {
+		conn.InsertRule(&nftables.Rule{
+			Table: filterTable,
+			Chain: newChain,
+			Exprs: exprs,
+		})
+	}
+	return len(expected), nil
+}
+
+func insertMissingIsolationRules(
+	conn *nftables.Conn,
+	table *nftables.Table,
+	chain *nftables.Chain,
+	expectedRules [][]expr.Any,
+) (int, error) {
+	rules, err := conn.GetRules(table, chain)
+	if err != nil {
+		return 0, fmt.Errorf("get nftables rules from %s: %w", chain.Name, err)
+	}
+
+	inserted := 0
+	for _, expected := range expectedRules {
+		exists := false
+		for _, rule := range rules {
+			if matchesIsolationRule(rule, expected) {
+				exists = true
+				break
+			}
+		}
+		if exists {
+			continue
+		}
+
+		conn.InsertRule(&nftables.Rule{
+			Table: table,
+			Chain: chain,
+			Exprs: expected,
+		})
+		inserted++
+	}
+	return inserted, nil
 }
 
 func (r *realNftablesConnector) removeHostIsolation(bridge string, subnet *net.IPNet) {
@@ -178,50 +425,90 @@ func (r *realNftablesConnector) removeHostIsolation(bridge string, subnet *net.I
 		)
 		return
 	}
-	chain, table, err := findDockerUserChain(conn)
-	if err != nil {
+	removed := 0
+	dockerUserChain, dockerUserTable, err := findDockerUserChain(conn)
+	if err == nil {
+		n, err := removeIsolationRulesFromChain(conn, dockerUserTable, dockerUserChain, expectedDockerUserIsolationRules(bridge, subnet))
+		if err != nil {
+			r.logger.Warn("failed to delete nftables host isolation rule",
+				slog.String("bridge", bridge),
+				slog.Any("error", err),
+			)
+			return
+		}
+		removed += n
+	} else {
 		r.logger.Warn("failed to find DOCKER-USER chain for cleanup",
 			slog.String("bridge", bridge),
 			slog.Any("error", err),
 		)
+	}
+
+	// Try both INPUT and AGBOX-INPUT chains; rules live in whichever existed
+	// when the sandbox was created.
+	for _, chainName := range []string{"INPUT", agboxInputChainName} {
+		chain, table, lookupErr := findFilterChain(conn, chainName)
+		if lookupErr != nil {
+			continue
+		}
+		n, removeErr := removeIsolationRulesFromChain(conn, table, chain, expectedInputIsolationRules(bridge, subnet))
+		if removeErr != nil {
+			r.logger.Warn("failed to delete nftables host input isolation rule",
+				slog.String("bridge", bridge),
+				slog.String("chain", chainName),
+				slog.Any("error", removeErr),
+			)
+			return
+		}
+		removed += n
+	}
+
+	if removed == 0 {
+		r.logger.Info("no matching nftables host isolation rules to remove",
+			slog.String("bridge", bridge),
+		)
 		return
 	}
 
-	rules, err := conn.GetRules(table, chain)
-	if err != nil {
-		r.logger.Warn("failed to get nftables rules for cleanup",
+	if err := conn.Flush(); err != nil {
+		r.logger.Warn("failed to flush nftables rule deletion",
 			slog.String("bridge", bridge),
 			slog.Any("error", err),
 		)
 		return
 	}
+	r.logger.Info("removed nftables host isolation rules",
+		slog.String("bridge", bridge),
+		slog.String("subnet", subnet.String()),
+		slog.Int("removed_rules", removed),
+	)
+}
 
+func removeIsolationRulesFromChain(
+	conn *nftables.Conn,
+	table *nftables.Table,
+	chain *nftables.Chain,
+	expectedRules [][]expr.Any,
+) (int, error) {
+	rules, err := conn.GetRules(table, chain)
+	if err != nil {
+		return 0, fmt.Errorf("get nftables rules from %s: %w", chain.Name, err)
+	}
+
+	removed := 0
 	for _, rule := range rules {
-		if matchesHostIsolationRule(rule, bridge, subnet) {
+		for _, expected := range expectedRules {
+			if !matchesIsolationRule(rule, expected) {
+				continue
+			}
 			if err := conn.DelRule(rule); err != nil {
-				r.logger.Warn("failed to delete nftables host isolation rule",
-					slog.String("bridge", bridge),
-					slog.Any("error", err),
-				)
-				return
+				return removed, err
 			}
-			if err := conn.Flush(); err != nil {
-				r.logger.Warn("failed to flush nftables rule deletion",
-					slog.String("bridge", bridge),
-					slog.Any("error", err),
-				)
-				return
-			}
-			r.logger.Info("removed nftables host isolation rule",
-				slog.String("bridge", bridge),
-				slog.String("subnet", subnet.String()),
-			)
-			return
+			removed++
+			break
 		}
 	}
-	r.logger.Info("no matching nftables host isolation rule to remove",
-		slog.String("bridge", bridge),
-	)
+	return removed, nil
 }
 
 // newNftablesConnector creates a real nftables connector for Linux.

--- a/internal/control/docker_runtime_nftables_linux_test.go
+++ b/internal/control/docker_runtime_nftables_linux_test.go
@@ -80,35 +80,134 @@ func TestBuildHostIsolationExprs(t *testing.T) {
 	}
 }
 
+func TestBuildDNATIsolationExprs(t *testing.T) {
+	_, subnet, err := net.ParseCIDR("172.18.0.0/16")
+	if err != nil {
+		t.Fatalf("ParseCIDR failed: %v", err)
+	}
+	exprs := buildDNATIsolationExprs("br-abc123def456", subnet)
+
+	// Expected structure: common bridge/subnet prefix, Ct, Bitwise, Cmp, Verdict.
+	if len(exprs) != 9 {
+		t.Fatalf("expected 9 expressions, got %d", len(exprs))
+	}
+
+	ct, ok := exprs[5].(*expr.Ct)
+	if !ok {
+		t.Fatalf("exprs[5]: expected Ct, got %T", exprs[5])
+	}
+	if ct.Key != expr.CtKeySTATUS || ct.Register != 1 {
+		t.Fatalf("unexpected Ct expression: key=%v register=%d", ct.Key, ct.Register)
+	}
+
+	bitwise, ok := exprs[6].(*expr.Bitwise)
+	if !ok {
+		t.Fatalf("exprs[6]: expected Bitwise, got %T", exprs[6])
+	}
+	expectedDNATMask := binaryutil.NativeEndian.PutUint32(ipsDstNAT)
+	if !bytes.Equal(bitwise.Mask, expectedDNATMask) {
+		t.Fatalf("DNAT mask mismatch: got %v, want %v", bitwise.Mask, expectedDNATMask)
+	}
+
+	cmpDNAT, ok := exprs[7].(*expr.Cmp)
+	if !ok {
+		t.Fatalf("exprs[7]: expected Cmp, got %T", exprs[7])
+	}
+	if cmpDNAT.Op != expr.CmpOpNeq || !bytes.Equal(cmpDNAT.Data, binaryutil.NativeEndian.PutUint32(0)) {
+		t.Fatalf("unexpected DNAT comparison: op=%v data=%v", cmpDNAT.Op, cmpDNAT.Data)
+	}
+
+	verdict, ok := exprs[8].(*expr.Verdict)
+	if !ok {
+		t.Fatalf("exprs[8]: expected Verdict, got %T", exprs[8])
+	}
+	if verdict.Kind != expr.VerdictDrop {
+		t.Fatalf("expected VerdictDrop, got %v", verdict.Kind)
+	}
+}
+
+func TestBuildHostInputIsolationExprs(t *testing.T) {
+	_, subnet, err := net.ParseCIDR("172.18.0.0/16")
+	if err != nil {
+		t.Fatalf("ParseCIDR failed: %v", err)
+	}
+	exprs := buildHostInputIsolationExprs("br-abc123def456", subnet)
+
+	if len(exprs) != 6 {
+		t.Fatalf("expected 6 expressions, got %d", len(exprs))
+	}
+
+	cmpIface := exprs[1].(*expr.Cmp)
+	expectedIfname := nftIfname("br-abc123def456")
+	if !bytes.Equal(cmpIface.Data, expectedIfname) {
+		t.Fatalf("interface name mismatch: got %v, want %v", cmpIface.Data, expectedIfname)
+	}
+
+	cmpNet := exprs[4].(*expr.Cmp)
+	if !bytes.Equal(cmpNet.Data, []byte{172, 18, 0, 0}) {
+		t.Fatalf("network address mismatch: got %v, want [172 18 0 0]", cmpNet.Data)
+	}
+
+	verdict, ok := exprs[5].(*expr.Verdict)
+	if !ok {
+		t.Fatalf("exprs[5]: expected Verdict, got %T", exprs[5])
+	}
+	if verdict.Kind != expr.VerdictDrop {
+		t.Fatalf("expected VerdictDrop, got %v", verdict.Kind)
+	}
+}
+
 func TestMatchesHostIsolationRule(t *testing.T) {
 	_, subnet, _ := net.ParseCIDR("172.18.0.0/16")
 	bridge := "br-abc123def456"
 
-	// Positive: matching rule should be detected.
-	matchingRule := &nftables.Rule{
+	hostRule := &nftables.Rule{
 		Exprs: buildHostIsolationExprs(bridge, subnet),
 	}
-	if !matchesHostIsolationRule(matchingRule, bridge, subnet) {
-		t.Fatal("expected matching rule to be detected")
+	if !matchesHostIsolationRule(hostRule, bridge, subnet) {
+		t.Fatal("expected host-local rule to be detected")
 	}
 
-	// Negative: different bridge should not match.
-	if matchesHostIsolationRule(matchingRule, "br-other", subnet) {
+	dnatRule := &nftables.Rule{
+		Exprs: buildDNATIsolationExprs(bridge, subnet),
+	}
+	if !matchesHostIsolationRule(dnatRule, bridge, subnet) {
+		t.Fatal("expected DNAT rule to be detected")
+	}
+
+	inputRule := &nftables.Rule{
+		Exprs: buildHostInputIsolationExprs(bridge, subnet),
+	}
+	if !matchesHostIsolationRule(inputRule, bridge, subnet) {
+		t.Fatal("expected INPUT rule to be detected")
+	}
+
+	if matchesHostIsolationRule(hostRule, "br-other", subnet) {
 		t.Fatal("different bridge should not match")
 	}
 
-	// Negative: different subnet should not match.
 	_, otherSubnet, _ := net.ParseCIDR("10.0.0.0/24")
-	if matchesHostIsolationRule(matchingRule, bridge, otherSubnet) {
+	if matchesHostIsolationRule(dnatRule, bridge, otherSubnet) {
 		t.Fatal("different subnet should not match")
 	}
 
-	// Negative: wrong number of expressions.
 	shortRule := &nftables.Rule{
 		Exprs: []expr.Any{&expr.Verdict{Kind: expr.VerdictDrop}},
 	}
 	if matchesHostIsolationRule(shortRule, bridge, subnet) {
 		t.Fatal("rule with wrong expression count should not match")
+	}
+
+	wrongTailRule := &nftables.Rule{
+		Exprs: buildDNATIsolationExprs(bridge, subnet),
+	}
+	wrongTailRule.Exprs[5] = &expr.Fib{
+		Register:       1,
+		FlagDADDR:      true,
+		ResultADDRTYPE: true,
+	}
+	if matchesHostIsolationRule(wrongTailRule, bridge, subnet) {
+		t.Fatal("rule with wrong tail expression should not match")
 	}
 }
 

--- a/sdk/python/tests/test_network_isolation.py
+++ b/sdk/python/tests/test_network_isolation.py
@@ -119,6 +119,52 @@ def _cleanup_companion(sandbox_id: str, companion_name: str) -> None:
     )
 
 
+def _start_port_mapped_container(container_name: str) -> int:
+    """Start an nginx container with a randomly assigned host port mapping.
+
+    Returns the host port that Docker mapped to nginx port 80.  The caller is
+    responsible for removing the container via _stop_port_mapped_container.
+    """
+    subprocess.run(
+        ["docker", "rm", "--force", container_name],
+        check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        ["docker", "run", "-d", "--name", container_name, "-p", "0:80", "nginx:alpine"],
+        check=True, stdout=subprocess.DEVNULL,
+    )
+    result = subprocess.run(
+        ["docker", "port", container_name, "80"],
+        capture_output=True, text=True, check=True,
+    )
+    # Output is like "0.0.0.0:32768\n" or "[::]:32768\n"; take the last token.
+    host_port = int(result.stdout.strip().rsplit(":", 1)[-1])
+    return host_port
+
+
+def _stop_port_mapped_container(container_name: str) -> None:
+    subprocess.run(
+        ["docker", "rm", "--force", container_name],
+        check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+def _get_default_docker_bridge_ip() -> str:
+    """Return the gateway IP of Docker's default bridge network (typically 172.17.0.1)."""
+    result = subprocess.run(
+        [
+            "docker", "network", "inspect", "bridge",
+            "--format", "{{range .IPAM.Config}}{{.Gateway}}{{end}}",
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    gw = result.stdout.strip()
+    return gw if gw else "172.17.0.1"
+
+
+DNAT_CONTAINER_NAME = "agbox-nettest-dnat"
+
+
 def test_sandbox_cannot_reach_host_but_can_reach_internet(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[3]
     if shutil.which("go") is None:
@@ -137,9 +183,12 @@ def test_sandbox_cannot_reach_host_but_can_reach_internet(tmp_path: Path) -> Non
     _ensure_runtime_image(repo_root)
     _cleanup_runtime_resources(SANDBOX_ID)
     _cleanup_companion(SANDBOX_ID, COMPANION_NAME)
+    _stop_port_mapped_container(DNAT_CONTAINER_NAME)
 
-    # Start a TCP listener on the host
+    # Start a TCP listener on the host (tests INPUT-chain blocking of native host ports).
     srv_socket, listener_port, stop_event = _start_tcp_listener()
+    # Start an nginx container with a Docker port mapping (tests DNAT/FORWARD-chain blocking).
+    dnat_port = _start_port_mapped_container(DNAT_CONTAINER_NAME)
 
     sandbox_id = ""
     try:
@@ -150,6 +199,7 @@ def test_sandbox_cannot_reach_host_but_can_reach_internet(tmp_path: Path) -> Non
                         socket_path=socket_path,
                         workspace=workspace,
                         listener_port=listener_port,
+                        dnat_port=dnat_port,
                     )
                 )
             finally:
@@ -158,6 +208,7 @@ def test_sandbox_cannot_reach_host_but_can_reach_internet(tmp_path: Path) -> Non
     finally:
         stop_event.set()
         srv_socket.close()
+        _stop_port_mapped_container(DNAT_CONTAINER_NAME)
         shutil.rmtree(runtime_dir, ignore_errors=True)
 
 
@@ -166,6 +217,7 @@ async def _run_network_isolation_test(
     socket_path: Path,
     workspace: Path,
     listener_port: int,
+    dnat_port: int,
 ) -> str:
     client = await _wait_for_client(socket_path)
     async with client:
@@ -209,6 +261,26 @@ async def _run_network_isolation_test(
             )
             assert exec_handle.exit_code != 0, (
                 f"SECURITY VIOLATION: primary container reached host via interface IP {host_ip}:{listener_port}"
+            )
+
+        # --- Negative tests: primary container must NOT reach Docker port-mapped (DNAT) services ---
+        # Docker port mappings use DNAT in PREROUTING/nat before reaching DOCKER-USER/FORWARD.
+        # Accessing gateway_ip:<dnat_port> hits the INPUT chain (via userland-proxy).
+        # Accessing the default Docker bridge gateway IP:<dnat_port> triggers DNAT in PREROUTING
+        # and then FORWARD through DOCKER-USER.  Both paths must be blocked.
+        default_bridge_ip = _get_default_docker_bridge_ip()
+        for dnat_target_ip in [gateway_ip, default_bridge_ip]:
+            exec_handle = await client.run(
+                sid,
+                (
+                    "curl", "--connect-timeout", "3", "-s", "-o", "/dev/null",
+                    f"http://{dnat_target_ip}:{dnat_port}",
+                ),
+                cwd="/workspace",
+            )
+            assert exec_handle.exit_code != 0, (
+                f"SECURITY VIOLATION: primary container reached Docker-mapped service via "
+                f"{dnat_target_ip}:{dnat_port} (DNAT path not blocked)"
             )
 
         # --- Positive tests: primary container CAN reach internet ---
@@ -257,6 +329,21 @@ async def _run_network_isolation_test(
             )
             assert result.returncode != 0, (
                 f"SECURITY VIOLATION: companion container reached host via interface IP {host_ip}:{listener_port}"
+            )
+
+        # --- Negative tests: companion container must NOT reach Docker port-mapped (DNAT) services ---
+        for dnat_target_ip in [gateway_ip, default_bridge_ip]:
+            result = subprocess.run(
+                [
+                    "docker", "exec", companion_container,
+                    "wget", "-q", "-O", "/dev/null", "--timeout=3",
+                    f"http://{dnat_target_ip}:{dnat_port}",
+                ],
+                capture_output=True, text=True, check=False,
+            )
+            assert result.returncode != 0, (
+                f"SECURITY VIOLATION: companion container reached Docker-mapped service via "
+                f"{dnat_target_ip}:{dnat_port} (DNAT path not blocked)"
             )
 
         # --- Positive test: companion container CAN reach internet ---


### PR DESCRIPTION
## Problem

Closes #213

The previous single `DOCKER-USER dst-type LOCAL` rule missed two traffic paths that allowed sandbox containers to reach host services:

### Path 1: Docker port-mapped (DNAT) traffic
Docker rewrites destination addresses for port-mapped containers (`-p host:container`) in `PREROUTING/nat` **before** packets reach `DOCKER-USER` in `filter/FORWARD`. After DNAT the destination is no longer a host-local address, so the `dst-type LOCAL` check never matched. A sandbox could reach any host-mapped port on `172.17.0.1:<host-port>`.

### Path 2: Bridge gateway via INPUT chain
Traffic to `<sandbox-bridge-gateway>:<port>` enters the host via the `INPUT` chain (handled by Docker's userland-proxy), not `FORWARD`/`DOCKER-USER`. A single `DOCKER-USER` rule never saw this traffic.

## Fix

Three nftables rules now cover all paths for each sandbox bridge:

| Chain | Match | Action |
|---|---|---|
| `DOCKER-USER` | iif=bridge, src=subnet, dst-type LOCAL | DROP |
| `DOCKER-USER` | iif=bridge, src=subnet, conntrack IPS_DST_NAT | DROP |
| `INPUT` | iif=bridge, src=subnet | DROP |

All three rules are managed idempotently: `applyHostIsolation` inserts only missing rules, `removeHostIsolation` deletes all three, and daemon restart recovery patches only whichever rules are absent on pre-existing sandboxes (`inserted_rules` log field).

## Changes

- `internal/control/docker_runtime_nftables_linux.go`
  - `buildDNATIsolationExprs` — new DNAT rule expression builder
  - `buildHostInputIsolationExprs` — new INPUT rule expression builder
  - `buildBridgeSubnetMatchExprs` — shared bridge+subnet prefix extractor
  - `findFilterChain` / `findInputChain` — generic chain lookup
  - `insertMissingIsolationRules` / `removeIsolationRulesFromChain` — idempotent multi-rule management
  - `matchesIsolationTail` — type-safe expression tail comparison (Fib, Ct, Bitwise, Cmp, Verdict)

- `internal/control/docker_runtime_nftables_linux_test.go`
  - `TestBuildDNATIsolationExprs` — validates Ct/Bitwise/Cmp/Verdict expression shape
  - `TestBuildHostInputIsolationExprs` — validates bridge/subnet/Verdict expression shape
  - Extended `TestMatchesHostIsolationRule` — positive match for all 3 rule types, negative for wrong tail

- `sdk/python/tests/test_network_isolation.py`
  - `_start_port_mapped_container` / `_stop_port_mapped_container` — start nginx with `-p 0:80`
  - `_get_default_docker_bridge_ip` — discover `docker0` gateway dynamically
  - DNAT negative tests: primary and companion containers cannot reach port-mapped service via sandbox bridge gateway or default Docker bridge gateway (`172.17.0.1`)

## Verified

- `go test ./...` passes (unit tests + mock tests)
- Manual E2E: new daemon logs `inserted_rules=3` on create, `removed_rules=3` on delete
- Blocked: `172.17.0.1:<port>`, `10.240.x.1:<port>`, mapped Docker ports → timeout
- Allowed: `https://example.com` → 200, companion nginx port 80 → 200