### PR TITLE
[ISSUE-215] Allow host ingress to published sandbox ports

### DIFF
--- a/docs/isolation_and_security.md
+++ b/docs/isolation_and_security.md
@@ -1,9 +1,9 @@
 # Isolation and Security
 
 Each sandbox is a Docker container isolated from the host in both **network** and **filesystem**.
-- No host network access
-- No host filesystem access
-- No exceptions.
+- Sandbox-originated host network access is blocked.
+- Explicit localhost port mappings are host-initiated ingress into declared container ports.
+- Host filesystem access is explicit-only.
 
 This document is the security posture reference for `agents-sandbox`.
 
@@ -34,11 +34,12 @@ flowchart TB
     NetA -.-|no connectivity| NetB
     NetA -->|NAT via Docker bridge| Internet
     NetB -->|NAT via Docker bridge| Internet
-    HostNet -.-|blocked permanently| NetA
+    HostNet -.->|declared localhost port mapping| NetA
+    NetA -.-|sandbox-originated host access blocked| HostNet
     HostFS -.-|explicit mount only| NetA
 ```
 
-- **Host network restricted.** Sandboxes are isolated from the host and from each other. If the agent needs databases, caches, or other dependencies, declare them as [companion containers](companion_container_guide.md) — they run on the same sandbox network and are reachable by DNS alias.
+- **Host network restricted.** Sandbox-originated connections to host-local addresses are blocked. Declared localhost port mappings are allowed because the host initiates ingress into an explicitly published sandbox port. If the agent needs databases, caches, or other dependencies, declare them as [companion containers](companion_container_guide.md) — they run on the same sandbox network and are reachable by DNS alias.
 - **Host filesystem invisible by default.** Only explicitly declared `mounts`, `copies`, and `builtin_tools` may enter the sandbox. Everything else is rejected.
 - **Internet fully available.** Outbound traffic is NAT'd via Docker bridge — agents can download packages, call APIs, and clone repos freely.
 - **Cross-sandbox isolated.** Each sandbox gets its own dedicated Docker network. Sandboxes cannot reach each other.
@@ -47,7 +48,7 @@ flowchart TB
 
 | Boundary | Mechanism | Detail |
 |----------|-----------|--------|
-| **Network** | Dedicated network + host isolation | Outbound internet via NAT; no shared bridge, no host network, no Docker socket exposure. Sandboxes are isolated from each other, and companion containers join the same sandbox network. Platform-specific enforcement is described below. |
+| **Network** | Dedicated network + host isolation | Outbound internet via NAT; no shared bridge, no host network, no Docker socket exposure. Sandbox-originated host access is blocked, while declared localhost port mappings allow host-initiated ingress. Sandboxes are isolated from each other, and companion containers join the same sandbox network. Platform-specific enforcement is described below. |
 | **Filesystem** | Explicit-only ingress | Only declared `mounts`, `copies`, and `builtin_tools` (host credential and cache mounts like `claude`, `git`, `uv`) enter the sandbox. Symlink sources and path traversal are rejected. See [Container Dependency Strategy](container_dependency_strategy.md). |
 | **Process** | Non-root user + init process | `HOST_UID`/`HOST_GID` align container user with host identity. `Init: true` handles signal forwarding and zombie reaping. |
 | **Docker access** | Daemon-mediated only | Sandboxes have no Docker socket. All Docker operations go through the daemon's structured API client. |
@@ -56,5 +57,5 @@ flowchart TB
 
 ## Platform-Specific Network Strategy
 
-- **Linux:** an nftables rule in the `DOCKER-USER` chain drops traffic from each sandbox subnet to host-local addresses, blocking access to host services at the network layer. The daemon requires `CAP_NET_ADMIN`.
+- **Linux:** nftables rules drop new sandbox-originated traffic from each sandbox subnet to host-local addresses and Docker-published host ports. Established replies for declared localhost port mappings are allowed. The daemon requires `CAP_NET_ADMIN`.
 - **macOS:** `host.docker.internal` and `gateway.docker.internal` are overridden to `0.0.0.0` via `--add-host`, reducing access to the macOS host through Docker Desktop's stable host-discovery aliases. This is a DNS-layer best-effort control, not Linux-equivalent network-layer isolation.

--- a/docs/sandbox_container_lifecycle.md
+++ b/docs/sandbox_container_lifecycle.md
@@ -7,7 +7,7 @@ This document describes the runtime lifecycle contract owned by `agents-sandbox`
 | Resource | Notes |
 |----------|-------|
 | Primary container | Runs the service process as its primary command (under tini) |
-| Dedicated network | One per sandbox; shared bridge and host network are not supported. On Linux, an nftables DOCKER-USER rule blocks container→host traffic (applied on create, re-applied on daemon restart recovery, removed on delete). On macOS, `host.docker.internal` is overridden to `0.0.0.0` via `--add-host`. |
+| Dedicated network | One per sandbox; shared bridge and host network are not supported. On Linux, nftables rules block new sandbox-originated host traffic (applied on create, re-applied on daemon restart recovery, removed on delete) without blocking established replies for declared host-initiated localhost port mappings. On macOS, `host.docker.internal` is overridden to `0.0.0.0` via `--add-host`. |
 | Companion containers | Declared via `CompanionContainerSpec`, on the same network |
 | Persistent event history | Stored in bbolt; lifecycle and exec events survive daemon restart until retention cleanup |
 | Exec output artifacts | Files under the configured artifact root |

--- a/internal/control/docker_runtime_nftables_linux.go
+++ b/internal/control/docker_runtime_nftables_linux.go
@@ -35,12 +35,12 @@ const rtnLocal = 2
 const ipsDstNAT = 1 << 5 // 32
 
 // buildHostIsolationExprs constructs the nftables expression list that drops
-// all traffic entering via `bridge` from `subnet` destined for any host-local
+// new traffic entering via `bridge` from `subnet` destined for any host-local
 // address. This is equivalent to:
 //
-//	iptables -I DOCKER-USER -i <bridge> -s <subnet> -m addrtype --dst-type LOCAL -j DROP
+//	iptables -I DOCKER-USER -i <bridge> -s <subnet> -m conntrack --ctstate NEW -m addrtype --dst-type LOCAL -j DROP
 func buildHostIsolationExprs(bridge string, subnet *net.IPNet) []expr.Any {
-	return buildBridgeSubnetMatchExprs(bridge, subnet, []expr.Any{
+	return buildBridgeSubnetMatchExprs(bridge, subnet, append(buildConntrackNewMatchExprs(), []expr.Any{
 		// Check if destination address type is LOCAL (fib lookup).
 		&expr.Fib{
 			Register:       1,
@@ -54,19 +54,19 @@ func buildHostIsolationExprs(bridge string, subnet *net.IPNet) []expr.Any {
 		},
 		// DROP verdict.
 		&expr.Verdict{Kind: expr.VerdictDrop},
-	}...)
+	}...)...)
 }
 
 // buildDNATIsolationExprs constructs the nftables expression list that drops
-// all DNAT'd traffic entering via `bridge` from `subnet`. Docker port mappings
+// new DNAT'd traffic entering via `bridge` from `subnet`. Docker port mappings
 // (-p host:container) rewrite the destination in PREROUTING/nat before packets
 // reach DOCKER-USER in filter/FORWARD, so the dst-type LOCAL check in
 // buildHostIsolationExprs never matches them. This rule catches that case by
 // matching conntrack status IPS_DST_NAT. Equivalent to:
 //
-//	iptables -I DOCKER-USER -i <bridge> -s <subnet> -m conntrack --ctstate DNAT -j DROP
+//	iptables -I DOCKER-USER -i <bridge> -s <subnet> -m conntrack --ctstate NEW -m conntrack --ctstate DNAT -j DROP
 func buildDNATIsolationExprs(bridge string, subnet *net.IPNet) []expr.Any {
-	return buildBridgeSubnetMatchExprs(bridge, subnet, []expr.Any{
+	return buildBridgeSubnetMatchExprs(bridge, subnet, append(buildConntrackNewMatchExprs(), []expr.Any{
 		// Load conntrack status into register 1.
 		&expr.Ct{
 			Register: 1,
@@ -88,15 +88,36 @@ func buildDNATIsolationExprs(bridge string, subnet *net.IPNet) []expr.Any {
 		},
 		// DROP verdict.
 		&expr.Verdict{Kind: expr.VerdictDrop},
-	}...)
+	}...)...)
 }
 
 // buildHostInputIsolationExprs constructs the nftables expression list that
-// drops packets from the sandbox subnet entering the host INPUT path via the
-// sandbox bridge. This blocks direct access to the bridge gateway address and
-// Docker userland-proxy listeners bound on host addresses.
+// drops new packets from the sandbox subnet entering the host INPUT path via
+// the sandbox bridge. This blocks direct access to the bridge gateway address
+// and Docker userland-proxy listeners bound on host addresses.
 func buildHostInputIsolationExprs(bridge string, subnet *net.IPNet) []expr.Any {
-	return buildBridgeSubnetMatchExprs(bridge, subnet, &expr.Verdict{Kind: expr.VerdictDrop})
+	return buildBridgeSubnetMatchExprs(bridge, subnet, append(buildConntrackNewMatchExprs(), &expr.Verdict{Kind: expr.VerdictDrop})...)
+}
+
+func buildConntrackNewMatchExprs() []expr.Any {
+	return []expr.Any{
+		&expr.Ct{
+			Register: 1,
+			Key:      expr.CtKeySTATE,
+		},
+		&expr.Bitwise{
+			SourceRegister: 1,
+			DestRegister:   1,
+			Len:            4,
+			Mask:           binaryutil.NativeEndian.PutUint32(expr.CtStateBitNEW),
+			Xor:            []byte{0, 0, 0, 0},
+		},
+		&expr.Cmp{
+			Op:       expr.CmpOpNeq,
+			Register: 1,
+			Data:     binaryutil.NativeEndian.PutUint32(0),
+		},
+	}
 }
 
 // buildBridgeSubnetMatchExprs constructs the common prefix expressions that
@@ -186,15 +207,19 @@ func expectedHostIsolationRules(bridge string, subnet *net.IPNet) [][]expr.Any {
 	)
 }
 
-// matchesHostIsolationRule checks whether an existing nftables rule matches
-// any host isolation rule (host-local or DNAT) for the given bridge and subnet.
-func matchesHostIsolationRule(rule *nftables.Rule, bridge string, subnet *net.IPNet) bool {
+func matchesCurrentHostIsolationRule(rule *nftables.Rule, bridge string, subnet *net.IPNet) bool {
 	for _, expected := range expectedHostIsolationRules(bridge, subnet) {
 		if matchesIsolationRule(rule, expected) {
 			return true
 		}
 	}
 	return false
+}
+
+// matchesHostIsolationRule checks whether an existing nftables rule matches
+// any host isolation rule for the given bridge and subnet.
+func matchesHostIsolationRule(rule *nftables.Rule, bridge string, subnet *net.IPNet) bool {
+	return matchesCurrentHostIsolationRule(rule, bridge, subnet)
 }
 
 // matchesIsolationRule checks whether a rule matches the expression shape used
@@ -307,7 +332,12 @@ func (r *realNftablesConnector) applyHostIsolation(bridge string, subnet *net.IP
 
 	inserted := 0
 
-	n, err := insertMissingIsolationRules(conn, dockerUserTable, dockerUserChain, expectedDockerUserIsolationRules(bridge, subnet))
+	n, err := insertMissingIsolationRules(
+		conn,
+		dockerUserTable,
+		dockerUserChain,
+		expectedDockerUserIsolationRules(bridge, subnet),
+	)
 	if err != nil {
 		return err
 	}
@@ -353,13 +383,23 @@ func (r *realNftablesConnector) applyInputIsolation(
 ) (int, error) {
 	inputChain, inputTable, err := findInputChain(conn)
 	if err == nil {
-		return insertMissingIsolationRules(conn, inputTable, inputChain, expectedInputIsolationRules(bridge, subnet))
+		return insertMissingIsolationRules(
+			conn,
+			inputTable,
+			inputChain,
+			expectedInputIsolationRules(bridge, subnet),
+		)
 	}
 
 	// Standard INPUT chain absent (native nftables mode). Find or create AGBOX-INPUT.
 	agboxChain, agboxTable, err := findFilterChain(conn, agboxInputChainName)
 	if err == nil {
-		return insertMissingIsolationRules(conn, agboxTable, agboxChain, expectedInputIsolationRules(bridge, subnet))
+		return insertMissingIsolationRules(
+			conn,
+			agboxTable,
+			agboxChain,
+			expectedInputIsolationRules(bridge, subnet),
+		)
 	}
 
 	// AGBOX-INPUT doesn't exist yet. Create it and add rules in the same
@@ -382,38 +422,46 @@ func (r *realNftablesConnector) applyInputIsolation(
 	return len(expected), nil
 }
 
+func selectMissingIsolationRules(
+	existingRules []*nftables.Rule,
+	currentRules [][]expr.Any,
+) [][]expr.Any {
+	var missing [][]expr.Any
+	for _, current := range currentRules {
+		exists := false
+		for _, rule := range existingRules {
+			if matchesIsolationRule(rule, current) {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			missing = append(missing, current)
+		}
+	}
+	return missing
+}
+
 func insertMissingIsolationRules(
 	conn *nftables.Conn,
 	table *nftables.Table,
 	chain *nftables.Chain,
-	expectedRules [][]expr.Any,
+	currentRules [][]expr.Any,
 ) (int, error) {
 	rules, err := conn.GetRules(table, chain)
 	if err != nil {
 		return 0, fmt.Errorf("get nftables rules from %s: %w", chain.Name, err)
 	}
 
-	inserted := 0
-	for _, expected := range expectedRules {
-		exists := false
-		for _, rule := range rules {
-			if matchesIsolationRule(rule, expected) {
-				exists = true
-				break
-			}
-		}
-		if exists {
-			continue
-		}
-
+	missing := selectMissingIsolationRules(rules, currentRules)
+	for _, exprs := range missing {
 		conn.InsertRule(&nftables.Rule{
 			Table: table,
 			Chain: chain,
-			Exprs: expected,
+			Exprs: exprs,
 		})
-		inserted++
 	}
-	return inserted, nil
+	return len(missing), nil
 }
 
 func (r *realNftablesConnector) removeHostIsolation(bridge string, subnet *net.IPNet) {
@@ -428,7 +476,12 @@ func (r *realNftablesConnector) removeHostIsolation(bridge string, subnet *net.I
 	removed := 0
 	dockerUserChain, dockerUserTable, err := findDockerUserChain(conn)
 	if err == nil {
-		n, err := removeIsolationRulesFromChain(conn, dockerUserTable, dockerUserChain, expectedDockerUserIsolationRules(bridge, subnet))
+		n, err := removeIsolationRulesFromChain(
+			conn,
+			dockerUserTable,
+			dockerUserChain,
+			expectedDockerUserIsolationRules(bridge, subnet),
+		)
 		if err != nil {
 			r.logger.Warn("failed to delete nftables host isolation rule",
 				slog.String("bridge", bridge),
@@ -451,7 +504,12 @@ func (r *realNftablesConnector) removeHostIsolation(bridge string, subnet *net.I
 		if lookupErr != nil {
 			continue
 		}
-		n, removeErr := removeIsolationRulesFromChain(conn, table, chain, expectedInputIsolationRules(bridge, subnet))
+		n, removeErr := removeIsolationRulesFromChain(
+			conn,
+			table,
+			chain,
+			expectedInputIsolationRules(bridge, subnet),
+		)
 		if removeErr != nil {
 			r.logger.Warn("failed to delete nftables host input isolation rule",
 				slog.String("bridge", bridge),
@@ -496,19 +554,26 @@ func removeIsolationRulesFromChain(
 	}
 
 	removed := 0
-	for _, rule := range rules {
-		for _, expected := range expectedRules {
-			if !matchesIsolationRule(rule, expected) {
-				continue
-			}
-			if err := conn.DelRule(rule); err != nil {
-				return removed, err
-			}
-			removed++
-			break
+	for _, rule := range selectIsolationRulesToRemove(rules, expectedRules) {
+		if err := conn.DelRule(rule); err != nil {
+			return removed, err
 		}
+		removed++
 	}
 	return removed, nil
+}
+
+func selectIsolationRulesToRemove(rules []*nftables.Rule, expectedRules [][]expr.Any) []*nftables.Rule {
+	var selected []*nftables.Rule
+	for _, rule := range rules {
+		for _, expected := range expectedRules {
+			if matchesIsolationRule(rule, expected) {
+				selected = append(selected, rule)
+				break
+			}
+		}
+	}
+	return selected
 }
 
 // newNftablesConnector creates a real nftables connector for Linux.

--- a/internal/control/docker_runtime_nftables_linux_test.go
+++ b/internal/control/docker_runtime_nftables_linux_test.go
@@ -19,13 +19,12 @@ func TestBuildHostIsolationExprs(t *testing.T) {
 	}
 	exprs := buildHostIsolationExprs("br-abc123def456", subnet)
 
-	// Expected structure: Meta, Cmp, Payload, Bitwise, Cmp, Fib, Cmp, Verdict = 8 expressions.
-	if len(exprs) != 8 {
-		t.Fatalf("expected 8 expressions, got %d", len(exprs))
+	// Expected structure: common bridge/subnet prefix, ct state NEW, Fib, Cmp, Verdict.
+	if len(exprs) != 11 {
+		t.Fatalf("expected 11 expressions, got %d", len(exprs))
 	}
 
-	// Verify expression types in order.
-	typeChecks := []string{"Meta", "Cmp", "Payload", "Bitwise", "Cmp", "Fib", "Cmp", "Verdict"}
+	typeChecks := []string{"Meta", "Cmp", "Payload", "Bitwise", "Cmp", "Ct", "Bitwise", "Cmp", "Fib", "Cmp", "Verdict"}
 	for i, name := range typeChecks {
 		var ok bool
 		switch name {
@@ -39,6 +38,8 @@ func TestBuildHostIsolationExprs(t *testing.T) {
 			_, ok = exprs[i].(*expr.Bitwise)
 		case "Fib":
 			_, ok = exprs[i].(*expr.Fib)
+		case "Ct":
+			_, ok = exprs[i].(*expr.Ct)
 		case "Verdict":
 			_, ok = exprs[i].(*expr.Verdict)
 		}
@@ -66,15 +67,17 @@ func TestBuildHostIsolationExprs(t *testing.T) {
 		t.Fatalf("network address mismatch: got %v, want [172 18 0 0]", cmpNet.Data)
 	}
 
+	assertConntrackNewMatch(t, exprs[5:8])
+
 	// Verify fib RTN_LOCAL comparison uses native endian.
-	cmpFib := exprs[6].(*expr.Cmp)
+	cmpFib := exprs[9].(*expr.Cmp)
 	expectedRTNLocal := binaryutil.NativeEndian.PutUint32(rtnLocal)
 	if !bytes.Equal(cmpFib.Data, expectedRTNLocal) {
 		t.Fatalf("RTN_LOCAL mismatch: got %v, want %v", cmpFib.Data, expectedRTNLocal)
 	}
 
 	// Verify DROP verdict.
-	verdict := exprs[7].(*expr.Verdict)
+	verdict := exprs[10].(*expr.Verdict)
 	if verdict.Kind != expr.VerdictDrop {
 		t.Fatalf("expected VerdictDrop, got %v", verdict.Kind)
 	}
@@ -87,39 +90,41 @@ func TestBuildDNATIsolationExprs(t *testing.T) {
 	}
 	exprs := buildDNATIsolationExprs("br-abc123def456", subnet)
 
-	// Expected structure: common bridge/subnet prefix, Ct, Bitwise, Cmp, Verdict.
-	if len(exprs) != 9 {
-		t.Fatalf("expected 9 expressions, got %d", len(exprs))
+	// Expected structure: common bridge/subnet prefix, ct state NEW, Ct status DNAT, Verdict.
+	if len(exprs) != 12 {
+		t.Fatalf("expected 12 expressions, got %d", len(exprs))
 	}
 
-	ct, ok := exprs[5].(*expr.Ct)
+	assertConntrackNewMatch(t, exprs[5:8])
+
+	ct, ok := exprs[8].(*expr.Ct)
 	if !ok {
-		t.Fatalf("exprs[5]: expected Ct, got %T", exprs[5])
+		t.Fatalf("exprs[8]: expected Ct, got %T", exprs[8])
 	}
 	if ct.Key != expr.CtKeySTATUS || ct.Register != 1 {
 		t.Fatalf("unexpected Ct expression: key=%v register=%d", ct.Key, ct.Register)
 	}
 
-	bitwise, ok := exprs[6].(*expr.Bitwise)
+	bitwise, ok := exprs[9].(*expr.Bitwise)
 	if !ok {
-		t.Fatalf("exprs[6]: expected Bitwise, got %T", exprs[6])
+		t.Fatalf("exprs[9]: expected Bitwise, got %T", exprs[9])
 	}
 	expectedDNATMask := binaryutil.NativeEndian.PutUint32(ipsDstNAT)
 	if !bytes.Equal(bitwise.Mask, expectedDNATMask) {
 		t.Fatalf("DNAT mask mismatch: got %v, want %v", bitwise.Mask, expectedDNATMask)
 	}
 
-	cmpDNAT, ok := exprs[7].(*expr.Cmp)
+	cmpDNAT, ok := exprs[10].(*expr.Cmp)
 	if !ok {
-		t.Fatalf("exprs[7]: expected Cmp, got %T", exprs[7])
+		t.Fatalf("exprs[10]: expected Cmp, got %T", exprs[10])
 	}
 	if cmpDNAT.Op != expr.CmpOpNeq || !bytes.Equal(cmpDNAT.Data, binaryutil.NativeEndian.PutUint32(0)) {
 		t.Fatalf("unexpected DNAT comparison: op=%v data=%v", cmpDNAT.Op, cmpDNAT.Data)
 	}
 
-	verdict, ok := exprs[8].(*expr.Verdict)
+	verdict, ok := exprs[11].(*expr.Verdict)
 	if !ok {
-		t.Fatalf("exprs[8]: expected Verdict, got %T", exprs[8])
+		t.Fatalf("exprs[11]: expected Verdict, got %T", exprs[11])
 	}
 	if verdict.Kind != expr.VerdictDrop {
 		t.Fatalf("expected VerdictDrop, got %v", verdict.Kind)
@@ -133,8 +138,8 @@ func TestBuildHostInputIsolationExprs(t *testing.T) {
 	}
 	exprs := buildHostInputIsolationExprs("br-abc123def456", subnet)
 
-	if len(exprs) != 6 {
-		t.Fatalf("expected 6 expressions, got %d", len(exprs))
+	if len(exprs) != 9 {
+		t.Fatalf("expected 9 expressions, got %d", len(exprs))
 	}
 
 	cmpIface := exprs[1].(*expr.Cmp)
@@ -148,12 +153,49 @@ func TestBuildHostInputIsolationExprs(t *testing.T) {
 		t.Fatalf("network address mismatch: got %v, want [172 18 0 0]", cmpNet.Data)
 	}
 
-	verdict, ok := exprs[5].(*expr.Verdict)
+	assertConntrackNewMatch(t, exprs[5:8])
+
+	verdict, ok := exprs[8].(*expr.Verdict)
 	if !ok {
-		t.Fatalf("exprs[5]: expected Verdict, got %T", exprs[5])
+		t.Fatalf("exprs[8]: expected Verdict, got %T", exprs[8])
 	}
 	if verdict.Kind != expr.VerdictDrop {
 		t.Fatalf("expected VerdictDrop, got %v", verdict.Kind)
+	}
+}
+
+func assertConntrackNewMatch(t *testing.T, exprs []expr.Any) {
+	t.Helper()
+	if len(exprs) != 3 {
+		t.Fatalf("expected 3 conntrack NEW expressions, got %d", len(exprs))
+	}
+	ct, ok := exprs[0].(*expr.Ct)
+	if !ok {
+		t.Fatalf("conntrack expr[0]: expected Ct, got %T", exprs[0])
+	}
+	if ct.Key != expr.CtKeySTATE || ct.Register != 1 {
+		t.Fatalf("unexpected conntrack state expression: key=%v register=%d", ct.Key, ct.Register)
+	}
+	bitwise, ok := exprs[1].(*expr.Bitwise)
+	if !ok {
+		t.Fatalf("conntrack expr[1]: expected Bitwise, got %T", exprs[1])
+	}
+	expectedNewMask := binaryutil.NativeEndian.PutUint32(expr.CtStateBitNEW)
+	if bitwise.SourceRegister != 1 ||
+		bitwise.DestRegister != 1 ||
+		bitwise.Len != 4 ||
+		!bytes.Equal(bitwise.Mask, expectedNewMask) ||
+		!bytes.Equal(bitwise.Xor, []byte{0, 0, 0, 0}) {
+		t.Fatalf("unexpected conntrack NEW bitwise expression: %#v", bitwise)
+	}
+	cmp, ok := exprs[2].(*expr.Cmp)
+	if !ok {
+		t.Fatalf("conntrack expr[2]: expected Cmp, got %T", exprs[2])
+	}
+	if cmp.Op != expr.CmpOpNeq ||
+		cmp.Register != 1 ||
+		!bytes.Equal(cmp.Data, binaryutil.NativeEndian.PutUint32(0)) {
+		t.Fatalf("unexpected conntrack NEW comparison: %#v", cmp)
 	}
 }
 
@@ -208,6 +250,99 @@ func TestMatchesHostIsolationRule(t *testing.T) {
 	}
 	if matchesHostIsolationRule(wrongTailRule, bridge, subnet) {
 		t.Fatal("rule with wrong tail expression should not match")
+	}
+}
+
+func TestHostIsolationCurrentRulesMatchConntrackNew(t *testing.T) {
+	_, subnet, _ := net.ParseCIDR("172.18.0.0/16")
+	_, otherSubnet, _ := net.ParseCIDR("172.19.0.0/16")
+	bridge := "br-abc123def456"
+
+	for _, exprs := range expectedHostIsolationRules(bridge, subnet) {
+		assertConntrackNewMatch(t, exprs[5:8])
+		rule := &nftables.Rule{Exprs: exprs}
+		if !matchesCurrentHostIsolationRule(rule, bridge, subnet) {
+			t.Fatalf("current rule did not match its bridge/subnet: %#v", exprs)
+		}
+		if !matchesHostIsolationRule(rule, bridge, subnet) {
+			t.Fatalf("current rule did not match host isolation matcher: %#v", exprs)
+		}
+		if matchesCurrentHostIsolationRule(rule, "br-other", subnet) {
+			t.Fatalf("current rule matched a different bridge: %#v", exprs)
+		}
+		if matchesCurrentHostIsolationRule(rule, bridge, otherSubnet) {
+			t.Fatalf("current rule matched a different subnet: %#v", exprs)
+		}
+	}
+}
+
+func TestHostIsolationApplyAndReapplyAreIdempotent(t *testing.T) {
+	_, subnet, _ := net.ParseCIDR("172.18.0.0/16")
+	_, otherSubnet, _ := net.ParseCIDR("172.19.0.0/16")
+	bridge := "br-abc123def456"
+
+	current := expectedHostIsolationRules(bridge, subnet)
+	unrelatedCurrent := &nftables.Rule{Exprs: buildDNATIsolationExprs(bridge, otherSubnet)}
+	existing := []*nftables.Rule{
+		{Exprs: current[0]},
+		unrelatedCurrent,
+	}
+
+	missing := selectMissingIsolationRules(existing, current)
+	if got, want := len(missing), len(current)-1; got != want {
+		t.Fatalf("expected %d current inserts, got %d", want, got)
+	}
+	for _, inserted := range missing {
+		if !matchesCurrentHostIsolationRule(&nftables.Rule{Exprs: inserted}, bridge, subnet) {
+			t.Fatalf("inserted non-current rule: %#v", inserted)
+		}
+	}
+
+	reapplied := selectMissingIsolationRules([]*nftables.Rule{
+		{Exprs: current[0]},
+		{Exprs: current[1]},
+		{Exprs: current[2]},
+		unrelatedCurrent,
+	}, current)
+	if len(reapplied) != 0 {
+		t.Fatalf("reapply should be idempotent, got inserts=%d", len(reapplied))
+	}
+}
+
+func TestHostIsolationRemoveDeletesCurrentRules(t *testing.T) {
+	_, subnet, _ := net.ParseCIDR("172.18.0.0/16")
+	_, otherSubnet, _ := net.ParseCIDR("172.19.0.0/16")
+	bridge := "br-abc123def456"
+
+	current := expectedHostIsolationRules(bridge, subnet)
+	sameBridgeRules := []*nftables.Rule{
+		{Exprs: current[0]},
+		{Exprs: current[1]},
+		{Exprs: current[2]},
+	}
+	unrelatedRules := []*nftables.Rule{
+		{Exprs: buildHostIsolationExprs("br-other", subnet)},
+		{Exprs: buildDNATIsolationExprs("br-other", subnet)},
+		{Exprs: buildHostInputIsolationExprs(bridge, otherSubnet)},
+	}
+
+	selected := selectIsolationRulesToRemove(append(sameBridgeRules, unrelatedRules...), current)
+	if got, want := len(selected), len(sameBridgeRules); got != want {
+		t.Fatalf("expected %d selected rules, got %d", want, got)
+	}
+	selectedSet := map[*nftables.Rule]bool{}
+	for _, rule := range selected {
+		selectedSet[rule] = true
+	}
+	for _, rule := range sameBridgeRules {
+		if !selectedSet[rule] {
+			t.Fatalf("same bridge/subnet rule was not selected: %#v", rule.Exprs)
+		}
+	}
+	for _, rule := range unrelatedRules {
+		if selectedSet[rule] {
+			t.Fatalf("unrelated bridge/subnet rule was selected: %#v", rule.Exprs)
+		}
 	}
 }
 

--- a/internal/control/reconcile_restore_test.go
+++ b/internal/control/reconcile_restore_test.go
@@ -107,6 +107,49 @@ func TestRestoreRecovery_DoesNotFailOnExitedPrimary(t *testing.T) {
 	}
 }
 
+func TestRestorePersistedSandboxesReappliesNetworkIsolation(t *testing.T) {
+	dbPath := t.TempDir() + "/ids.db"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	first := newPersistentBufconnHarness(t, ctx, ServiceConfig{
+		TransitionDelay: 5 * time.Millisecond,
+		PollInterval:    2 * time.Millisecond,
+	}, dbPath)
+	_, err := first.client.CreateSandbox(context.Background(), &agboxv1.CreateSandboxRequest{
+		SandboxId:  "ready-reapply",
+		CreateSpec: &agboxv1.CreateSpec{Image: "test:latest"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox failed: %v", err)
+	}
+	waitForSandboxState(t, first.client, "ready-reapply", agboxv1.SandboxState_SANDBOX_STATE_READY)
+	first.close()
+
+	backend := &fakeRuntimeBackend{
+		inspectResults: map[string]ContainerInspectResult{
+			dockerPrimaryContainerName("ready-reapply"): {Exists: true, Running: true},
+		},
+	}
+	second := newPersistentBufconnHarness(t, ctx, ServiceConfig{
+		TransitionDelay: 5 * time.Millisecond,
+		PollInterval:    2 * time.Millisecond,
+		runtimeBackend:  backend,
+	}, dbPath)
+	defer second.close()
+
+	resp, err := second.client.GetSandbox(context.Background(), &agboxv1.GetSandboxRequest{SandboxId: "ready-reapply"})
+	if err != nil {
+		t.Fatalf("GetSandbox failed: %v", err)
+	}
+	if resp.GetSandbox().GetState() != agboxv1.SandboxState_SANDBOX_STATE_READY {
+		t.Fatalf("expected READY after restore, got %s", resp.GetSandbox().GetState())
+	}
+	if got, want := backend.reapplyNetworkCalls, []string{"ready-reapply"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("expected ReapplyNetworkIsolation calls %v, got %v", want, got)
+	}
+}
+
 // ---- AT-MQ1S: FAILED sandbox keeps runtimeState for DeleteSandbox ----
 
 func TestRestoreRecovery_FailedSandboxKeepsRuntimeStateForDelete(t *testing.T) {

--- a/internal/control/service.go
+++ b/internal/control/service.go
@@ -427,6 +427,7 @@ func (s *Service) SubscribeSandboxEvents(req *agboxv1.SubscribeSandboxEventsRequ
 		s.mu.RUnlock()
 		return err
 	}
+	subscribedRecord := record
 	initialEvents := eventsAfter(record, nextSequence)
 	s.mu.RUnlock()
 
@@ -448,8 +449,17 @@ func (s *Service) SubscribeSandboxEvents(req *agboxv1.SubscribeSandboxEventsRequ
 			s.mu.RLock()
 			record, ok := s.boxes[req.GetSandboxId()]
 			if !ok {
+				// The sandbox can be purged while an existing subscriber has not
+				// yet observed the terminal events; drain the subscribed record.
+				pendingEvents := eventsAfter(subscribedRecord, nextSequence)
 				s.mu.RUnlock()
-				return newStatusError(codes.NotFound, ReasonSandboxNotFound, map[string]string{"sandbox_id": req.GetSandboxId()}, "sandbox %s was not found", req.GetSandboxId())
+				for _, event := range pendingEvents {
+					if err := stream.Send(event); err != nil {
+						return err
+					}
+					nextSequence = event.GetSequence()
+				}
+				return nil
 			}
 			if err := validateSequenceNotExpired(record, nextSequence); err != nil {
 				s.mu.RUnlock()

--- a/sdk/python/tests/test_network_isolation.py
+++ b/sdk/python/tests/test_network_isolation.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import shlex
 import shutil
 import socket
 import subprocess
 import tempfile
 import threading
+import time
+import urllib.request
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 import pytest
@@ -16,6 +20,7 @@ from agents_sandbox import (
     AgentsSandboxClient,
     CompanionContainerSpec,
     MountSpec,
+    PortMapping,
 )
 
 from tests.test_real_runtime import (
@@ -33,7 +38,7 @@ from tests.smoke_support import daemon_socket_path
 
 COMPANION_NAME = "netcheck"
 COMPANION_IMAGE = "nginx:alpine"
-SANDBOX_ID = "net-isolation"
+PUBLISHED_PORT_RESPONSE = "agents-sandbox-published-port-ok"
 
 
 def _companion_container_name(sandbox_id: str, companion_name: str) -> str:
@@ -98,7 +103,6 @@ def _get_host_interface_ips() -> list[str]:
 
 def _wait_for_companion_running(container_name: str, timeout: float = 60.0) -> None:
     """Wait until a companion container is running."""
-    import time
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         result = subprocess.run(
@@ -108,7 +112,9 @@ def _wait_for_companion_running(container_name: str, timeout: float = 60.0) -> N
         if result.returncode == 0 and result.stdout.strip() == "true":
             return
         time.sleep(0.5)
-    raise AssertionError(f"companion container {container_name} did not become running within {timeout}s")
+    raise AssertionError(
+        f"companion container {container_name} did not become running within {timeout}s"
+    )
 
 
 def _cleanup_companion(sandbox_id: str, companion_name: str) -> None:
@@ -162,11 +168,17 @@ def _get_default_docker_bridge_ip() -> str:
     return gw if gw else "172.17.0.1"
 
 
-DNAT_CONTAINER_NAME = "agbox-nettest-dnat"
+def _reserve_unused_host_port() -> tuple[socket.socket, int]:
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        srv.bind(("127.0.0.1", 0))
+        return srv, srv.getsockname()[1]
+    except Exception:
+        srv.close()
+        raise
 
 
-def test_sandbox_cannot_reach_host_but_can_reach_internet(tmp_path: Path) -> None:
-    repo_root = Path(__file__).resolve().parents[3]
+def _require_network_integration(repo_root: Path) -> None:
     if shutil.which("go") is None:
         pytest.skip("go is required")
     if shutil.which("docker") is None:
@@ -175,185 +187,287 @@ def test_sandbox_cannot_reach_host_but_can_reach_internet(tmp_path: Path) -> Non
         if os.environ.get("AGBOX_REQUIRE_INTEGRATION"):
             pytest.fail("CAP_NET_ADMIN is required for integration tests but sudo -n setcap is not available")
         pytest.skip("CAP_NET_ADMIN required; grant passwordless sudo or run as root")
+    _ensure_runtime_image(repo_root)
+
+
+NetworkScenario = Callable[[Path, Path, str], Awaitable[str]]
+
+
+def _run_network_scenario(tmp_path: Path, sandbox_id: str, scenario: NetworkScenario) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    _require_network_integration(repo_root)
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     runtime_dir = Path(tempfile.mkdtemp(prefix="agbox-"))
     socket_path = daemon_socket_path(runtime_dir)
-    _ensure_runtime_image(repo_root)
-    _cleanup_runtime_resources(SANDBOX_ID)
-    _cleanup_companion(SANDBOX_ID, COMPANION_NAME)
-    _stop_port_mapped_container(DNAT_CONTAINER_NAME)
+    _cleanup_runtime_resources(sandbox_id)
+    _cleanup_companion(sandbox_id, COMPANION_NAME)
 
-    # Start a TCP listener on the host (tests INPUT-chain blocking of native host ports).
-    srv_socket, listener_port, stop_event = _start_tcp_listener()
-    # Start an nginx container with a Docker port mapping (tests DNAT/FORWARD-chain blocking).
-    dnat_port = _start_port_mapped_container(DNAT_CONTAINER_NAME)
-
-    sandbox_id = ""
+    created_sandbox_id = ""
     try:
         with _running_test_daemon(repo_root, runtime_dir):
             try:
-                sandbox_id = asyncio.run(
-                    _run_network_isolation_test(
-                        socket_path=socket_path,
-                        workspace=workspace,
-                        listener_port=listener_port,
-                        dnat_port=dnat_port,
-                    )
-                )
+                created_sandbox_id = asyncio.run(scenario(socket_path, workspace, sandbox_id))
             finally:
-                _cleanup_companion(sandbox_id or SANDBOX_ID, COMPANION_NAME)
-                _cleanup_runtime_resources(sandbox_id or SANDBOX_ID)
+                _cleanup_companion(created_sandbox_id or sandbox_id, COMPANION_NAME)
+                _cleanup_runtime_resources(created_sandbox_id or sandbox_id)
     finally:
-        stop_event.set()
-        srv_socket.close()
-        _stop_port_mapped_container(DNAT_CONTAINER_NAME)
         shutil.rmtree(runtime_dir, ignore_errors=True)
 
 
-async def _run_network_isolation_test(
+async def _create_network_sandbox(
     *,
-    socket_path: Path,
+    client: AgentsSandboxClient,
     workspace: Path,
-    listener_port: int,
-    dnat_port: int,
-) -> str:
-    client = await _wait_for_client(socket_path)
-    async with client:
-        sandbox = await client.create_sandbox(
-            image=RUNTIME_IMAGE,
-            sandbox_id=SANDBOX_ID,
-            mounts=(MountSpec(source=str(workspace), target="/workspace", writable=True),),
-            companion_containers=(
-                CompanionContainerSpec(
-                    name=COMPANION_NAME,
-                    image=COMPANION_IMAGE,
-                ),
+    sandbox_id: str,
+    ports: tuple[PortMapping, ...] = (),
+) -> tuple[str, str, str]:
+    sandbox = await client.create_sandbox(
+        image=RUNTIME_IMAGE,
+        sandbox_id=sandbox_id,
+        mounts=(MountSpec(source=str(workspace), target="/workspace", writable=True),),
+        ports=ports,
+        companion_containers=(
+            CompanionContainerSpec(
+                name=COMPANION_NAME,
+                image=COMPANION_IMAGE,
             ),
-        )
-        sid = sandbox.sandbox_id
+        ),
+    )
+    sid = sandbox.sandbox_id
 
-        # Wait for companion container to be running
-        companion_container = _companion_container_name(sid, COMPANION_NAME)
-        _wait_for_companion_running(companion_container)
+    companion_container = _companion_container_name(sid, COMPANION_NAME)
+    _wait_for_companion_running(companion_container)
+    gateway_ip = _get_gateway_ip(sid)
+    return sid, companion_container, gateway_ip
 
-        gateway_ip = _get_gateway_ip(sid)
-        host_ips = _get_host_interface_ips()
 
-        # --- Negative tests: primary container must NOT reach host ---
-        # Use curl --connect-timeout: exit 7 = connection refused, 28 = timeout (both = blocked = GOOD)
-        # exit 0 = connected = SECURITY VIOLATION
+async def _assert_primary_cannot_reach(
+    client: AgentsSandboxClient,
+    sandbox_id: str,
+    url: str,
+    label: str,
+) -> None:
+    exec_handle = await client.run(
+        sandbox_id,
+        ("curl", "--connect-timeout", "3", "-s", "-o", "/dev/null", url),
+        cwd="/workspace",
+    )
+    assert exec_handle.exit_code != 0, f"SECURITY VIOLATION: primary container reached {label} at {url}"
+
+
+def _assert_companion_cannot_reach(container_name: str, url: str, label: str) -> None:
+    result = subprocess.run(
+        [
+            "docker", "exec", container_name,
+            "wget", "-q", "-O", "/dev/null", "--timeout=3", url,
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    assert result.returncode != 0, f"SECURITY VIOLATION: companion container reached {label} at {url}"
+
+
+async def _start_primary_http_server(client: AgentsSandboxClient, sandbox_id: str) -> None:
+    expected_response = shlex.quote(PUBLISHED_PORT_RESPONSE)
+    exec_handle = await client.run(
+        sandbox_id,
+        (
+            "sh",
+            "-lc",
+            "set -eu\n"
+            "server_dir=/tmp/agbox-port-test\n"
+            'mkdir -p "$server_dir"\n'
+            'cat > "$server_dir/server.js" <<\'JS\'\n'
+            "const http = require('http');\n"
+            "const response = process.env.PUBLISHED_PORT_RESPONSE;\n"
+            "const server = http.createServer((req, res) => {\n"
+            "  res.writeHead(200, {'content-type': 'text/plain'});\n"
+            "  res.end(`${response}\\n`);\n"
+            "});\n"
+            "server.listen(8443, '0.0.0.0');\n"
+            "JS\n"
+            f"PUBLISHED_PORT_RESPONSE={expected_response} "
+            'nohup node "$server_dir/server.js" >"$server_dir/server.log" 2>&1 &\n'
+            "server_pid=$!\n"
+            "attempt=0\n"
+            'while [ "$attempt" -lt 30 ]; do\n'
+            "  attempt=$((attempt + 1))\n"
+            f"  if curl --fail --silent --show-error --max-time 2 http://127.0.0.1:8443/ | grep -Fx {expected_response}; then\n"
+            "    exit 0\n"
+            "  fi\n"
+            '  if ! kill -0 "$server_pid" 2>/dev/null; then\n'
+            '    cat "$server_dir/server.log" >&2 || true\n'
+            "    exit 1\n"
+            "  fi\n"
+            "  sleep 0.2\n"
+            "done\n"
+            'cat "$server_dir/server.log" >&2 || true\n'
+            "exit 1",
+        ),
+        cwd="/workspace",
+    )
+    assert exec_handle.exit_code == 0, (
+        "failed to start primary HTTP server\n"
+        f"{_primary_http_server_diagnostics(sandbox_id)}"
+    )
+
+
+def _primary_http_server_diagnostics(sandbox_id: str) -> str:
+    container_name = _primary_container_name(sandbox_id)
+    result = subprocess.run(
+        [
+            "docker", "exec", container_name,
+            "sh", "-lc",
+            "set +e\n"
+            "echo '--- /tmp/agbox-port-test ---'\n"
+            "ls -la /tmp/agbox-port-test 2>&1\n"
+            "echo '--- server.log ---'\n"
+            "cat /tmp/agbox-port-test/server.log 2>&1\n"
+            "echo '--- container curl ---'\n"
+            "curl --verbose --max-time 2 http://127.0.0.1:8443/ 2>&1",
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    return (
+        f"docker exec diagnostics for {container_name} exited {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def _wait_for_host_http_response(url: str, expected: str, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as response:
+                body = response.read().decode("utf-8").strip()
+            if body == expected:
+                return
+            raise AssertionError(f"unexpected response body {body!r}")
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            time.sleep(0.5)
+    raise AssertionError(f"host did not receive expected response from {url}: {last_error}") from last_error
+
+
+async def _assert_primary_can_reach_companion(client: AgentsSandboxClient, sandbox_id: str) -> None:
+    for _ in range(10):
         exec_handle = await client.run(
-            sid,
-            ("curl", "--connect-timeout", "3", "-s", "-o", "/dev/null", f"http://{gateway_ip}:{listener_port}"),
+            sandbox_id,
+            ("curl", "--connect-timeout", "3", "-s", "-o", "/dev/null", f"http://{COMPANION_NAME}:80"),
             cwd="/workspace",
         )
-        assert exec_handle.exit_code != 0, (
-            f"SECURITY VIOLATION: primary container reached host via gateway IP {gateway_ip}:{listener_port}"
-        )
+        if exec_handle.exit_code == 0:
+            return
+        await asyncio.sleep(3)
+    raise AssertionError(f"primary container cannot reach companion '{COMPANION_NAME}' on port 80")
 
-        for host_ip in host_ips:
-            exec_handle = await client.run(
-                sid,
-                ("curl", "--connect-timeout", "3", "-s", "-o", "/dev/null", f"http://{host_ip}:{listener_port}"),
-                cwd="/workspace",
-            )
-            assert exec_handle.exit_code != 0, (
-                f"SECURITY VIOLATION: primary container reached host via interface IP {host_ip}:{listener_port}"
-            )
 
-        # --- Negative tests: primary container must NOT reach Docker port-mapped (DNAT) services ---
-        # Docker port mappings use DNAT in PREROUTING/nat before reaching DOCKER-USER/FORWARD.
-        # Accessing gateway_ip:<dnat_port> hits the INPUT chain (via userland-proxy).
-        # Accessing the default Docker bridge gateway IP:<dnat_port> triggers DNAT in PREROUTING
-        # and then FORWARD through DOCKER-USER.  Both paths must be blocked.
-        default_bridge_ip = _get_default_docker_bridge_ip()
-        for dnat_target_ip in [gateway_ip, default_bridge_ip]:
-            exec_handle = await client.run(
-                sid,
-                (
-                    "curl", "--connect-timeout", "3", "-s", "-o", "/dev/null",
-                    f"http://{dnat_target_ip}:{dnat_port}",
+def test_sandbox_published_port_allows_host_ingress_without_sandbox_egress(tmp_path: Path) -> None:
+    sandbox_id = "net-published-port"
+    port_reservation: socket.socket | None
+    port_reservation, published_host_port = _reserve_unused_host_port()
+
+    async def scenario(socket_path: Path, workspace: Path, sandbox_id: str) -> str:
+        nonlocal port_reservation
+        client = await _wait_for_client(socket_path)
+        async with client:
+            if port_reservation is None:
+                raise AssertionError("host port reservation was already released")
+            port_reservation.close()
+            port_reservation = None
+            sid, companion_container, gateway_ip = await _create_network_sandbox(
+                client=client,
+                workspace=workspace,
+                sandbox_id=sandbox_id,
+                ports=(
+                    PortMapping(container_port=8443, host_port=published_host_port, protocol="tcp"),
                 ),
-                cwd="/workspace",
             )
-            assert exec_handle.exit_code != 0, (
-                f"SECURITY VIOLATION: primary container reached Docker-mapped service via "
-                f"{dnat_target_ip}:{dnat_port} (DNAT path not blocked)"
+            await _start_primary_http_server(client, sid)
+
+            host_url = f"http://127.0.0.1:{published_host_port}"
+            try:
+                _wait_for_host_http_response(host_url, PUBLISHED_PORT_RESPONSE)
+            except AssertionError as exc:
+                raise AssertionError(
+                    f"{exc}\n{_primary_http_server_diagnostics(sid)}"
+                ) from exc
+
+            egress_url = f"http://{gateway_ip}:{published_host_port}"
+            await _assert_primary_cannot_reach(client, sid, egress_url, "sandbox published host port")
+            _assert_companion_cannot_reach(companion_container, egress_url, "sandbox published host port")
+            return sid
+
+    try:
+        _run_network_scenario(tmp_path, sandbox_id, scenario)
+    finally:
+        if port_reservation is not None:
+            port_reservation.close()
+
+
+def test_sandbox_host_isolation_blocks_primary_and_companion_egress(tmp_path: Path) -> None:
+    sandbox_id = "net-host-isolation"
+    dnat_container = "agbox-nettest-dnat"
+    _stop_port_mapped_container(dnat_container)
+
+    srv_socket, listener_port, stop_event = _start_tcp_listener()
+    dnat_port = _start_port_mapped_container(dnat_container)
+    try:
+        async def scenario(socket_path: Path, workspace: Path, sandbox_id: str) -> str:
+            client = await _wait_for_client(socket_path)
+            async with client:
+                sid, companion_container, gateway_ip = await _create_network_sandbox(
+                    client=client,
+                    workspace=workspace,
+                    sandbox_id=sandbox_id,
+                )
+                host_ips = _get_host_interface_ips()
+                default_bridge_ip = _get_default_docker_bridge_ip()
+
+                blocked_urls = [(f"http://{gateway_ip}:{listener_port}", "sandbox gateway host listener")]
+                blocked_urls.extend(
+                    (f"http://{host_ip}:{listener_port}", "host physical interface listener")
+                    for host_ip in host_ips
+                )
+                blocked_urls.extend(
+                    [
+                        (f"http://{gateway_ip}:{dnat_port}", "unrelated published port via sandbox gateway"),
+                        (
+                            f"http://{default_bridge_ip}:{dnat_port}",
+                            "unrelated published port via default Docker bridge",
+                        ),
+                    ]
+                )
+
+                for url, label in blocked_urls:
+                    await _assert_primary_cannot_reach(client, sid, url, label)
+                    _assert_companion_cannot_reach(companion_container, url, label)
+                return sid
+
+        _run_network_scenario(tmp_path, sandbox_id, scenario)
+    finally:
+        stop_event.set()
+        srv_socket.close()
+        _stop_port_mapped_container(dnat_container)
+
+
+def test_sandbox_primary_can_reach_companion_under_host_isolation(
+    tmp_path: Path,
+) -> None:
+    sandbox_id = "net-companion-access"
+
+    async def scenario(socket_path: Path, workspace: Path, sandbox_id: str) -> str:
+        client = await _wait_for_client(socket_path)
+        async with client:
+            sid, _, _ = await _create_network_sandbox(
+                client=client,
+                workspace=workspace,
+                sandbox_id=sandbox_id,
             )
+            await _assert_primary_can_reach_companion(client, sid)
+            return sid
 
-        # --- Positive tests: primary container CAN reach internet ---
-        exec_handle = await client.run(
-            sid,
-            ("curl", "--connect-timeout", "5", "-s", "-o", "/dev/null", "http://1.1.1.1"),
-            cwd="/workspace",
-        )
-        assert exec_handle.exit_code == 0, "primary container cannot reach internet (1.1.1.1)"
-
-        # --- Positive test: primary container CAN reach companion by DNS alias ---
-        # Companion runs nginx on port 80. Retry to handle Docker DNS registration delay.
-        for attempt in range(10):
-            exec_handle = await client.run(
-                sid,
-                ("curl", "--connect-timeout", "3", "-s", "-o", "/dev/null", f"http://{COMPANION_NAME}:80"),
-                cwd="/workspace",
-            )
-            if exec_handle.exit_code == 0:
-                break
-            await asyncio.sleep(3)
-        assert exec_handle.exit_code == 0, (
-            f"primary container cannot reach companion '{COMPANION_NAME}' on port 80 (exit {exec_handle.exit_code})"
-        )
-
-        # --- Negative tests: companion container must NOT reach host ---
-        # Companion image (nginx:alpine) has wget (busybox applet) but not curl.
-        result = subprocess.run(
-            [
-                "docker", "exec", companion_container,
-                "wget", "-q", "-O", "/dev/null", "--timeout=3", f"http://{gateway_ip}:{listener_port}",
-            ],
-            capture_output=True, text=True, check=False,
-        )
-        assert result.returncode != 0, (
-            f"SECURITY VIOLATION: companion container reached host via gateway IP {gateway_ip}:{listener_port}"
-        )
-
-        for host_ip in host_ips:
-            result = subprocess.run(
-                [
-                    "docker", "exec", companion_container,
-                    "wget", "-q", "-O", "/dev/null", "--timeout=3", f"http://{host_ip}:{listener_port}",
-                ],
-                capture_output=True, text=True, check=False,
-            )
-            assert result.returncode != 0, (
-                f"SECURITY VIOLATION: companion container reached host via interface IP {host_ip}:{listener_port}"
-            )
-
-        # --- Negative tests: companion container must NOT reach Docker port-mapped (DNAT) services ---
-        for dnat_target_ip in [gateway_ip, default_bridge_ip]:
-            result = subprocess.run(
-                [
-                    "docker", "exec", companion_container,
-                    "wget", "-q", "-O", "/dev/null", "--timeout=3",
-                    f"http://{dnat_target_ip}:{dnat_port}",
-                ],
-                capture_output=True, text=True, check=False,
-            )
-            assert result.returncode != 0, (
-                f"SECURITY VIOLATION: companion container reached Docker-mapped service via "
-                f"{dnat_target_ip}:{dnat_port} (DNAT path not blocked)"
-            )
-
-        # --- Positive test: companion container CAN reach internet ---
-        result = subprocess.run(
-            [
-                "docker", "exec", companion_container,
-                "wget", "-q", "-O", "/dev/null", "--timeout=5", "http://1.1.1.1",
-            ],
-            capture_output=True, text=True, check=False,
-        )
-        assert result.returncode == 0, "companion container cannot reach internet (1.1.1.1)"
-
-        return sid
+    _run_network_scenario(tmp_path, sandbox_id, scenario)


### PR DESCRIPTION
## Summary
- Constrain Linux host isolation nftables drops to sandbox-originated `ct state NEW` flows so host-initiated localhost published-port ingress can receive replies.
- Add Go regression coverage for the new rule shape, idempotent apply/remove behavior, and restart recovery reapply.
- Split Python network isolation integration coverage into published-port ingress, host/unrelated published-port egress blocking, and companion access tests.
- Update public isolation/lifecycle docs to describe localhost port mappings as host-initiated ingress, not sandbox egress exceptions.
- Fix an event-subscription cleanup race exposed by macOS CI so existing sandbox event streams can drain deletion events after cleanup purges the record.

## Validation
- `uv run /home/fanrui/code/skill-hub/scripts/lint_acceptance_doc.py requirements/215/`
- `go test ./internal/control -run 'TestHostIsolationCurrentRulesMatchConntrackNew|TestHostIsolationApplyAndReapplyAreIdempotent|TestHostIsolationRemoveDeletesCurrentRules|TestRestorePersistedSandboxesReappliesNetworkIsolation' -v`
- `AGBOX_REQUIRE_INTEGRATION=1 uv run pytest tests/test_network_isolation.py::test_sandbox_published_port_allows_host_ingress_without_sandbox_egress -v`
- `AGBOX_REQUIRE_INTEGRATION=1 uv run pytest tests/test_network_isolation.py::test_sandbox_host_isolation_blocks_primary_and_companion_egress -v`
- `AGBOX_REQUIRE_INTEGRATION=1 uv run pytest tests/test_network_isolation.py::test_sandbox_primary_can_reach_companion_under_host_isolation -v`
- `go test ./internal/control -run 'TestCleanupTTLDeletesStoppedSandbox|TestRestorePersistedSandboxesReappliesNetworkIsolation' -count=50 -v`
- GitHub checks: `test (ubuntu-latest)` and `test (macos-latest)` passed

close #215
