### PR TITLE
[ISSUE-219] Fix uv builtin Python install mount

### DIFF
--- a/docs/container_dependency_strategy.md
+++ b/docs/container_dependency_strategy.md
@@ -31,7 +31,7 @@ Tools are the user-facing names passed in `builtin_tools`. Each tool resolves to
 | `claude` | `~/.claude` → `/home/agbox/.claude` (rw), `~/.claude.json` → `/home/agbox/.claude.json` (rw), `$XDG_RUNTIME_DIR/pulse/native` → `/pulse-audio` (socket forwarding, when host socket exists) |
 | `codex` | `~/.codex` → `/home/agbox/.codex` (rw), `~/.agents` → `/home/agbox/.agents` (rw) |
 | `git` | `SSH_AUTH_SOCK` → `/ssh-agent` (socket forwarding), `~/.config/gh` → `/home/agbox/.config/gh` (read-only), `~/.ssh/known_hosts` → `/home/agbox/.ssh/known_hosts` (read-write) |
-| `uv` | `~/.cache/uv` → `/home/agbox/.cache/uv` (rw), `~/.local/share/uv` → `/home/agbox/.local/share/uv` (rw) |
+| `uv` | `~/.cache/uv` → `/home/agbox/.cache/uv` (rw), `~/.local/share/uv/python` → the same resolved host path inside the container (rw), plus `UV_PYTHON_INSTALL_DIR` set to that path |
 | `npm` | `~/.npm` → `/home/agbox/.npm` (read-write) |
 | `apt` | `~/.cache/agents-sandbox-apt` → `/var/cache/apt/archives` (read-write) |
 | `opencode` | `~/.config/opencode` → `/home/agbox/.config/opencode` (rw), `~/.local/share/opencode` → `/home/agbox/.local/share/opencode` (rw) |
@@ -39,7 +39,7 @@ Tools are the user-facing names passed in `builtin_tools`. Each tool resolves to
 Notes:
 - `codex` mounts both `~/.codex` and `~/.agents`; `~/.agents` is the shared agents state directory.
 - `git` bundles SSH agent forwarding, GitHub CLI auth, and SSH known-hosts; requesting `git` is equivalent to requesting all three.
-- `uv` mounts both the package cache and the data directory holding Python interpreters and globally installed tools.
+- `uv` mounts the package cache under the sandbox home, but mounts uv-managed Python installations at the host-identical absolute path and sets `UV_PYTHON_INSTALL_DIR` accordingly. The daemon does not mount the whole uv data directory into `/home/agbox`.
 - `claude` includes optional PulseAudio socket forwarding for voice support; the mount is silently skipped when the host socket does not exist.
 
 These are daemon-defined capabilities. Callers may select from this set but may not replace them with arbitrary host paths. The minimal base runtime image asset is under `images/base-runtime/`; the HOME-aligned coding runtime image is under `images/coding-runtime/`.

--- a/internal/control/docker_runtime.go
+++ b/internal/control/docker_runtime.go
@@ -239,10 +239,11 @@ func (backend *dockerRuntimeBackend) CreateSandbox(ctx context.Context, record *
 		_ = backend.deleteRuntimeArtifacts(cleanupCtx, state)
 	}()
 
-	mounts, err := backend.materializeBuiltinTools(record.handle.GetSandboxId(), record.createSpec.GetBuiltinTools(), state)
+	builtinTools, err := backend.materializeBuiltinTools(record.handle.GetSandboxId(), record.createSpec.GetBuiltinTools(), state)
 	if err != nil {
 		return runtimeCreateResult{}, err
 	}
+	mounts := builtinTools.Mounts
 	genericMounts, err := backend.materializeGenericMounts(record.createSpec.GetMounts())
 	if err != nil {
 		return runtimeCreateResult{}, err
@@ -314,6 +315,9 @@ func (backend *dockerRuntimeBackend) CreateSandbox(ctx context.Context, record *
 		}
 	}
 	primaryEnv := primaryContainerEnvironment(mounts)
+	for k, v := range builtinTools.Environment {
+		primaryEnv[k] = v
+	}
 	for k, v := range record.createSpec.GetEnvs() {
 		primaryEnv[k] = v
 	}

--- a/internal/control/docker_runtime_dockerapi.go
+++ b/internal/control/docker_runtime_dockerapi.go
@@ -42,6 +42,11 @@ type dockerMount struct {
 	ReadOnly bool
 }
 
+type builtinToolMaterialization struct {
+	Mounts      []dockerMount
+	Environment map[string]string
+}
+
 type dockerPortMapping struct {
 	ContainerPort uint32
 	HostPort      uint32

--- a/internal/control/docker_runtime_materialize.go
+++ b/internal/control/docker_runtime_materialize.go
@@ -102,9 +102,9 @@ func (backend *dockerRuntimeBackend) materializeBuiltinTools(
 	sandboxID string,
 	resources []string,
 	state *sandboxRuntimeState,
-) ([]dockerMount, error) {
+) (builtinToolMaterialization, error) {
 	if len(resources) == 0 {
-		return nil, nil
+		return builtinToolMaterialization{}, nil
 	}
 
 	// Resolve each tool into its mount IDs, tracking which mounts belong to optional tools.
@@ -117,7 +117,7 @@ func (backend *dockerRuntimeBackend) materializeBuiltinTools(
 	for _, resource := range resources {
 		capability, ok := profile.CapabilityByID(resource)
 		if !ok {
-			return nil, fmt.Errorf("unknown builtin resource %q", resource)
+			return builtinToolMaterialization{}, fmt.Errorf("unknown builtin resource %q", resource)
 		}
 		for _, mountID := range capability.MountIDs {
 			if _, exists := seen[mountID]; !exists {
@@ -134,10 +134,11 @@ func (backend *dockerRuntimeBackend) materializeBuiltinTools(
 	}
 
 	mounts := make([]dockerMount, 0, len(entries))
+	environment := make(map[string]string)
 	for _, entry := range entries {
 		mount, ok := profile.MountByID(entry.mountID)
 		if !ok {
-			return nil, fmt.Errorf("unknown capability mount %q", entry.mountID)
+			return builtinToolMaterialization{}, fmt.Errorf("unknown capability mount %q", entry.mountID)
 		}
 		sourcePath, err := resolveCapabilityMountSource(mount)
 		if err != nil {
@@ -147,7 +148,7 @@ func (backend *dockerRuntimeBackend) materializeBuiltinTools(
 					slog.String("error", err.Error()))
 				continue
 			}
-			return nil, err
+			return builtinToolMaterialization{}, err
 		}
 
 		// Project credentials from macOS Keychain into the host mount directory
@@ -173,14 +174,16 @@ func (backend *dockerRuntimeBackend) materializeBuiltinTools(
 							slog.String("error", err.Error()))
 						continue
 					}
-					return nil, err
+					return builtinToolMaterialization{}, err
 				}
 			}
+			target := capabilityMountTarget(mount, sourcePath)
 			mounts = append(mounts, dockerMount{
 				Source:   sourcePath,
-				Target:   mount.ContainerTarget,
+				Target:   target,
 				ReadOnly: false,
 			})
+			addBuiltinMountEnvironment(mount, target, environment)
 		default:
 			writable := mount.Mode == profile.CapabilityModeReadWrite
 			actualSource, readOnly, err := backend.materializeBuiltinToolPath(sourcePath, writable, state)
@@ -191,16 +194,18 @@ func (backend *dockerRuntimeBackend) materializeBuiltinTools(
 						slog.String("error", err.Error()))
 					continue
 				}
-				return nil, err
+				return builtinToolMaterialization{}, err
 			}
+			target := capabilityMountTarget(mount, actualSource)
 			mounts = append(mounts, dockerMount{
 				Source:   actualSource,
-				Target:   mount.ContainerTarget,
+				Target:   target,
 				ReadOnly: readOnly,
 			})
+			addBuiltinMountEnvironment(mount, target, environment)
 		}
 	}
-	return mounts, nil
+	return builtinToolMaterialization{Mounts: mounts, Environment: environment}, nil
 }
 
 func (backend *dockerRuntimeBackend) materializeBuiltinToolPath(
@@ -208,7 +213,6 @@ func (backend *dockerRuntimeBackend) materializeBuiltinToolPath(
 	writable bool,
 	state *sandboxRuntimeState,
 ) (string, bool, error) {
-	// Builtin tools are always bind-mounted as-is, including any symlinks.
 	// Builtin tools are always bind-mounted as-is, including any symlinks. These are trusted host directories
 	// (tool configs, caches) that may contain symlinks to arbitrary host paths,
 	// and the container is expected to see them exactly as they appear on the host.
@@ -216,6 +220,19 @@ func (backend *dockerRuntimeBackend) materializeBuiltinToolPath(
 		return "", false, err
 	}
 	return sourcePath, !writable, nil
+}
+
+func capabilityMountTarget(mount profile.CapabilityMount, sourcePath string) string {
+	if mount.ContainerTargetMode == profile.CapabilityContainerTargetHostPath {
+		return sourcePath
+	}
+	return mount.ContainerTarget
+}
+
+func addBuiltinMountEnvironment(mount profile.CapabilityMount, target string, environment map[string]string) {
+	if mount.ContainerTargetEnvKey != "" {
+		environment[mount.ContainerTargetEnvKey] = target
+	}
 }
 
 func resolveCapabilityMountSource(mount profile.CapabilityMount) (string, error) {

--- a/internal/control/service_stage2_runtime_contracts_test.go
+++ b/internal/control/service_stage2_runtime_contracts_test.go
@@ -642,10 +642,11 @@ func TestBuiltinToolMountsPreserveSymlinks(t *testing.T) {
 	// Builtin resources are mounted directly from the host path; symlinks are preserved as-is.
 	runtimeState := &sandboxRuntimeState{}
 	backendWithoutState := &dockerRuntimeBackend{config: ServiceConfig{}}
-	mounts, err := backendWithoutState.materializeBuiltinTools("sandbox-builtin", []string{"claude"}, runtimeState)
+	builtinTools, err := backendWithoutState.materializeBuiltinTools("sandbox-builtin", []string{"claude"}, runtimeState)
 	if err != nil {
 		t.Fatalf("materializeBuiltinTools failed: %v", err)
 	}
+	mounts := builtinTools.Mounts
 	if len(mounts) != 2 {
 		t.Fatalf("expected two builtin mounts, got %d", len(mounts))
 	}
@@ -680,20 +681,62 @@ func TestMaterializeBuiltinToolsSkipsOptionalWhenHostPathMissing(t *testing.T) {
 		config: ServiceConfig{},
 	}
 
-	// Request an optional tool (uv) whose host paths do not exist.
+	// Request an optional tool (npm) whose host path does not exist.
 	// materializeBuiltinTools should skip them silently instead of failing.
-	mounts, err := backendWithoutState.materializeBuiltinTools("sandbox-optional-skip", []string{"uv"}, &sandboxRuntimeState{})
+	builtinTools, err := backendWithoutState.materializeBuiltinTools("sandbox-optional-skip", []string{"npm"}, &sandboxRuntimeState{})
 	if err != nil {
 		t.Fatalf("expected optional tool mounts to be skipped, got error: %v", err)
 	}
+	mounts := builtinTools.Mounts
 	if len(mounts) != 0 {
 		t.Fatalf("expected zero mounts when optional host paths are missing, got %d", len(mounts))
 	}
 
 	// When mixing required and optional tools, the required tool must still fail
 	// if its path is missing.
-	if _, err := backendWithoutState.materializeBuiltinTools("sandbox-mixed", []string{"uv", "claude"}, &sandboxRuntimeState{}); err == nil {
+	if _, err := backendWithoutState.materializeBuiltinTools("sandbox-mixed", []string{"npm", "claude"}, &sandboxRuntimeState{}); err == nil {
 		t.Fatal("expected error for required tool (claude) with missing host path, got nil")
+	}
+}
+
+func TestMaterializeUVBuiltinMountsPythonInstallDirAtHostPath(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	cacheSource := filepath.Join(homeDir, ".cache", "uv")
+	if err := os.MkdirAll(cacheSource, 0o755); err != nil {
+		t.Fatalf("MkdirAll uv cache failed: %v", err)
+	}
+	pythonInstallDir := filepath.Join(homeDir, ".local", "share", "uv", "python")
+	if err := os.MkdirAll(pythonInstallDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll uv python install dir failed: %v", err)
+	}
+
+	backendWithoutState := &dockerRuntimeBackend{config: ServiceConfig{}}
+	builtinTools, err := backendWithoutState.materializeBuiltinTools("sandbox-uv", []string{"uv"}, &sandboxRuntimeState{})
+	if err != nil {
+		t.Fatalf("materializeBuiltinTools failed: %v", err)
+	}
+
+	mounts := builtinTools.Mounts
+	if len(mounts) != 2 {
+		t.Fatalf("expected uv cache and python mounts, got %d: %#v", len(mounts), mounts)
+	}
+	if mounts[0].Source != cacheSource || mounts[0].Target != "/home/agbox/.cache/uv" {
+		t.Fatalf("unexpected uv cache mount: %#v", mounts[0])
+	}
+	if mounts[1].Source != pythonInstallDir || mounts[1].Target != pythonInstallDir {
+		t.Fatalf("unexpected uv python mount: %#v want source=target=%q", mounts[1], pythonInstallDir)
+	}
+	if mounts[1].ReadOnly {
+		t.Fatal("expected uv python mount to be writable")
+	}
+	if got := builtinTools.Environment["UV_PYTHON_INSTALL_DIR"]; got != pythonInstallDir {
+		t.Fatalf("unexpected UV_PYTHON_INSTALL_DIR: got %q want %q", got, pythonInstallDir)
+	}
+	for _, mount := range mounts {
+		if mount.Target == "/home/agbox/.local/share/uv" {
+			t.Fatalf("uv builtin must not mount the whole data directory into sandbox home: %#v", mount)
+		}
 	}
 }
 

--- a/internal/profile/capabilities.go
+++ b/internal/profile/capabilities.go
@@ -13,6 +13,19 @@ const (
 	CapabilityModeSocket    CapabilityMode = "socket"
 )
 
+// CapabilityContainerTargetMode controls how a capability mount chooses the
+// Docker mount target inside the container.
+type CapabilityContainerTargetMode string
+
+const (
+	// CapabilityContainerTargetDeclared uses CapabilityMount.ContainerTarget as
+	// the container path. This is the normal host-path -> container-home-path mode.
+	CapabilityContainerTargetDeclared CapabilityContainerTargetMode = "declared_container_path"
+	// CapabilityContainerTargetHostPath uses the resolved host source path as
+	// the container path too. Host and container see the same absolute path.
+	CapabilityContainerTargetHostPath CapabilityContainerTargetMode = "host_path"
+)
+
 // ContainerUserHome is the home directory of the default user inside
 // AgentsSandbox runtime containers. This constant is the single source
 // of truth; all container-side home-relative paths must derive from it.
@@ -30,7 +43,7 @@ const (
 	MountIDSSHAgent       MountID = "ssh-agent"
 	MountIDSSHKnownHosts  MountID = "ssh-known-hosts"
 	MountIDUVCache        MountID = "uv-cache"
-	MountIDUVData         MountID = "uv-data"
+	MountIDUVPython       MountID = "uv-python"
 	MountIDNPM            MountID = "npm"
 	MountIDApt            MountID = "apt"
 	MountIDPulseAudio     MountID = "pulse-audio"
@@ -68,14 +81,18 @@ type MacOSKeychainCredential struct {
 // CapabilityMount is a named host-to-container mount unit.
 // Multiple tools may reference the same mount; the daemon deduplicates by ID.
 type CapabilityMount struct {
-	ID              MountID
-	DefaultHostPath string
-	ContainerTarget string
-	Mode            CapabilityMode
+	ID                  MountID
+	DefaultHostPath     string
+	ContainerTarget     string
+	ContainerTargetMode CapabilityContainerTargetMode
+	Mode                CapabilityMode
 	// Optional marks this mount as individually skippable when the host resource
 	// is unavailable, even if the parent tool is required. This allows a required
 	// tool (e.g. claude) to include mounts that may not exist on all hosts.
 	Optional bool
+	// ContainerTargetEnvKey injects an environment variable whose value is the
+	// resolved container target when this mount is materialized.
+	ContainerTargetEnvKey string
 	// MacOSKeychain, when non-nil, triggers credential projection from macOS
 	// Keychain before bind-mounting. See MacOSKeychainCredential for the full contract.
 	MacOSKeychain *MacOSKeychainCredential
@@ -140,7 +157,7 @@ var capabilityMounts = buildMountIndex([]CapabilityMount{
 		Mode:            CapabilityModeReadWrite,
 		Optional:        true,
 	},
-	// uv-cache holds downloaded packages; uv-data holds uv-managed Python interpreters and global tools.
+	// uv-cache holds downloaded packages; uv-python holds uv-managed Python installations.
 	{
 		ID:              MountIDUVCache,
 		DefaultHostPath: "~/.cache/uv",
@@ -149,11 +166,12 @@ var capabilityMounts = buildMountIndex([]CapabilityMount{
 		Optional:        true,
 	},
 	{
-		ID:              MountIDUVData,
-		DefaultHostPath: "~/.local/share/uv",
-		ContainerTarget: path.Join(ContainerUserHome, ".local/share/uv"),
-		Mode:            CapabilityModeReadWrite,
-		Optional:        true,
+		ID:                    MountIDUVPython,
+		DefaultHostPath:       "~/.local/share/uv/python",
+		ContainerTargetMode:   CapabilityContainerTargetHostPath,
+		Mode:                  CapabilityModeReadWrite,
+		Optional:              true,
+		ContainerTargetEnvKey: "UV_PYTHON_INSTALL_DIR",
 	},
 	{
 		ID:              MountIDNPM,
@@ -204,7 +222,7 @@ var builtInToolingCapabilities = map[ToolID]ToolingCapability{
 	ToolIDClaude:   {MountIDs: []MountID{MountIDClaude, MountIDClaudeJSON, MountIDPulseAudio}},
 	ToolIDCodex:    {MountIDs: []MountID{MountIDCodex, MountIDAgents}},
 	ToolIDGit:      {MountIDs: []MountID{MountIDSSHAgent, MountIDGHAuth, MountIDSSHKnownHosts}},
-	ToolIDUV:       {MountIDs: []MountID{MountIDUVCache, MountIDUVData}},
+	ToolIDUV:       {MountIDs: []MountID{MountIDUVCache, MountIDUVPython}},
 	ToolIDNPM:      {MountIDs: []MountID{MountIDNPM}},
 	ToolIDApt:      {MountIDs: []MountID{MountIDApt}},
 	ToolIDOpenCode: {MountIDs: []MountID{MountIDOpenCodeConfig, MountIDOpenCodeData}},

--- a/internal/profile/capabilities_test.go
+++ b/internal/profile/capabilities_test.go
@@ -44,7 +44,7 @@ func TestCodexMountsBothDirs(t *testing.T) {
 	}
 }
 
-func TestUVMountsBothDirs(t *testing.T) {
+func TestUVMountsCacheAndPythonInstallDir(t *testing.T) {
 	capability, ok := CapabilityByID(string(ToolIDUV))
 	if !ok {
 		t.Fatal("missing tool capability uv")
@@ -52,8 +52,33 @@ func TestUVMountsBothDirs(t *testing.T) {
 	if len(capability.MountIDs) != 2 {
 		t.Fatalf("expected uv to have 2 mount IDs, got %d", len(capability.MountIDs))
 	}
-	if capability.MountIDs[0] != MountIDUVCache || capability.MountIDs[1] != MountIDUVData {
+	if capability.MountIDs[0] != MountIDUVCache || capability.MountIDs[1] != MountIDUVPython {
 		t.Fatalf("unexpected uv mount IDs: %v", capability.MountIDs)
+	}
+}
+
+func TestUVPythonMountUsesHostIdenticalTarget(t *testing.T) {
+	mount, ok := MountByID(MountIDUVPython)
+	if !ok {
+		t.Fatal("missing mount uv-python")
+	}
+	if mount.DefaultHostPath != "~/.local/share/uv/python" {
+		t.Fatalf("unexpected DefaultHostPath: got %q want %q", mount.DefaultHostPath, "~/.local/share/uv/python")
+	}
+	if mount.ContainerTarget != "" {
+		t.Fatalf("uv-python must not use a fixed container-home target, got %q", mount.ContainerTarget)
+	}
+	if mount.ContainerTargetMode != CapabilityContainerTargetHostPath {
+		t.Fatalf("unexpected ContainerTargetMode: got %q want %q", mount.ContainerTargetMode, CapabilityContainerTargetHostPath)
+	}
+	if mount.ContainerTargetEnvKey != "UV_PYTHON_INSTALL_DIR" {
+		t.Fatalf("unexpected ContainerTargetEnvKey: got %q want %q", mount.ContainerTargetEnvKey, "UV_PYTHON_INSTALL_DIR")
+	}
+	if mount.Mode != CapabilityModeReadWrite {
+		t.Fatalf("unexpected Mode: got %q want %q", mount.Mode, CapabilityModeReadWrite)
+	}
+	if !mount.Optional {
+		t.Fatal("expected Optional to be true")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stop mounting the full uv data directory into `/home/agbox/.local/share/uv`.
- Add capability-level container target mode configuration so mounts can use either a declared container path or the resolved host path.
- Mount uv-managed Python installs at the host-identical absolute path and inject `UV_PYTHON_INSTALL_DIR` when that mount is materialized.
- Update builtin tooling documentation and tests for the uv mount contract.

## Tests

- `go test ./internal/profile ./internal/control`
- pre-commit hook during commit, including Go tests and Python SDK tests

Close #219
